### PR TITLE
Slice 4: tenant settings and configuration UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Before planning or coding, read these exact files:
 - `/Users/romeoman/Documents/Dev/HubSpot/Account Plan App/planning/local/TASKMASTER_EXECUTION_PRD.md`
 - `/Users/romeoman/Documents/Dev/HubSpot/Account Plan App/docs/security/SECURITY.md`
 - `/Users/romeoman/Documents/Dev/HubSpot/Account Plan App/docs/slice-3-preflight-notes.md`
+- `/Users/romeoman/Documents/Dev/HubSpot/Account Plan App/docs/slice-4-preflight-notes.md`
 
 If a path referenced by older planning docs has moved, resolve it via `PLANNING_INDEX.md` instead of guessing.
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { type CorrelationVariables, correlationMiddleware } from "./middleware/c
 import { nonceMiddleware } from "./middleware/nonce";
 import { type TenantVariables, tenantMiddleware } from "./middleware/tenant";
 import { createOAuthRoutes } from "./routes/oauth";
+import { settingsRoutes } from "./routes/settings";
 import { snapshotRoutes } from "./routes/snapshot";
 
 type AppVars = TenantVariables & CorrelationVariables & { portalId?: string; rawBody?: string };
@@ -49,7 +50,7 @@ app.use(
   "*",
   cors({
     origin: (origin) => resolveCorsOrigin(origin ?? ""),
-    allowMethods: ["GET", "POST", "OPTIONS"],
+    allowMethods: ["GET", "POST", "PUT", "OPTIONS"],
     allowHeaders: ["Authorization", "Content-Type", "x-test-portal-id"],
     credentials: false,
     maxAge: 600,
@@ -141,6 +142,7 @@ app.use("/api/*", async (c, next) => {
 });
 app.use("/api/*", nonceMiddleware());
 
+app.route("/api/settings", settingsRoutes);
 app.route("/api/snapshot", snapshotRoutes);
 
 // Only start server when run directly (not when imported by tests).

--- a/apps/api/src/lib/__tests__/settings-service.test.ts
+++ b/apps/api/src/lib/__tests__/settings-service.test.ts
@@ -1,0 +1,223 @@
+import { randomUUID } from "node:crypto";
+import { createDatabase, llmConfig, providerConfig, tenants } from "@hap/db";
+import { and, eq, like } from "drizzle-orm";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { decryptProviderKey } from "../encryption";
+import { readSettings, updateSettings } from "../settings-service";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
+
+const db = createDatabase(DATABASE_URL);
+const PORTAL_PREFIX = `settingssvc-${randomUUID().slice(0, 8)}-`;
+
+function portalId() {
+  return `${PORTAL_PREFIX}${randomUUID().slice(0, 8)}`;
+}
+
+async function seedTenant(settings?: Record<string, unknown>) {
+  const [row] = await db
+    .insert(tenants)
+    .values({
+      hubspotPortalId: portalId(),
+      name: "Settings Service Tenant",
+      settings: settings ?? {},
+    })
+    .returning();
+  if (!row) throw new Error("failed to seed tenant");
+  return row;
+}
+
+beforeEach(async () => {
+  await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+});
+
+afterAll(async () => {
+  await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+});
+
+describe("readSettings", () => {
+  it("returns the default settings shape when no config rows exist", async () => {
+    const tenant = await seedTenant();
+
+    const settings = await readSettings({ db, tenantId: tenant.id });
+
+    expect(settings).toEqual({
+      tenantId: tenant.id,
+      signalProviders: {
+        exa: { enabled: false, hasApiKey: false },
+        news: { enabled: false, hasApiKey: false },
+        hubspotEnrichment: { enabled: false, hasApiKey: false },
+      },
+      llm: {
+        provider: null,
+        model: "",
+        endpointUrl: undefined,
+        hasApiKey: false,
+      },
+      eligibility: {
+        propertyName: "hs_is_target_account",
+      },
+      thresholds: {
+        freshnessMaxDays: 30,
+        minConfidence: 0.5,
+      },
+    });
+  });
+});
+
+describe("updateSettings", () => {
+  it("writes encrypted provider and llm keys and reflects them in the read model", async () => {
+    const tenant = await seedTenant();
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        signalProviders: {
+          exa: { enabled: true, apiKey: "exa-secret-1" },
+          news: { enabled: true },
+          hubspotEnrichment: { enabled: true },
+        },
+        llm: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          apiKey: "openai-secret-1",
+        },
+        eligibility: {
+          propertyName: "custom_target_property",
+        },
+        thresholds: {
+          freshnessMaxDays: 14,
+          minConfidence: 0.4,
+        },
+      },
+    );
+
+    const [exaRow] = await db
+      .select()
+      .from(providerConfig)
+      .where(and(eq(providerConfig.tenantId, tenant.id), eq(providerConfig.providerName, "exa")));
+    expect(exaRow?.enabled).toBe(true);
+    expect(exaRow?.apiKeyEncrypted).toBeTruthy();
+    expect(decryptProviderKey(tenant.id, exaRow?.apiKeyEncrypted ?? "")).toBe("exa-secret-1");
+
+    const [llmRow] = await db
+      .select()
+      .from(llmConfig)
+      .where(and(eq(llmConfig.tenantId, tenant.id), eq(llmConfig.providerName, "openai")));
+    expect(llmRow?.modelName).toBe("gpt-5.4-mini");
+    expect(llmRow?.apiKeyEncrypted).toBeTruthy();
+    expect(decryptProviderKey(tenant.id, llmRow?.apiKeyEncrypted ?? "")).toBe("openai-secret-1");
+
+    const settings = await readSettings({ db, tenantId: tenant.id });
+    expect(settings.signalProviders.exa).toEqual({ enabled: true, hasApiKey: true });
+    expect(settings.signalProviders.news).toEqual({ enabled: true, hasApiKey: false });
+    expect(settings.signalProviders.hubspotEnrichment).toEqual({
+      enabled: true,
+      hasApiKey: false,
+    });
+    expect(settings.llm).toEqual({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      endpointUrl: undefined,
+      hasApiKey: true,
+    });
+    expect(settings.eligibility.propertyName).toBe("custom_target_property");
+    expect(settings.thresholds).toEqual({
+      freshnessMaxDays: 14,
+      minConfidence: 0.4,
+    });
+  });
+
+  it("preserves existing encrypted secrets when the update omits apiKey", async () => {
+    const tenant = await seedTenant();
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        signalProviders: {
+          exa: { enabled: true, apiKey: "exa-secret-1" },
+        },
+        llm: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "anthropic-secret-1",
+        },
+      },
+    );
+
+    const [beforeExa] = await db
+      .select()
+      .from(providerConfig)
+      .where(and(eq(providerConfig.tenantId, tenant.id), eq(providerConfig.providerName, "exa")));
+    const [beforeLlm] = await db
+      .select()
+      .from(llmConfig)
+      .where(and(eq(llmConfig.tenantId, tenant.id), eq(llmConfig.providerName, "anthropic")));
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        signalProviders: {
+          exa: { enabled: false },
+        },
+        llm: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+      },
+    );
+
+    const [afterExa] = await db
+      .select()
+      .from(providerConfig)
+      .where(and(eq(providerConfig.tenantId, tenant.id), eq(providerConfig.providerName, "exa")));
+    const [afterLlm] = await db
+      .select()
+      .from(llmConfig)
+      .where(and(eq(llmConfig.tenantId, tenant.id), eq(llmConfig.providerName, "anthropic")));
+
+    expect(afterExa?.enabled).toBe(false);
+    expect(afterExa?.apiKeyEncrypted).toBe(beforeExa?.apiKeyEncrypted);
+    expect(afterLlm?.apiKeyEncrypted).toBe(beforeLlm?.apiKeyEncrypted);
+    expect(decryptProviderKey(tenant.id, afterExa?.apiKeyEncrypted ?? "")).toBe("exa-secret-1");
+    expect(decryptProviderKey(tenant.id, afterLlm?.apiKeyEncrypted ?? "")).toBe(
+      "anthropic-secret-1",
+    );
+  });
+
+  it("clears llm configuration when the settings payload disables the llm provider", async () => {
+    const tenant = await seedTenant();
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        llm: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          apiKey: "openai-secret-1",
+        },
+      },
+    );
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        llm: {
+          provider: null,
+        },
+      },
+    );
+
+    const llmRows = await db.select().from(llmConfig).where(eq(llmConfig.tenantId, tenant.id));
+    expect(llmRows).toHaveLength(0);
+
+    const settings = await readSettings({ db, tenantId: tenant.id });
+    expect(settings.llm).toEqual({
+      provider: null,
+      model: "",
+      endpointUrl: undefined,
+      hasApiKey: false,
+    });
+  });
+});

--- a/apps/api/src/lib/__tests__/settings-service.test.ts
+++ b/apps/api/src/lib/__tests__/settings-service.test.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { createDatabase, llmConfig, providerConfig, tenants } from "@hap/db";
 import { and, eq, like } from "drizzle-orm";
-import { afterAll, beforeEach, describe, expect, it } from "vitest";
-import { decryptProviderKey } from "../encryption";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { __resetEncryptionCacheForTests, decryptProviderKey } from "../encryption";
 import { readSettings, updateSettings } from "../settings-service";
 
 const DATABASE_URL =
@@ -10,6 +10,14 @@ const DATABASE_URL =
 
 const db = createDatabase(DATABASE_URL);
 const PORTAL_PREFIX = `settingssvc-${randomUUID().slice(0, 8)}-`;
+const ROOT_KEK_BASE64 = Buffer.alloc(32, 9).toString("base64");
+let savedRootKek: string | undefined;
+
+beforeAll(() => {
+  savedRootKek = process.env.ROOT_KEK;
+  process.env.ROOT_KEK = ROOT_KEK_BASE64;
+  __resetEncryptionCacheForTests();
+});
 
 function portalId() {
   return `${PORTAL_PREFIX}${randomUUID().slice(0, 8)}`;
@@ -34,6 +42,12 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+  if (savedRootKek !== undefined) {
+    process.env.ROOT_KEK = savedRootKek;
+  } else {
+    delete process.env.ROOT_KEK;
+  }
+  __resetEncryptionCacheForTests();
 });
 
 describe("readSettings", () => {
@@ -218,6 +232,88 @@ describe("updateSettings", () => {
       model: "",
       endpointUrl: undefined,
       hasApiKey: false,
+    });
+  });
+
+  it("clears the current llm api key without requiring a full provider/model rewrite", async () => {
+    const tenant = await seedTenant({ defaultLlmProvider: "openai" });
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        llm: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          apiKey: "openai-secret-1",
+        },
+      },
+    );
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        llm: {
+          clearApiKey: true,
+        },
+      },
+    );
+
+    const [llmRow] = await db
+      .select()
+      .from(llmConfig)
+      .where(and(eq(llmConfig.tenantId, tenant.id), eq(llmConfig.providerName, "openai")));
+
+    expect(llmRow?.apiKeyEncrypted).toBeNull();
+
+    const settings = await readSettings({ db, tenantId: tenant.id });
+    expect(settings.llm).toEqual({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      endpointUrl: undefined,
+      hasApiKey: false,
+    });
+  });
+
+  it("switching llm providers removes stale rows and only exposes the active provider", async () => {
+    const tenant = await seedTenant();
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        llm: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "anthropic-secret-1",
+        },
+      },
+    );
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        llm: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          apiKey: "openai-secret-1",
+        },
+      },
+    );
+
+    const llmRows = await db
+      .select({
+        providerName: llmConfig.providerName,
+      })
+      .from(llmConfig)
+      .where(eq(llmConfig.tenantId, tenant.id));
+
+    expect(llmRows).toEqual([{ providerName: "openai" }]);
+
+    const settings = await readSettings({ db, tenantId: tenant.id });
+    expect(settings.llm).toEqual({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      endpointUrl: undefined,
+      hasApiKey: true,
     });
   });
 });

--- a/apps/api/src/lib/settings-service.ts
+++ b/apps/api/src/lib/settings-service.ts
@@ -112,7 +112,7 @@ async function readLlmRow(
 
   if (!rows[0]) return null;
   if (!defaultProvider) return rows[0];
-  return rows.find((row) => row.providerName === defaultProvider) ?? rows[0];
+  return rows.find((row) => row.providerName === defaultProvider) ?? null;
 }
 
 export async function readSettings(deps: SettingsServiceDeps): Promise<SettingsResponse> {
@@ -253,144 +253,169 @@ export async function updateSettings(
 ): Promise<void> {
   const { db, tenantId } = deps;
 
-  const existingProviders = await readSignalProviderRows(db, tenantId);
-  const providerByName = new Map(existingProviders.map((row) => [row.providerName, row]));
-  const tenantSettings = (await getTenantSettings(db, tenantId)) ?? {};
-  const currentDefaultProvider =
-    typeof tenantSettings.defaultLlmProvider === "string"
-      ? (tenantSettings.defaultLlmProvider as LlmProviderType)
-      : undefined;
+  await db.transaction(async (tx) => {
+    const txDb = tx as unknown as Database;
 
-  if (update.thresholds) {
-    const nextThresholds: ThresholdConfig = {
-      ...DEFAULT_THRESHOLDS,
-      ...parseThresholds(providerByName.get("exa")?.thresholds),
-      ...update.thresholds,
-    };
+    const existingProviders = await readSignalProviderRows(txDb, tenantId);
+    const providerByName = new Map(existingProviders.map((row) => [row.providerName, row]));
+    const tenantSettings = (await getTenantSettings(txDb, tenantId)) ?? {};
+    const currentDefaultProvider =
+      typeof tenantSettings.defaultLlmProvider === "string"
+        ? (tenantSettings.defaultLlmProvider as LlmProviderType)
+        : undefined;
 
-    for (const { providerName } of MANAGED_SIGNAL_PROVIDERS) {
-      const existing = providerByName.get(providerName);
-      await upsertSignalProvider(db, tenantId, providerName, {
-        enabled: existing?.enabled ?? false,
-        apiKeyEncrypted: existing?.apiKeyEncrypted ?? null,
-        thresholds: nextThresholds,
-      });
+    if (update.thresholds) {
+      const existingThresholdSource = MANAGED_SIGNAL_PROVIDERS.map(({ providerName }) =>
+        providerByName.get(providerName),
+      ).find((row) => row);
+
+      const nextThresholds: ThresholdConfig = {
+        ...DEFAULT_THRESHOLDS,
+        ...(existingThresholdSource ? parseThresholds(existingThresholdSource.thresholds) : {}),
+        ...update.thresholds,
+      };
+
+      for (const { providerName } of MANAGED_SIGNAL_PROVIDERS) {
+        const existing = providerByName.get(providerName);
+        await upsertSignalProvider(txDb, tenantId, providerName, {
+          enabled: existing?.enabled ?? false,
+          apiKeyEncrypted: existing?.apiKeyEncrypted ?? null,
+          thresholds: nextThresholds,
+        });
+      }
     }
-  }
 
-  if (update.signalProviders) {
-    for (const { key, providerName } of MANAGED_SIGNAL_PROVIDERS) {
-      const patch = update.signalProviders[key];
-      if (!patch) continue;
-      const existing = providerByName.get(providerName);
-      await upsertSignalProvider(db, tenantId, providerName, {
-        enabled: patch.enabled ?? existing?.enabled ?? false,
-        apiKeyEncrypted: patch.clearApiKey
-          ? null
-          : patch.apiKey
-            ? encryptProviderKey(tenantId, patch.apiKey)
-            : (existing?.apiKeyEncrypted ?? null),
+    if (update.signalProviders) {
+      for (const { key, providerName } of MANAGED_SIGNAL_PROVIDERS) {
+        const patch = update.signalProviders[key];
+        if (!patch) continue;
+        const existing = providerByName.get(providerName);
+        await upsertSignalProvider(txDb, tenantId, providerName, {
+          enabled: patch.enabled ?? existing?.enabled ?? false,
+          apiKeyEncrypted: patch.clearApiKey
+            ? null
+            : patch.apiKey
+              ? encryptProviderKey(tenantId, patch.apiKey)
+              : (existing?.apiKeyEncrypted ?? null),
+          thresholds: {
+            ...DEFAULT_THRESHOLDS,
+            ...parseThresholds(existing?.thresholds),
+            ...update.thresholds,
+          },
+        });
+      }
+    }
+
+    if (update.eligibility?.propertyName) {
+      const existing = providerByName.get(HUBSPOT_PROVIDER_NAME);
+      const existingSettings =
+        existing?.settings &&
+        typeof existing.settings === "object" &&
+        !Array.isArray(existing.settings)
+          ? (existing.settings as Record<string, unknown>)
+          : {};
+
+      await upsertSignalProvider(txDb, tenantId, HUBSPOT_PROVIDER_NAME, {
+        // HubSpot base config is OAuth-backed and used only for settings lookup,
+        // not end-user enable/disable gating like hubspot-enrichment.
+        enabled: existing?.enabled ?? true,
+        apiKeyEncrypted: existing?.apiKeyEncrypted ?? null,
         thresholds: {
           ...DEFAULT_THRESHOLDS,
           ...parseThresholds(existing?.thresholds),
-          ...update.thresholds,
         },
-      });
-    }
-  }
-
-  if (update.eligibility?.propertyName) {
-    const existing = providerByName.get(HUBSPOT_PROVIDER_NAME);
-    const existingSettings =
-      existing?.settings &&
-      typeof existing.settings === "object" &&
-      !Array.isArray(existing.settings)
-        ? (existing.settings as Record<string, unknown>)
-        : {};
-
-    await upsertSignalProvider(db, tenantId, HUBSPOT_PROVIDER_NAME, {
-      enabled: existing?.enabled ?? true,
-      apiKeyEncrypted: existing?.apiKeyEncrypted ?? null,
-      thresholds: {
-        ...DEFAULT_THRESHOLDS,
-        ...parseThresholds(existing?.thresholds),
-      },
-      settings: {
-        ...existingSettings,
-        [ELIGIBILITY_PROPERTY_SETTINGS_KEY]: update.eligibility.propertyName,
-      },
-    });
-  }
-
-  if (update.llm?.provider === null) {
-    await db.delete(llmConfig).where(eq(llmConfig.tenantId, tenantId));
-
-    const { defaultLlmProvider: _removed, ...nextTenantSettings } = tenantSettings;
-    await db
-      .update(tenants)
-      .set({
-        settings: nextTenantSettings,
-        updatedAt: sql`now()`,
-      })
-      .where(eq(tenants.id, tenantId));
-  } else if (update.llm?.provider && update.llm.model) {
-    const existingRows = await db
-      .select({
-        providerName: llmConfig.providerName,
-        modelName: llmConfig.modelName,
-        apiKeyEncrypted: llmConfig.apiKeyEncrypted,
-        endpointUrl: llmConfig.endpointUrl,
-      })
-      .from(llmConfig)
-      .where(and(eq(llmConfig.tenantId, tenantId), eq(llmConfig.providerName, update.llm.provider)))
-      .limit(1);
-
-    const existing = existingRows[0];
-    await upsertLlmProvider(db, tenantId, update.llm.provider, {
-      model: update.llm.model,
-      apiKeyEncrypted: update.llm.clearApiKey
-        ? null
-        : update.llm.apiKey
-          ? encryptProviderKey(tenantId, update.llm.apiKey)
-          : (existing?.apiKeyEncrypted ?? null),
-      endpointUrl:
-        update.llm.provider === "custom"
-          ? (update.llm.endpointUrl ?? existing?.endpointUrl ?? null)
-          : null,
-    });
-
-    await db
-      .update(tenants)
-      .set({
         settings: {
-          ...tenantSettings,
-          defaultLlmProvider: update.llm.provider,
+          ...existingSettings,
+          [ELIGIBILITY_PROPERTY_SETTINGS_KEY]: update.eligibility.propertyName,
         },
-        updatedAt: sql`now()`,
-      })
-      .where(eq(tenants.id, tenantId));
-  } else if (currentDefaultProvider && update.llm?.apiKey) {
-    const existingRows = await db
-      .select({
-        providerName: llmConfig.providerName,
-        modelName: llmConfig.modelName,
-        apiKeyEncrypted: llmConfig.apiKeyEncrypted,
-        endpointUrl: llmConfig.endpointUrl,
-      })
-      .from(llmConfig)
-      .where(
-        and(eq(llmConfig.tenantId, tenantId), eq(llmConfig.providerName, currentDefaultProvider)),
-      )
-      .limit(1);
-    const existing = existingRows[0];
-    if (existing) {
-      await upsertLlmProvider(db, tenantId, currentDefaultProvider, {
-        model: existing.modelName,
-        apiKeyEncrypted: encryptProviderKey(tenantId, update.llm.apiKey),
-        endpointUrl: existing.endpointUrl,
       });
     }
-  }
+
+    if (update.llm?.provider === null) {
+      await tx.delete(llmConfig).where(eq(llmConfig.tenantId, tenantId));
+
+      const { defaultLlmProvider: _removed, ...nextTenantSettings } = tenantSettings;
+      await tx
+        .update(tenants)
+        .set({
+          settings: nextTenantSettings,
+          updatedAt: sql`now()`,
+        })
+        .where(eq(tenants.id, tenantId));
+    } else if (update.llm?.provider && update.llm.model) {
+      const existingRows = await tx
+        .select({
+          providerName: llmConfig.providerName,
+          modelName: llmConfig.modelName,
+          apiKeyEncrypted: llmConfig.apiKeyEncrypted,
+          endpointUrl: llmConfig.endpointUrl,
+        })
+        .from(llmConfig)
+        .where(
+          and(eq(llmConfig.tenantId, tenantId), eq(llmConfig.providerName, update.llm.provider)),
+        )
+        .limit(1);
+
+      const existing = existingRows[0];
+      await upsertLlmProvider(txDb, tenantId, update.llm.provider, {
+        model: update.llm.model,
+        apiKeyEncrypted: update.llm.clearApiKey
+          ? null
+          : update.llm.apiKey
+            ? encryptProviderKey(tenantId, update.llm.apiKey)
+            : (existing?.apiKeyEncrypted ?? null),
+        endpointUrl:
+          update.llm.provider === "custom"
+            ? (update.llm.endpointUrl ?? existing?.endpointUrl ?? null)
+            : null,
+      });
+
+      await tx
+        .delete(llmConfig)
+        .where(
+          and(
+            eq(llmConfig.tenantId, tenantId),
+            sql`${llmConfig.providerName} <> ${update.llm.provider}`,
+          ),
+        );
+
+      await tx
+        .update(tenants)
+        .set({
+          settings: {
+            ...tenantSettings,
+            defaultLlmProvider: update.llm.provider,
+          },
+          updatedAt: sql`now()`,
+        })
+        .where(eq(tenants.id, tenantId));
+    } else if (currentDefaultProvider && (update.llm?.apiKey || update.llm?.clearApiKey)) {
+      const existingRows = await tx
+        .select({
+          providerName: llmConfig.providerName,
+          modelName: llmConfig.modelName,
+          apiKeyEncrypted: llmConfig.apiKeyEncrypted,
+          endpointUrl: llmConfig.endpointUrl,
+        })
+        .from(llmConfig)
+        .where(
+          and(eq(llmConfig.tenantId, tenantId), eq(llmConfig.providerName, currentDefaultProvider)),
+        )
+        .limit(1);
+      const existing = existingRows[0];
+      if (existing) {
+        await upsertLlmProvider(txDb, tenantId, currentDefaultProvider, {
+          model: existing.modelName,
+          apiKeyEncrypted: update.llm.clearApiKey
+            ? null
+            : update.llm.apiKey
+              ? encryptProviderKey(tenantId, update.llm.apiKey)
+              : existing.apiKeyEncrypted,
+          endpointUrl: existing.endpointUrl,
+        });
+      }
+    }
+  });
 
   invalidateTenantConfig(tenantId);
 }

--- a/apps/api/src/lib/settings-service.ts
+++ b/apps/api/src/lib/settings-service.ts
@@ -1,0 +1,396 @@
+import type {
+  LlmProviderType,
+  SettingsResponse,
+  SettingsUpdate,
+  ThresholdConfig,
+} from "@hap/config";
+import { type Database, llmConfig, providerConfig, tenants } from "@hap/db";
+import { and, asc, eq, sql } from "drizzle-orm";
+import { DEFAULT_ELIGIBILITY_PROPERTY } from "../services/eligibility";
+import { DEFAULT_THRESHOLDS, invalidateTenantConfig } from "./config-resolver";
+import { encryptProviderKey } from "./encryption";
+
+const MANAGED_SIGNAL_PROVIDERS = [
+  { key: "exa", providerName: "exa" },
+  { key: "news", providerName: "news" },
+  { key: "hubspotEnrichment", providerName: "hubspot-enrichment" },
+] as const;
+
+const HUBSPOT_PROVIDER_NAME = "hubspot";
+const ELIGIBILITY_PROPERTY_SETTINGS_KEY = "eligibilityPropertyName";
+
+type SettingsServiceDeps = {
+  db: Database;
+  tenantId: string;
+};
+
+type ProviderRow = {
+  providerName: string;
+  enabled: boolean;
+  apiKeyEncrypted: string | null;
+  thresholds: unknown;
+  settings: unknown;
+};
+
+type LlmRow = {
+  providerName: string;
+  modelName: string;
+  apiKeyEncrypted: string | null;
+  endpointUrl: string | null;
+};
+
+function parseThresholds(raw: unknown): Partial<ThresholdConfig> {
+  const out: Partial<ThresholdConfig> = {};
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const rec = raw as Record<string, unknown>;
+    if (typeof rec.freshnessMaxDays === "number" && Number.isFinite(rec.freshnessMaxDays)) {
+      out.freshnessMaxDays = rec.freshnessMaxDays;
+    }
+    if (typeof rec.minConfidence === "number" && Number.isFinite(rec.minConfidence)) {
+      out.minConfidence = rec.minConfidence;
+    }
+  }
+  return out;
+}
+
+async function getTenantSettings(
+  db: Database,
+  tenantId: string,
+): Promise<Record<string, unknown> | undefined> {
+  const rows = await db
+    .select({ settings: tenants.settings })
+    .from(tenants)
+    .where(eq(tenants.id, tenantId))
+    .limit(1);
+
+  const value = rows[0]?.settings;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function resolveEligibilityProperty(settings: unknown): string {
+  if (settings && typeof settings === "object" && !Array.isArray(settings)) {
+    const raw = (settings as Record<string, unknown>)[ELIGIBILITY_PROPERTY_SETTINGS_KEY];
+    if (typeof raw === "string" && raw.length > 0) {
+      return raw;
+    }
+  }
+  return DEFAULT_ELIGIBILITY_PROPERTY;
+}
+
+async function readSignalProviderRows(db: Database, tenantId: string): Promise<ProviderRow[]> {
+  return db
+    .select({
+      providerName: providerConfig.providerName,
+      enabled: providerConfig.enabled,
+      apiKeyEncrypted: providerConfig.apiKeyEncrypted,
+      thresholds: providerConfig.thresholds,
+      settings: providerConfig.settings,
+    })
+    .from(providerConfig)
+    .where(eq(providerConfig.tenantId, tenantId))
+    .orderBy(asc(providerConfig.id));
+}
+
+async function readLlmRow(
+  db: Database,
+  tenantId: string,
+  defaultProvider: LlmProviderType | undefined,
+): Promise<LlmRow | null> {
+  const rows = await db
+    .select({
+      providerName: llmConfig.providerName,
+      modelName: llmConfig.modelName,
+      apiKeyEncrypted: llmConfig.apiKeyEncrypted,
+      endpointUrl: llmConfig.endpointUrl,
+    })
+    .from(llmConfig)
+    .where(eq(llmConfig.tenantId, tenantId))
+    .orderBy(asc(llmConfig.id));
+
+  if (!rows[0]) return null;
+  if (!defaultProvider) return rows[0];
+  return rows.find((row) => row.providerName === defaultProvider) ?? rows[0];
+}
+
+export async function readSettings(deps: SettingsServiceDeps): Promise<SettingsResponse> {
+  const { db, tenantId } = deps;
+  const tenantSettings = await getTenantSettings(db, tenantId);
+  const defaultProvider =
+    typeof tenantSettings?.defaultLlmProvider === "string"
+      ? (tenantSettings.defaultLlmProvider as LlmProviderType)
+      : undefined;
+
+  const providerRows = await readSignalProviderRows(db, tenantId);
+  const rowByProvider = new Map(providerRows.map((row) => [row.providerName, row]));
+
+  const thresholdSource = MANAGED_SIGNAL_PROVIDERS.map(({ providerName }) =>
+    rowByProvider.get(providerName),
+  ).find((row) => row);
+  const thresholds: ThresholdConfig = {
+    ...DEFAULT_THRESHOLDS,
+    ...(thresholdSource ? parseThresholds(thresholdSource.thresholds) : {}),
+  };
+
+  const hubspotSettings = rowByProvider.get(HUBSPOT_PROVIDER_NAME)?.settings;
+  const llmRow = await readLlmRow(db, tenantId, defaultProvider);
+
+  return {
+    tenantId,
+    signalProviders: {
+      exa: {
+        enabled: rowByProvider.get("exa")?.enabled ?? false,
+        hasApiKey: !!rowByProvider.get("exa")?.apiKeyEncrypted,
+      },
+      news: {
+        enabled: rowByProvider.get("news")?.enabled ?? false,
+        hasApiKey: !!rowByProvider.get("news")?.apiKeyEncrypted,
+      },
+      hubspotEnrichment: {
+        enabled: rowByProvider.get("hubspot-enrichment")?.enabled ?? false,
+        hasApiKey: !!rowByProvider.get("hubspot-enrichment")?.apiKeyEncrypted,
+      },
+    },
+    llm: {
+      provider: (llmRow?.providerName as LlmProviderType | undefined) ?? null,
+      model: llmRow?.modelName ?? "",
+      endpointUrl: llmRow?.endpointUrl ?? undefined,
+      hasApiKey: !!llmRow?.apiKeyEncrypted,
+    },
+    eligibility: {
+      propertyName: resolveEligibilityProperty(hubspotSettings),
+    },
+    thresholds,
+  };
+}
+
+async function upsertSignalProvider(
+  db: Database,
+  tenantId: string,
+  providerName: string,
+  set: {
+    enabled?: boolean;
+    apiKeyEncrypted?: string | null;
+    thresholds?: ThresholdConfig;
+    settings?: Record<string, unknown>;
+  },
+): Promise<void> {
+  const values: {
+    tenantId: string;
+    providerName: string;
+    enabled?: boolean;
+    apiKeyEncrypted?: string | null;
+    thresholds?: ThresholdConfig;
+    settings?: Record<string, unknown>;
+  } = {
+    tenantId,
+    providerName,
+  };
+
+  if (set.enabled !== undefined) values.enabled = set.enabled;
+  if (set.apiKeyEncrypted !== undefined) values.apiKeyEncrypted = set.apiKeyEncrypted;
+  if (set.thresholds !== undefined) values.thresholds = set.thresholds;
+  if (set.settings !== undefined) values.settings = set.settings;
+
+  const updateSet: Record<string, unknown> = {};
+  if (set.enabled !== undefined) updateSet.enabled = set.enabled;
+  if (set.apiKeyEncrypted !== undefined) updateSet.apiKeyEncrypted = set.apiKeyEncrypted;
+  if (set.thresholds !== undefined) updateSet.thresholds = set.thresholds;
+  if (set.settings !== undefined) updateSet.settings = set.settings;
+
+  await db
+    .insert(providerConfig)
+    .values({
+      tenantId: values.tenantId,
+      providerName: values.providerName,
+      enabled: values.enabled ?? false,
+      apiKeyEncrypted: values.apiKeyEncrypted ?? null,
+      thresholds: values.thresholds ?? {},
+      settings: values.settings ?? {},
+    })
+    .onConflictDoUpdate({
+      target: [providerConfig.tenantId, providerConfig.providerName],
+      set: updateSet,
+    });
+}
+
+async function upsertLlmProvider(
+  db: Database,
+  tenantId: string,
+  provider: LlmProviderType,
+  set: {
+    model: string;
+    apiKeyEncrypted?: string | null;
+    endpointUrl?: string | null;
+  },
+): Promise<void> {
+  const updateSet: Record<string, unknown> = {
+    modelName: set.model,
+  };
+  if (set.apiKeyEncrypted !== undefined) updateSet.apiKeyEncrypted = set.apiKeyEncrypted;
+  if (set.endpointUrl !== undefined) updateSet.endpointUrl = set.endpointUrl;
+
+  await db
+    .insert(llmConfig)
+    .values({
+      tenantId,
+      providerName: provider,
+      modelName: set.model,
+      apiKeyEncrypted: set.apiKeyEncrypted ?? null,
+      endpointUrl: set.endpointUrl ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [llmConfig.tenantId, llmConfig.providerName],
+      set: updateSet,
+    });
+}
+
+export async function updateSettings(
+  deps: SettingsServiceDeps,
+  update: SettingsUpdate,
+): Promise<void> {
+  const { db, tenantId } = deps;
+
+  const existingProviders = await readSignalProviderRows(db, tenantId);
+  const providerByName = new Map(existingProviders.map((row) => [row.providerName, row]));
+  const tenantSettings = (await getTenantSettings(db, tenantId)) ?? {};
+  const currentDefaultProvider =
+    typeof tenantSettings.defaultLlmProvider === "string"
+      ? (tenantSettings.defaultLlmProvider as LlmProviderType)
+      : undefined;
+
+  if (update.thresholds) {
+    const nextThresholds: ThresholdConfig = {
+      ...DEFAULT_THRESHOLDS,
+      ...parseThresholds(providerByName.get("exa")?.thresholds),
+      ...update.thresholds,
+    };
+
+    for (const { providerName } of MANAGED_SIGNAL_PROVIDERS) {
+      const existing = providerByName.get(providerName);
+      await upsertSignalProvider(db, tenantId, providerName, {
+        enabled: existing?.enabled ?? false,
+        apiKeyEncrypted: existing?.apiKeyEncrypted ?? null,
+        thresholds: nextThresholds,
+      });
+    }
+  }
+
+  if (update.signalProviders) {
+    for (const { key, providerName } of MANAGED_SIGNAL_PROVIDERS) {
+      const patch = update.signalProviders[key];
+      if (!patch) continue;
+      const existing = providerByName.get(providerName);
+      await upsertSignalProvider(db, tenantId, providerName, {
+        enabled: patch.enabled ?? existing?.enabled ?? false,
+        apiKeyEncrypted: patch.clearApiKey
+          ? null
+          : patch.apiKey
+            ? encryptProviderKey(tenantId, patch.apiKey)
+            : (existing?.apiKeyEncrypted ?? null),
+        thresholds: {
+          ...DEFAULT_THRESHOLDS,
+          ...parseThresholds(existing?.thresholds),
+          ...update.thresholds,
+        },
+      });
+    }
+  }
+
+  if (update.eligibility?.propertyName) {
+    const existing = providerByName.get(HUBSPOT_PROVIDER_NAME);
+    const existingSettings =
+      existing?.settings &&
+      typeof existing.settings === "object" &&
+      !Array.isArray(existing.settings)
+        ? (existing.settings as Record<string, unknown>)
+        : {};
+
+    await upsertSignalProvider(db, tenantId, HUBSPOT_PROVIDER_NAME, {
+      enabled: existing?.enabled ?? true,
+      apiKeyEncrypted: existing?.apiKeyEncrypted ?? null,
+      thresholds: {
+        ...DEFAULT_THRESHOLDS,
+        ...parseThresholds(existing?.thresholds),
+      },
+      settings: {
+        ...existingSettings,
+        [ELIGIBILITY_PROPERTY_SETTINGS_KEY]: update.eligibility.propertyName,
+      },
+    });
+  }
+
+  if (update.llm?.provider === null) {
+    await db.delete(llmConfig).where(eq(llmConfig.tenantId, tenantId));
+
+    const { defaultLlmProvider: _removed, ...nextTenantSettings } = tenantSettings;
+    await db
+      .update(tenants)
+      .set({
+        settings: nextTenantSettings,
+        updatedAt: sql`now()`,
+      })
+      .where(eq(tenants.id, tenantId));
+  } else if (update.llm?.provider && update.llm.model) {
+    const existingRows = await db
+      .select({
+        providerName: llmConfig.providerName,
+        modelName: llmConfig.modelName,
+        apiKeyEncrypted: llmConfig.apiKeyEncrypted,
+        endpointUrl: llmConfig.endpointUrl,
+      })
+      .from(llmConfig)
+      .where(and(eq(llmConfig.tenantId, tenantId), eq(llmConfig.providerName, update.llm.provider)))
+      .limit(1);
+
+    const existing = existingRows[0];
+    await upsertLlmProvider(db, tenantId, update.llm.provider, {
+      model: update.llm.model,
+      apiKeyEncrypted: update.llm.clearApiKey
+        ? null
+        : update.llm.apiKey
+          ? encryptProviderKey(tenantId, update.llm.apiKey)
+          : (existing?.apiKeyEncrypted ?? null),
+      endpointUrl:
+        update.llm.provider === "custom"
+          ? (update.llm.endpointUrl ?? existing?.endpointUrl ?? null)
+          : null,
+    });
+
+    await db
+      .update(tenants)
+      .set({
+        settings: {
+          ...tenantSettings,
+          defaultLlmProvider: update.llm.provider,
+        },
+        updatedAt: sql`now()`,
+      })
+      .where(eq(tenants.id, tenantId));
+  } else if (currentDefaultProvider && update.llm?.apiKey) {
+    const existingRows = await db
+      .select({
+        providerName: llmConfig.providerName,
+        modelName: llmConfig.modelName,
+        apiKeyEncrypted: llmConfig.apiKeyEncrypted,
+        endpointUrl: llmConfig.endpointUrl,
+      })
+      .from(llmConfig)
+      .where(
+        and(eq(llmConfig.tenantId, tenantId), eq(llmConfig.providerName, currentDefaultProvider)),
+      )
+      .limit(1);
+    const existing = existingRows[0];
+    if (existing) {
+      await upsertLlmProvider(db, tenantId, currentDefaultProvider, {
+        model: existing.modelName,
+        apiKeyEncrypted: encryptProviderKey(tenantId, update.llm.apiKey),
+        endpointUrl: existing.endpointUrl,
+      });
+    }
+  }
+
+  invalidateTenantConfig(tenantId);
+}

--- a/apps/api/src/routes/__tests__/settings.test.ts
+++ b/apps/api/src/routes/__tests__/settings.test.ts
@@ -1,0 +1,367 @@
+import { randomUUID } from "node:crypto";
+import { createDatabase, llmConfig, providerConfig, tenants } from "@hap/db";
+import { and, eq, like } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearConfigResolverCache,
+  getLlmConfig,
+  getProviderConfig,
+} from "../../lib/config-resolver";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
+
+const db = createDatabase(DATABASE_URL);
+const PORTAL_PREFIX = `settingroute-${randomUUID().slice(0, 8)}-`;
+const ROOT_KEK_BASE64 = Buffer.alloc(32, 9).toString("base64");
+let savedRootKek: string | undefined;
+
+function portalId() {
+  return `${PORTAL_PREFIX}${randomUUID().slice(0, 8)}`;
+}
+
+async function seedTenant(name = "Settings Route Tenant") {
+  const [row] = await db
+    .insert(tenants)
+    .values({
+      hubspotPortalId: portalId(),
+      name,
+    })
+    .returning();
+  if (!row) throw new Error("failed to seed tenant");
+  return row;
+}
+
+async function loadApp() {
+  const mod = await import("../../index");
+  return mod.default;
+}
+
+beforeAll(() => {
+  process.env.NODE_ENV = "test";
+  process.env.DATABASE_URL = DATABASE_URL;
+  savedRootKek = process.env.ROOT_KEK;
+  process.env.ROOT_KEK = ROOT_KEK_BASE64;
+});
+
+beforeEach(async () => {
+  clearConfigResolverCache();
+  await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+});
+
+afterAll(async () => {
+  await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+  if (savedRootKek !== undefined) {
+    process.env.ROOT_KEK = savedRootKek;
+  } else {
+    delete process.env.ROOT_KEK;
+  }
+});
+
+describe("GET /api/settings", () => {
+  it("returns the default settings shape for a tenant with no config rows", async () => {
+    const tenant = await seedTenant();
+    const app = await loadApp();
+
+    const res = await app.request("/api/settings", {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tenantId: string;
+      signalProviders: Record<string, { enabled: boolean; hasApiKey: boolean }>;
+      llm: { provider: string | null; model: string; hasApiKey: boolean; endpointUrl?: string };
+      eligibility: { propertyName: string };
+      thresholds: { freshnessMaxDays: number; minConfidence: number };
+    };
+
+    expect(body).toEqual({
+      tenantId: tenant.id,
+      signalProviders: {
+        exa: { enabled: false, hasApiKey: false },
+        news: { enabled: false, hasApiKey: false },
+        hubspotEnrichment: { enabled: false, hasApiKey: false },
+      },
+      llm: {
+        provider: null,
+        model: "",
+        hasApiKey: false,
+      },
+      eligibility: {
+        propertyName: "hs_is_target_account",
+      },
+      thresholds: {
+        freshnessMaxDays: 30,
+        minConfidence: 0.5,
+      },
+    });
+  });
+});
+
+describe("PUT /api/settings", () => {
+  it("writes settings and returns a write-only read model", async () => {
+    const tenant = await seedTenant();
+    const app = await loadApp();
+
+    const res = await app.request("/api/settings", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        signalProviders: {
+          exa: { enabled: true, apiKey: "exa-secret-route" },
+          news: { enabled: true },
+          hubspotEnrichment: { enabled: true },
+        },
+        llm: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          apiKey: "openai-secret-route",
+        },
+        eligibility: {
+          propertyName: "custom_target_property",
+        },
+        thresholds: {
+          freshnessMaxDays: 10,
+          minConfidence: 0.7,
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(JSON.stringify(body)).not.toContain("exa-secret-route");
+    expect(JSON.stringify(body)).not.toContain("openai-secret-route");
+    expect(body).toMatchObject({
+      tenantId: tenant.id,
+      signalProviders: {
+        exa: { enabled: true, hasApiKey: true },
+        news: { enabled: true, hasApiKey: false },
+        hubspotEnrichment: { enabled: true, hasApiKey: false },
+      },
+      llm: {
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        hasApiKey: true,
+      },
+      eligibility: {
+        propertyName: "custom_target_property",
+      },
+      thresholds: {
+        freshnessMaxDays: 10,
+        minConfidence: 0.7,
+      },
+    });
+
+    const getRes = await app.request("/api/settings", {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+      },
+    });
+    expect(getRes.status).toBe(200);
+    const getBody = (await getRes.json()) as Record<string, unknown>;
+    expect(getBody).toMatchObject(body);
+  });
+
+  it("preserves existing encrypted secrets when blank apiKey fields are submitted", async () => {
+    const tenant = await seedTenant();
+    const app = await loadApp();
+
+    const first = await app.request("/api/settings", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        signalProviders: {
+          exa: { enabled: true, apiKey: "exa-secret-route" },
+        },
+        llm: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "anthropic-secret-route",
+        },
+      }),
+    });
+    expect(first.status).toBe(200);
+
+    const [beforeExa] = await db
+      .select()
+      .from(providerConfig)
+      .where(and(eq(providerConfig.tenantId, tenant.id), eq(providerConfig.providerName, "exa")));
+    const [beforeLlm] = await db
+      .select()
+      .from(llmConfig)
+      .where(and(eq(llmConfig.tenantId, tenant.id), eq(llmConfig.providerName, "anthropic")));
+
+    const second = await app.request("/api/settings", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        signalProviders: {
+          exa: { enabled: false, apiKey: "   " },
+        },
+        llm: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "   ",
+        },
+      }),
+    });
+    expect(second.status).toBe(200);
+
+    const [afterExa] = await db
+      .select()
+      .from(providerConfig)
+      .where(and(eq(providerConfig.tenantId, tenant.id), eq(providerConfig.providerName, "exa")));
+    const [afterLlm] = await db
+      .select()
+      .from(llmConfig)
+      .where(and(eq(llmConfig.tenantId, tenant.id), eq(llmConfig.providerName, "anthropic")));
+
+    expect(afterExa?.enabled).toBe(false);
+    expect(afterExa?.apiKeyEncrypted).toBe(beforeExa?.apiKeyEncrypted);
+    expect(afterLlm?.apiKeyEncrypted).toBe(beforeLlm?.apiKeyEncrypted);
+  });
+
+  it("rejects invalid settings payloads with 400", async () => {
+    const tenant = await seedTenant();
+    const app = await loadApp();
+
+    const res = await app.request("/api/settings", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        llm: {
+          provider: "custom",
+          model: "custom-model",
+          endpointUrl: "not-a-url",
+        },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("keeps tenant writes isolated to the authenticated portal", async () => {
+    const tenantA = await seedTenant("Tenant A");
+    const tenantB = await seedTenant("Tenant B");
+    const app = await loadApp();
+
+    const putRes = await app.request("/api/settings", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenantA.hubspotPortalId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        signalProviders: {
+          exa: { enabled: true },
+        },
+      }),
+    });
+    expect(putRes.status).toBe(200);
+
+    const getRes = await app.request("/api/settings", {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenantB.hubspotPortalId,
+      },
+    });
+    expect(getRes.status).toBe(200);
+    const body = (await getRes.json()) as {
+      tenantId: string;
+      signalProviders: { exa: { enabled: boolean; hasApiKey: boolean } };
+    };
+    expect(body.tenantId).toBe(tenantB.id);
+    expect(body.signalProviders.exa).toEqual({ enabled: false, hasApiKey: false });
+  });
+
+  it("invalidates cached provider and llm config immediately after settings save", async () => {
+    const tenant = await seedTenant();
+    const app = await loadApp();
+
+    const initial = await app.request("/api/settings", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        signalProviders: {
+          exa: { enabled: false },
+        },
+        llm: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "anthropic-old",
+        },
+      }),
+    });
+    expect(initial.status).toBe(200);
+
+    const cachedProvider = await getProviderConfig(
+      { db },
+      { tenantId: tenant.id, providerName: "exa" },
+    );
+    const cachedLlm = await getLlmConfig({ db }, { tenantId: tenant.id });
+    expect(cachedProvider?.enabled).toBe(false);
+    expect(cachedLlm?.provider).toBe("anthropic");
+    expect(cachedLlm?.model).toBe("claude-sonnet-4-6");
+
+    const updated = await app.request("/api/settings", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        signalProviders: {
+          exa: { enabled: true, apiKey: "exa-new" },
+        },
+        llm: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          apiKey: "openai-new",
+        },
+      }),
+    });
+    expect(updated.status).toBe(200);
+
+    const freshProvider = await getProviderConfig(
+      { db },
+      { tenantId: tenant.id, providerName: "exa" },
+    );
+    const freshLlm = await getLlmConfig({ db }, { tenantId: tenant.id });
+
+    expect(freshProvider?.enabled).toBe(true);
+    expect(freshProvider?.apiKeyRef).toBe("exa-new");
+    expect(freshLlm?.provider).toBe("openai");
+    expect(freshLlm?.model).toBe("gpt-5.4-mini");
+    expect(freshLlm?.apiKeyRef).toBe("openai-new");
+  });
+});

--- a/apps/api/src/routes/__tests__/settings.test.ts
+++ b/apps/api/src/routes/__tests__/settings.test.ts
@@ -7,6 +7,7 @@ import {
   getLlmConfig,
   getProviderConfig,
 } from "../../lib/config-resolver";
+import { __resetEncryptionCacheForTests } from "../../lib/encryption";
 
 const DATABASE_URL =
   process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
@@ -42,6 +43,7 @@ beforeAll(() => {
   process.env.DATABASE_URL = DATABASE_URL;
   savedRootKek = process.env.ROOT_KEK;
   process.env.ROOT_KEK = ROOT_KEK_BASE64;
+  __resetEncryptionCacheForTests();
 });
 
 beforeEach(async () => {
@@ -56,6 +58,7 @@ afterAll(async () => {
   } else {
     delete process.env.ROOT_KEK;
   }
+  __resetEncryptionCacheForTests();
 });
 
 describe("GET /api/settings", () => {

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -1,0 +1,50 @@
+import type { SettingsUpdate } from "@hap/config";
+import { settingsResponseSchema, settingsUpdateSchema } from "@hap/validators";
+import { Hono } from "hono";
+import { readSettings, updateSettings } from "../lib/settings-service";
+import type { TenantVariables } from "../middleware/tenant";
+
+export const settingsRoutes = new Hono<{ Variables: TenantVariables }>();
+
+settingsRoutes.get("/", async (c) => {
+  const tenantId = c.get("tenantId");
+  const db = c.get("db");
+  if (!tenantId || !db) {
+    return c.json({ error: "tenant_context_missing" }, 500);
+  }
+
+  const settings = await readSettings({ db, tenantId });
+  const parsed = settingsResponseSchema.safeParse(settings);
+  if (!parsed.success) {
+    return c.json({ error: "invalid_settings_response" }, 500);
+  }
+  return c.json(parsed.data, 200);
+});
+
+settingsRoutes.put("/", async (c) => {
+  const tenantId = c.get("tenantId");
+  const db = c.get("db");
+  if (!tenantId || !db) {
+    return c.json({ error: "tenant_context_missing" }, 500);
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid_json" }, 400);
+  }
+
+  const parsed = settingsUpdateSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return c.json({ error: "invalid_settings", issues: parsed.error.issues }, 400);
+  }
+
+  await updateSettings({ db, tenantId }, parsed.data as SettingsUpdate);
+  const settings = await readSettings({ db, tenantId });
+  const response = settingsResponseSchema.safeParse(settings);
+  if (!response.success) {
+    return c.json({ error: "invalid_settings_response" }, 500);
+  }
+  return c.json(response.data, 200);
+});

--- a/apps/hubspot-extension/src/features/snapshot/components/__tests__/empty-states.test.tsx
+++ b/apps/hubspot-extension/src/features/snapshot/components/__tests__/empty-states.test.tsx
@@ -28,6 +28,8 @@ describe("empty-state components", () => {
     renderer.render(<UnconfiguredState />);
     const text = renderer.find(Text).text;
     expect(text?.toLowerCase()).toContain("not configured");
+    expect(text?.toLowerCase()).toContain("connected apps");
+    expect(text?.toLowerCase()).toContain("settings");
   });
 
   it("RestrictedState renders a generic 'no data available' message with no evidence details", () => {

--- a/apps/hubspot-extension/src/features/snapshot/components/empty-states.tsx
+++ b/apps/hubspot-extension/src/features/snapshot/components/empty-states.tsx
@@ -20,7 +20,12 @@ export function IneligibleState() {
 
 /** Tenant has not finished provider/threshold setup. */
 export function UnconfiguredState() {
-  return <Text>This workspace is not configured yet.</Text>;
+  return (
+    <Text>
+      This workspace is not configured yet. In HubSpot, open Connected apps, choose this app, then
+      use the Settings tab to finish setup.
+    </Text>
+  );
 }
 
 /**

--- a/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
@@ -1,0 +1,218 @@
+import {
+  Heading,
+  Input,
+  LoadingButton,
+  NumberInput,
+  Select,
+  Text,
+  Toggle,
+} from "@hubspot/ui-extensions";
+import { createRenderer } from "@hubspot/ui-extensions/testing";
+import { describe, expect, it, vi } from "vitest";
+import { HubSpotSettingsPage } from "../settings-page";
+
+function triggerValue(node: unknown, value: unknown) {
+  (
+    node as {
+      trigger: (eventPropName: "onChange", eventArg?: unknown) => void;
+    }
+  ).trigger("onChange", value);
+}
+
+const VALID_SETTINGS = {
+  tenantId: "tenant-1",
+  signalProviders: {
+    exa: { enabled: true, hasApiKey: true },
+    news: { enabled: false, hasApiKey: false },
+    hubspotEnrichment: { enabled: true, hasApiKey: false },
+  },
+  llm: {
+    provider: "openai" as const,
+    model: "gpt-5.4-mini",
+    hasApiKey: true,
+  },
+  eligibility: {
+    propertyName: "hs_is_target_account",
+  },
+  thresholds: {
+    freshnessMaxDays: 30,
+    minConfidence: 0.5,
+  },
+};
+
+describe("HubSpotSettingsPage", () => {
+  it("renders the settings sections and stored-secret indicators after load", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      expect(renderer.findAll(Heading).length).toBeGreaterThanOrEqual(4);
+    });
+
+    const headings = renderer.findAll(Heading).map((node) => node.text ?? "");
+    expect(headings).toContain("Signal Providers");
+    expect(headings).toContain("LLM Settings");
+    expect(headings).toContain("Eligibility");
+    expect(headings).toContain("Thresholds");
+
+    const allText = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(allText).toContain("Stored key on file");
+  });
+
+  it("sends the expected settings payload when the user edits and saves", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const updateSettings = vi.fn(async () => ({
+      ...VALID_SETTINGS,
+      signalProviders: {
+        ...VALID_SETTINGS.signalProviders,
+        news: { enabled: true, hasApiKey: false },
+      },
+      llm: {
+        provider: "custom" as const,
+        model: "custom-model",
+        endpointUrl: "https://example.test/v1",
+        hasApiKey: true,
+      },
+      eligibility: {
+        propertyName: "custom_target_flag",
+      },
+      thresholds: {
+        freshnessMaxDays: 21,
+        minConfidence: 0.8,
+      },
+    }));
+
+    renderer.render(
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
+    );
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    triggerValue(renderer.find(Toggle, { name: "newsEnabled" }), true);
+    triggerValue(renderer.find(Select, { name: "llmProvider" }), "custom");
+    triggerValue(renderer.find(Input, { name: "llmModel" }), "custom-model");
+    triggerValue(renderer.find(Input, { name: "llmEndpointUrl" }), "https://example.test/v1");
+    triggerValue(renderer.find(Input, { name: "llmApiKey" }), "custom-secret");
+    triggerValue(renderer.find(Input, { name: "exaApiKey" }), "exa-rotated");
+    triggerValue(renderer.find(Input, { name: "eligibilityPropertyName" }), "custom_target_flag");
+    triggerValue(renderer.find(NumberInput, { name: "freshnessMaxDays" }), 21);
+    triggerValue(renderer.find(NumberInput, { name: "minConfidence" }), 0.8);
+    renderer.find(LoadingButton).trigger("onClick");
+
+    await renderer.waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledTimes(1);
+    });
+
+    await renderer.waitFor(() => {
+      const text = renderer
+        .findAll(Text)
+        .map((node) => node.text ?? "")
+        .join(" ");
+      expect(text).toContain("Settings saved.");
+    });
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      signalProviders: {
+        exa: { enabled: true, apiKey: "exa-rotated" },
+        news: { enabled: true },
+        hubspotEnrichment: { enabled: true },
+      },
+      llm: {
+        provider: "custom",
+        model: "custom-model",
+        endpointUrl: "https://example.test/v1",
+        apiKey: "custom-secret",
+      },
+      eligibility: {
+        propertyName: "custom_target_flag",
+      },
+      thresholds: {
+        freshnessMaxDays: 21,
+        minConfidence: 0.8,
+      },
+    });
+  });
+
+  it("blocks save when the custom llm provider is missing an endpoint url", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const updateSettings = vi.fn();
+
+    renderer.render(
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
+    );
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    triggerValue(renderer.find(Select, { name: "llmProvider" }), "custom");
+    triggerValue(renderer.find(Input, { name: "llmModel" }), "custom-model");
+    triggerValue(renderer.find(Input, { name: "llmEndpointUrl" }), "");
+    renderer.find(LoadingButton).trigger("onClick");
+
+    await renderer.waitFor(() => {
+      const text = renderer
+        .findAll(Text)
+        .map((node) => node.text ?? "")
+        .join(" ");
+      expect(text).toContain("Custom provider requires an endpoint URL.");
+    });
+
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("sends an explicit llm disable payload when the user selects None", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const updateSettings = vi.fn(async () => ({
+      ...VALID_SETTINGS,
+      llm: {
+        provider: null,
+        model: "",
+        hasApiKey: false,
+      },
+    }));
+
+    renderer.render(
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
+    );
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    triggerValue(renderer.find(Select, { name: "llmProvider" }), "none");
+    renderer.find(LoadingButton).trigger("onClick");
+
+    await renderer.waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledTimes(1);
+    });
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      signalProviders: {
+        exa: { enabled: true },
+        news: { enabled: false },
+        hubspotEnrichment: { enabled: true },
+      },
+      llm: {
+        provider: null,
+      },
+      eligibility: {
+        propertyName: "hs_is_target_account",
+      },
+      thresholds: {
+        freshnessMaxDays: 30,
+        minConfidence: 0.5,
+      },
+    });
+  });
+});

--- a/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
@@ -215,4 +215,40 @@ describe("HubSpotSettingsPage", () => {
       },
     });
   });
+
+  it("renders the initial load error instead of staying on an indefinite loading state", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => {
+      throw new Error("settings-fetch-failed: 401 Unauthorized");
+    });
+
+    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      const text = renderer
+        .findAll(Text)
+        .map((node) => node.text ?? "")
+        .join(" ");
+      expect(text).toContain("settings-fetch-failed: 401 Unauthorized");
+    });
+
+    const text = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(text).not.toBe("Loading…");
+  });
+
+  it("shows a HubSpot enrichment api key input when configuring that provider", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    expect(renderer.find(Input, { name: "hubspotEnrichmentApiKey" })).toBeTruthy();
+  });
 });

--- a/apps/hubspot-extension/src/settings/__tests__/use-settings.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/use-settings.test.tsx
@@ -1,0 +1,160 @@
+import { hubspot, Text } from "@hubspot/ui-extensions";
+import { createRenderer } from "@hubspot/ui-extensions/testing";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_API_BASE_URL } from "../api-fetcher";
+import { type UseSettingsArgs, useSettings } from "../use-settings";
+
+const VALID_SETTINGS = {
+  tenantId: "tenant-1",
+  signalProviders: {
+    exa: { enabled: true, hasApiKey: true },
+    news: { enabled: false, hasApiKey: false },
+    hubspotEnrichment: { enabled: true, hasApiKey: false },
+  },
+  llm: {
+    provider: "openai" as const,
+    model: "gpt-5.4-mini",
+    hasApiKey: true,
+  },
+  eligibility: {
+    propertyName: "hs_is_target_account",
+  },
+  thresholds: {
+    freshnessMaxDays: 30,
+    minConfidence: 0.5,
+  },
+};
+
+function Probe({
+  fetchSettings,
+  updateSettings,
+  triggerSave,
+}: {
+  fetchSettings?: UseSettingsArgs["fetchSettings"];
+  updateSettings?: UseSettingsArgs["updateSettings"];
+  triggerSave?: boolean;
+}) {
+  const state = useSettings({ fetchSettings, updateSettings });
+
+  useEffect(() => {
+    if (triggerSave && !state.loading && !state.saving && state.settings) {
+      void state.save({
+        signalProviders: {
+          exa: { enabled: false },
+        },
+      });
+    }
+  }, [state, triggerSave]);
+
+  return (
+    <Text>
+      {JSON.stringify({
+        loading: state.loading,
+        saving: state.saving,
+        error: state.error ? state.error.message : null,
+        tenantId: state.settings?.tenantId ?? null,
+        exaEnabled: state.settings?.signalProviders.exa.enabled ?? null,
+        exaHasApiKey: state.settings?.signalProviders.exa.hasApiKey ?? null,
+        saveSucceeded: state.saveSucceeded,
+        saveIsFn: typeof state.save === "function",
+      })}
+    </Text>
+  );
+}
+
+describe("useSettings", () => {
+  it("loads valid settings and exposes a save function", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<Probe fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      const parsed = JSON.parse(renderer.find(Text).text ?? "{}");
+      expect(parsed.loading).toBe(false);
+    });
+
+    const parsed = JSON.parse(renderer.find(Text).text ?? "{}");
+    expect(parsed.error).toBeNull();
+    expect(parsed.tenantId).toBe("tenant-1");
+    expect(parsed.exaEnabled).toBe(true);
+    expect(parsed.exaHasApiKey).toBe(true);
+    expect(parsed.saveSucceeded).toBe(false);
+    expect(parsed.saveIsFn).toBe(true);
+  });
+
+  it("updates the local settings state after a successful save", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const updateSettings = vi.fn(async () => ({
+      ...VALID_SETTINGS,
+      signalProviders: {
+        ...VALID_SETTINGS.signalProviders,
+        exa: { enabled: false, hasApiKey: true },
+      },
+    }));
+
+    renderer.render(
+      <Probe fetchSettings={fetchSettings} updateSettings={updateSettings} triggerSave={true} />,
+    );
+
+    await renderer.waitFor(() => {
+      const parsed = JSON.parse(renderer.find(Text).text ?? "{}");
+      expect(parsed.loading).toBe(false);
+      expect(parsed.saving).toBe(false);
+      expect(parsed.exaEnabled).toBe(false);
+      expect(parsed.saveSucceeded).toBe(true);
+    });
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      signalProviders: {
+        exa: { enabled: false },
+      },
+    });
+  });
+
+  it("surfaces validation errors for malformed settings responses", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => ({
+      tenantId: "tenant-1",
+    }));
+
+    renderer.render(<Probe fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      const parsed = JSON.parse(renderer.find(Text).text ?? "{}");
+      expect(parsed.loading).toBe(false);
+    });
+
+    const parsed = JSON.parse(renderer.find(Text).text ?? "{}");
+    expect(parsed.tenantId).toBeNull();
+    expect(parsed.error).not.toBeNull();
+  });
+
+  it("uses the real hubspot.fetch transport when no custom fetchers are injected", async () => {
+    const fetchSpy = vi.spyOn(hubspot, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => VALID_SETTINGS,
+    } as unknown as Response);
+
+    const renderer = createRenderer("settings");
+    renderer.render(<Probe />);
+
+    await renderer.waitFor(() => {
+      const parsed = JSON.parse(renderer.find(Text).text ?? "{}");
+      expect(parsed.loading).toBe(false);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const call = fetchSpy.mock.calls[0];
+    if (!call) throw new Error("hubspot.fetch was not called");
+    const [url, options] = call;
+    expect(url).toBe(`${DEFAULT_API_BASE_URL}/api/settings`);
+    expect((options as { method: string }).method).toBe("GET");
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/apps/hubspot-extension/src/settings/__tests__/use-settings.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/use-settings.test.tsx
@@ -1,6 +1,6 @@
 import { hubspot, Text } from "@hubspot/ui-extensions";
 import { createRenderer } from "@hubspot/ui-extensions/testing";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_API_BASE_URL } from "../api-fetcher";
 import { type UseSettingsArgs, useSettings } from "../use-settings";
@@ -60,6 +60,23 @@ function Probe({
         saveIsFn: typeof state.save === "function",
       })}
     </Text>
+  );
+}
+
+function InlineFetcherProbe({ fetchSpy }: { fetchSpy: () => Promise<typeof VALID_SETTINGS> }) {
+  const [tick, setTick] = useState(0);
+  const state = useSettings({
+    fetchSettings: () => fetchSpy(),
+  });
+
+  useEffect(() => {
+    if (!state.loading && state.settings && tick === 0) {
+      setTick(1);
+    }
+  }, [state.loading, state.settings, tick]);
+
+  return (
+    <Text>{JSON.stringify({ loading: state.loading, tenantId: state.settings?.tenantId })}</Text>
   );
 }
 
@@ -156,5 +173,22 @@ describe("useSettings", () => {
     expect((options as { method: string }).method).toBe("GET");
 
     fetchSpy.mockRestore();
+  });
+
+  it("does not refetch forever when callers pass inline fetcher functions", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSpy = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<InlineFetcherProbe fetchSpy={fetchSpy} />);
+
+    await renderer.waitFor(() => {
+      const parsed = JSON.parse(renderer.find(Text).text ?? "{}");
+      expect(parsed.loading).toBe(false);
+      expect(parsed.tenantId).toBe("tenant-1");
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/hubspot-extension/src/settings/api-fetcher.ts
+++ b/apps/hubspot-extension/src/settings/api-fetcher.ts
@@ -1,0 +1,48 @@
+import type { SettingsResponse, SettingsUpdate } from "@hap/config";
+import { hubspot } from "@hubspot/ui-extensions";
+
+export const DEFAULT_API_BASE_URL = "https://hap-signal-workspace.vercel.app";
+
+export class SettingsApiError extends Error {
+  public readonly status: number;
+  public readonly statusText: string;
+
+  constructor(status: number, statusText: string) {
+    super(`settings-fetch-failed: ${status} ${statusText}`);
+    this.name = "SettingsApiError";
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+
+export type SettingsFetcher = () => Promise<unknown>;
+export type SettingsUpdater = (update: SettingsUpdate) => Promise<unknown>;
+
+export function createSettingsFetcher(baseUrl = DEFAULT_API_BASE_URL): SettingsFetcher {
+  return async () => {
+    const response = await hubspot.fetch(`${baseUrl}/api/settings`, {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw new SettingsApiError(response.status, response.statusText);
+    }
+
+    return await response.json();
+  };
+}
+
+export function createSettingsUpdater(baseUrl = DEFAULT_API_BASE_URL): SettingsUpdater {
+  return async (update) => {
+    const response = await hubspot.fetch(`${baseUrl}/api/settings`, {
+      method: "PUT",
+      body: update as unknown as Record<string, unknown>,
+    });
+
+    if (!response.ok) {
+      throw new SettingsApiError(response.status, response.statusText);
+    }
+
+    return (await response.json()) as SettingsResponse;
+  };
+}

--- a/apps/hubspot-extension/src/settings/index.tsx
+++ b/apps/hubspot-extension/src/settings/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./settings-entry";

--- a/apps/hubspot-extension/src/settings/settings-entry.tsx
+++ b/apps/hubspot-extension/src/settings/settings-entry.tsx
@@ -1,7 +1,8 @@
 import { hubspot } from "@hubspot/ui-extensions";
+import { HubSpotSettingsPage } from "./settings-page";
 
 export default function HubSpotSettingsEntry() {
-  return null;
+  return <HubSpotSettingsPage />;
 }
 
 hubspot.extend<"settings">(() => <HubSpotSettingsEntry />);

--- a/apps/hubspot-extension/src/settings/settings-entry.tsx
+++ b/apps/hubspot-extension/src/settings/settings-entry.tsx
@@ -1,0 +1,7 @@
+import { hubspot } from "@hubspot/ui-extensions";
+
+export default function HubSpotSettingsEntry() {
+  return null;
+}
+
+hubspot.extend<"settings">(() => <HubSpotSettingsEntry />);

--- a/apps/hubspot-extension/src/settings/settings-page.tsx
+++ b/apps/hubspot-extension/src/settings/settings-page.tsx
@@ -1,0 +1,316 @@
+import type { LlmProviderType, SettingsResponse, SettingsUpdate } from "@hap/config";
+import {
+  Divider,
+  Flex,
+  Heading,
+  Input,
+  LoadingButton,
+  NumberInput,
+  Select,
+  Text,
+  Toggle,
+} from "@hubspot/ui-extensions";
+import { useEffect, useState } from "react";
+import type { SettingsFetcher, SettingsUpdater } from "./api-fetcher";
+import { useSettings } from "./use-settings";
+
+type DraftState = {
+  signalProviders: {
+    exaEnabled: boolean;
+    newsEnabled: boolean;
+    hubspotEnrichmentEnabled: boolean;
+    exaApiKey: string;
+    newsApiKey: string;
+    hubspotEnrichmentApiKey: string;
+  };
+  llm: {
+    provider: LlmProviderType | "none";
+    model: string;
+    endpointUrl: string;
+    apiKey: string;
+  };
+  eligibilityPropertyName: string;
+  freshnessMaxDays: number;
+  minConfidence: number;
+};
+
+export type HubSpotSettingsPageProps = {
+  fetchSettings?: SettingsFetcher;
+  updateSettings?: SettingsUpdater;
+};
+
+const LLM_PROVIDER_OPTIONS = [
+  { label: "None", value: "none" },
+  { label: "OpenAI", value: "openai" },
+  { label: "Anthropic", value: "anthropic" },
+  { label: "Gemini", value: "gemini" },
+  { label: "OpenRouter", value: "openrouter" },
+  { label: "Custom", value: "custom" },
+] as const;
+
+function buildDraft(settings: SettingsResponse): DraftState {
+  return {
+    signalProviders: {
+      exaEnabled: settings.signalProviders.exa.enabled,
+      newsEnabled: settings.signalProviders.news.enabled,
+      hubspotEnrichmentEnabled: settings.signalProviders.hubspotEnrichment.enabled,
+      exaApiKey: "",
+      newsApiKey: "",
+      hubspotEnrichmentApiKey: "",
+    },
+    llm: {
+      provider: settings.llm.provider ?? "none",
+      model: settings.llm.model,
+      endpointUrl: settings.llm.endpointUrl ?? "",
+      apiKey: "",
+    },
+    eligibilityPropertyName: settings.eligibility.propertyName,
+    freshnessMaxDays: settings.thresholds.freshnessMaxDays,
+    minConfidence: settings.thresholds.minConfidence,
+  };
+}
+
+export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSettingsPageProps) {
+  const state = useSettings({ fetchSettings, updateSettings });
+  const [draft, setDraft] = useState<DraftState | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (state.settings) {
+      setDraft(buildDraft(state.settings));
+    }
+  }, [state.settings]);
+
+  if (state.loading || !draft || !state.settings) {
+    return <Text>Loading…</Text>;
+  }
+
+  const saveSettings = async () => {
+    setValidationError(null);
+    if (draft.llm.provider === "custom" && draft.llm.endpointUrl.trim().length === 0) {
+      setValidationError("Custom provider requires an endpoint URL.");
+      return;
+    }
+
+    const update: SettingsUpdate = {
+      signalProviders: {
+        exa: {
+          enabled: draft.signalProviders.exaEnabled,
+          ...(draft.signalProviders.exaApiKey.trim().length > 0
+            ? { apiKey: draft.signalProviders.exaApiKey.trim() }
+            : {}),
+        },
+        news: {
+          enabled: draft.signalProviders.newsEnabled,
+          ...(draft.signalProviders.newsApiKey.trim().length > 0
+            ? { apiKey: draft.signalProviders.newsApiKey.trim() }
+            : {}),
+        },
+        hubspotEnrichment: {
+          enabled: draft.signalProviders.hubspotEnrichmentEnabled,
+          ...(draft.signalProviders.hubspotEnrichmentApiKey.trim().length > 0
+            ? { apiKey: draft.signalProviders.hubspotEnrichmentApiKey.trim() }
+            : {}),
+        },
+      },
+      llm:
+        draft.llm.provider === "none"
+          ? { provider: null }
+          : {
+              provider: draft.llm.provider,
+              model: draft.llm.model,
+              ...(draft.llm.endpointUrl.trim().length > 0
+                ? { endpointUrl: draft.llm.endpointUrl.trim() }
+                : {}),
+              ...(draft.llm.apiKey.trim().length > 0 ? { apiKey: draft.llm.apiKey.trim() } : {}),
+            },
+      eligibility: {
+        propertyName: draft.eligibilityPropertyName,
+      },
+      thresholds: {
+        freshnessMaxDays: draft.freshnessMaxDays,
+        minConfidence: draft.minConfidence,
+      },
+    };
+
+    await state.save(update);
+  };
+
+  return (
+    <Flex direction="column" gap="md">
+      <Heading>Signal Providers</Heading>
+      <Toggle
+        name="exaEnabled"
+        label="Enable Exa"
+        checked={draft.signalProviders.exaEnabled}
+        onChange={(checked) =>
+          setDraft((current) =>
+            current
+              ? {
+                  ...current,
+                  signalProviders: { ...current.signalProviders, exaEnabled: checked },
+                }
+              : current,
+          )
+        }
+      />
+      {state.settings.signalProviders.exa.hasApiKey ? <Text>Stored key on file</Text> : null}
+      <Input
+        name="exaApiKey"
+        label="Exa API key"
+        type="password"
+        value={draft.signalProviders.exaApiKey}
+        onChange={(value) =>
+          setDraft((current) =>
+            current
+              ? {
+                  ...current,
+                  signalProviders: { ...current.signalProviders, exaApiKey: value },
+                }
+              : current,
+          )
+        }
+      />
+      <Toggle
+        name="newsEnabled"
+        label="Enable News"
+        checked={draft.signalProviders.newsEnabled}
+        onChange={(checked) =>
+          setDraft((current) =>
+            current
+              ? {
+                  ...current,
+                  signalProviders: { ...current.signalProviders, newsEnabled: checked },
+                }
+              : current,
+          )
+        }
+      />
+      <Input
+        name="newsApiKey"
+        label="News API key"
+        type="password"
+        value={draft.signalProviders.newsApiKey}
+        onChange={(value) =>
+          setDraft((current) =>
+            current
+              ? {
+                  ...current,
+                  signalProviders: { ...current.signalProviders, newsApiKey: value },
+                }
+              : current,
+          )
+        }
+      />
+      <Toggle
+        name="hubspotEnrichmentEnabled"
+        label="Enable HubSpot enrichment"
+        checked={draft.signalProviders.hubspotEnrichmentEnabled}
+        onChange={(checked) =>
+          setDraft((current) =>
+            current
+              ? {
+                  ...current,
+                  signalProviders: {
+                    ...current.signalProviders,
+                    hubspotEnrichmentEnabled: checked,
+                  },
+                }
+              : current,
+          )
+        }
+      />
+
+      <Divider />
+      <Heading>LLM Settings</Heading>
+      {state.settings.llm.hasApiKey ? <Text>Stored key on file</Text> : null}
+      <Select
+        name="llmProvider"
+        label="Provider"
+        value={draft.llm.provider}
+        options={LLM_PROVIDER_OPTIONS as unknown as { label: string; value: string }[]}
+        onChange={(value) =>
+          setDraft((current) =>
+            current
+              ? {
+                  ...current,
+                  llm: { ...current.llm, provider: value as DraftState["llm"]["provider"] },
+                }
+              : current,
+          )
+        }
+      />
+      <Input
+        name="llmModel"
+        label="Model"
+        value={draft.llm.model}
+        onChange={(value) =>
+          setDraft((current) =>
+            current ? { ...current, llm: { ...current.llm, model: value } } : current,
+          )
+        }
+      />
+      <Input
+        name="llmEndpointUrl"
+        label="Endpoint URL"
+        value={draft.llm.endpointUrl}
+        onChange={(value) =>
+          setDraft((current) =>
+            current ? { ...current, llm: { ...current.llm, endpointUrl: value } } : current,
+          )
+        }
+      />
+      <Input
+        name="llmApiKey"
+        label="LLM API key"
+        type="password"
+        value={draft.llm.apiKey}
+        onChange={(value) =>
+          setDraft((current) =>
+            current ? { ...current, llm: { ...current.llm, apiKey: value } } : current,
+          )
+        }
+      />
+
+      <Divider />
+      <Heading>Eligibility</Heading>
+      <Input
+        name="eligibilityPropertyName"
+        label="Eligibility property"
+        value={draft.eligibilityPropertyName}
+        onChange={(value) =>
+          setDraft((current) =>
+            current ? { ...current, eligibilityPropertyName: value } : current,
+          )
+        }
+      />
+
+      <Divider />
+      <Heading>Thresholds</Heading>
+      <NumberInput
+        name="freshnessMaxDays"
+        label="Freshness max days"
+        value={draft.freshnessMaxDays}
+        onChange={(value) =>
+          setDraft((current) => (current ? { ...current, freshnessMaxDays: value } : current))
+        }
+      />
+      <NumberInput
+        name="minConfidence"
+        label="Minimum confidence"
+        value={draft.minConfidence}
+        onChange={(value) =>
+          setDraft((current) => (current ? { ...current, minConfidence: value } : current))
+        }
+      />
+
+      {validationError ? <Text>{validationError}</Text> : null}
+      {state.error ? <Text>{state.error.message}</Text> : null}
+      {state.saveSucceeded ? <Text>Settings saved.</Text> : null}
+
+      <LoadingButton loading={state.saving} onClick={() => void saveSettings()}>
+        Save settings
+      </LoadingButton>
+    </Flex>
+  );
+}

--- a/apps/hubspot-extension/src/settings/settings-page.tsx
+++ b/apps/hubspot-extension/src/settings/settings-page.tsx
@@ -81,7 +81,15 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
     }
   }, [state.settings]);
 
-  if (state.loading || !draft || !state.settings) {
+  if (state.loading) {
+    return <Text>Loading…</Text>;
+  }
+
+  if (state.error && (!draft || !state.settings)) {
+    return <Text>{state.error.message}</Text>;
+  }
+
+  if (!draft || !state.settings) {
     return <Text>Loading…</Text>;
   }
 
@@ -214,6 +222,28 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
                   signalProviders: {
                     ...current.signalProviders,
                     hubspotEnrichmentEnabled: checked,
+                  },
+                }
+              : current,
+          )
+        }
+      />
+      {state.settings.signalProviders.hubspotEnrichment.hasApiKey ? (
+        <Text>Stored key on file</Text>
+      ) : null}
+      <Input
+        name="hubspotEnrichmentApiKey"
+        label="HubSpot enrichment API key"
+        type="password"
+        value={draft.signalProviders.hubspotEnrichmentApiKey}
+        onChange={(value) =>
+          setDraft((current) =>
+            current
+              ? {
+                  ...current,
+                  signalProviders: {
+                    ...current.signalProviders,
+                    hubspotEnrichmentApiKey: value,
                   },
                 }
               : current,

--- a/apps/hubspot-extension/src/settings/use-settings.ts
+++ b/apps/hubspot-extension/src/settings/use-settings.ts
@@ -1,0 +1,101 @@
+import type { SettingsResponse, SettingsUpdate } from "@hap/config";
+import { settingsResponseSchema } from "@hap/validators";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  createSettingsFetcher,
+  createSettingsUpdater,
+  type SettingsFetcher,
+  type SettingsUpdater,
+} from "./api-fetcher";
+
+export type UseSettingsArgs = {
+  fetchSettings?: SettingsFetcher;
+  updateSettings?: SettingsUpdater;
+};
+
+export type UseSettingsState = {
+  settings: SettingsResponse | null;
+  loading: boolean;
+  saving: boolean;
+  saveSucceeded: boolean;
+  error?: Error;
+  save: (update: SettingsUpdate) => Promise<void>;
+};
+
+export function useSettings({
+  fetchSettings,
+  updateSettings,
+}: UseSettingsArgs = {}): UseSettingsState {
+  const [settings, setSettings] = useState<SettingsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveSucceeded, setSaveSucceeded] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  const defaultFetcher = useMemo(() => createSettingsFetcher(), []);
+  const defaultUpdater = useMemo(() => createSettingsUpdater(), []);
+  const activeFetcher = fetchSettings ?? defaultFetcher;
+  const activeUpdater = updateSettings ?? defaultUpdater;
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(undefined);
+    setSaveSucceeded(false);
+    setSettings(null);
+
+    activeFetcher()
+      .then((raw) => {
+        if (cancelled) return;
+        const parsed = settingsResponseSchema.safeParse(raw);
+        if (!parsed.success) {
+          setError(new Error(`settings-validation-failed: ${parsed.error.message}`));
+          setLoading(false);
+          return;
+        }
+        setSettings(parsed.data);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeFetcher]);
+
+  const save = useCallback(
+    async (update: SettingsUpdate) => {
+      setSaving(true);
+      setError(undefined);
+      setSaveSucceeded(false);
+      try {
+        const raw = await activeUpdater(update);
+        const parsed = settingsResponseSchema.safeParse(raw);
+        if (!parsed.success) {
+          throw new Error(`settings-validation-failed: ${parsed.error.message}`);
+        }
+        setSettings(parsed.data);
+        setSaveSucceeded(true);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setSaveSucceeded(false);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [activeUpdater],
+  );
+
+  return {
+    settings,
+    loading,
+    saving,
+    saveSucceeded,
+    error,
+    save,
+  };
+}

--- a/apps/hubspot-extension/src/settings/use-settings.ts
+++ b/apps/hubspot-extension/src/settings/use-settings.ts
@@ -1,6 +1,6 @@
 import type { SettingsResponse, SettingsUpdate } from "@hap/config";
 import { settingsResponseSchema } from "@hap/validators";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   createSettingsFetcher,
   createSettingsUpdater,
@@ -34,8 +34,11 @@ export function useSettings({
 
   const defaultFetcher = useMemo(() => createSettingsFetcher(), []);
   const defaultUpdater = useMemo(() => createSettingsUpdater(), []);
-  const activeFetcher = fetchSettings ?? defaultFetcher;
-  const activeUpdater = updateSettings ?? defaultUpdater;
+  const activeFetcherRef = useRef<SettingsFetcher>(fetchSettings ?? defaultFetcher);
+  const activeUpdaterRef = useRef<SettingsUpdater>(updateSettings ?? defaultUpdater);
+
+  activeFetcherRef.current = fetchSettings ?? defaultFetcher;
+  activeUpdaterRef.current = updateSettings ?? defaultUpdater;
 
   useEffect(() => {
     let cancelled = false;
@@ -44,7 +47,8 @@ export function useSettings({
     setSaveSucceeded(false);
     setSettings(null);
 
-    activeFetcher()
+    activeFetcherRef
+      .current()
       .then((raw) => {
         if (cancelled) return;
         const parsed = settingsResponseSchema.safeParse(raw);
@@ -65,30 +69,27 @@ export function useSettings({
     return () => {
       cancelled = true;
     };
-  }, [activeFetcher]);
+  }, []);
 
-  const save = useCallback(
-    async (update: SettingsUpdate) => {
-      setSaving(true);
-      setError(undefined);
-      setSaveSucceeded(false);
-      try {
-        const raw = await activeUpdater(update);
-        const parsed = settingsResponseSchema.safeParse(raw);
-        if (!parsed.success) {
-          throw new Error(`settings-validation-failed: ${parsed.error.message}`);
-        }
-        setSettings(parsed.data);
-        setSaveSucceeded(true);
-      } catch (err: unknown) {
-        setError(err instanceof Error ? err : new Error(String(err)));
-        setSaveSucceeded(false);
-      } finally {
-        setSaving(false);
+  const save = useCallback(async (update: SettingsUpdate) => {
+    setSaving(true);
+    setError(undefined);
+    setSaveSucceeded(false);
+    try {
+      const raw = await activeUpdaterRef.current(update);
+      const parsed = settingsResponseSchema.safeParse(raw);
+      if (!parsed.success) {
+        throw new Error(`settings-validation-failed: ${parsed.error.message}`);
       }
-    },
-    [activeUpdater],
-  );
+      setSettings(parsed.data);
+      setSaveSucceeded(true);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+      setSaveSucceeded(false);
+    } finally {
+      setSaving(false);
+    }
+  }, []);
 
   return {
     settings,

--- a/apps/hubspot-project/__validate__/scaffold.test.ts
+++ b/apps/hubspot-project/__validate__/scaffold.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import appHsmeta from "../src/app/app-hsmeta.json";
 import cardHsmeta from "../src/app/cards/card-hsmeta.json";
+import settingsHsmeta from "../src/app/settings/settings-hsmeta.json";
 
 // hsproject.json lives at the project root (outside src/). Its shape is
 // enforced by HubSpot's own `hs project validate` and checked in CI via
@@ -61,5 +62,42 @@ describe("HubSpot project scaffold (Slice 3 Task 5)", () => {
     const signalCardSource = readFileSync(signalCardPath, "utf8").trim();
 
     expect(signalCardSource).toBe('export { default } from "./dist/index.js";');
+  });
+
+  it("settings-hsmeta.json registers a settings extension entrypoint", () => {
+    expect(settingsHsmeta.type).toBe("settings");
+    expect(settingsHsmeta.config.entrypoint).toBe("/app/settings/Settings.tsx");
+  });
+
+  it("Settings.tsx re-exports the bundled settings default export directly", () => {
+    const settingsPath = resolve(import.meta.dirname, "../src/app/settings/Settings.tsx");
+    const settingsSource = readFileSync(settingsPath, "utf8").trim();
+
+    expect(settingsSource).toBe('export { default } from "./dist/index.js";');
+  });
+
+  it("settings/package.json mirrors the HubSpot feature scaffold shape", () => {
+    const settingsPackagePath = resolve(import.meta.dirname, "../src/app/settings/package.json");
+    const settingsPackage = JSON.parse(readFileSync(settingsPackagePath, "utf8")) as {
+      name: string;
+      type: string;
+      dependencies?: Record<string, string>;
+    };
+
+    expect(settingsPackage.name).toBe("hap-signal-workspace-settings");
+    expect(settingsPackage.type).toBe("module");
+    expect(settingsPackage.dependencies?.["@hubspot/ui-extensions"]).toBeDefined();
+    expect(settingsPackage.dependencies?.react).toBeDefined();
+  });
+
+  it("settings-entry.tsx registers a HubSpot settings extension", () => {
+    const settingsEntryPath = resolve(
+      import.meta.dirname,
+      "../../hubspot-extension/src/settings/settings-entry.tsx",
+    );
+    const settingsEntrySource = readFileSync(settingsEntryPath, "utf8");
+
+    expect(settingsEntrySource).toContain('hubspot.extend<"settings">');
+    expect(settingsEntrySource).toContain("export default function HubSpotSettingsEntry()");
   });
 });

--- a/apps/hubspot-project/src/app/settings/Settings.tsx
+++ b/apps/hubspot-project/src/app/settings/Settings.tsx
@@ -1,0 +1,1 @@
+export { default } from "./dist/index.js";

--- a/apps/hubspot-project/src/app/settings/package.json
+++ b/apps/hubspot-project/src/app/settings/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hap-signal-workspace-settings",
+  "version": "0.1.0",
+  "license": "MIT",
+  "type": "module",
+  "dependencies": {
+    "@hubspot/ui-extensions": "^0.13.0",
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "eslint": "^9.37.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/apps/hubspot-project/src/app/settings/settings-hsmeta.json
+++ b/apps/hubspot-project/src/app/settings/settings-hsmeta.json
@@ -1,0 +1,7 @@
+{
+  "uid": "hap_signal_workspace_settings",
+  "type": "settings",
+  "config": {
+    "entrypoint": "/app/settings/Settings.tsx"
+  }
+}

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -419,7 +419,7 @@ Verified limitations (HubSpot docs + Exa research, 2026-04-15):
 - `scripts/seed-hubspot-test-portal.ts`: user first installs the app into their test portal via the install flow (one-click on HubSpot's side); seed script then reads the stored tenant token and proceeds. No env-variable token path.
 - `packages/config/src/env.ts`: `HUBSPOT_DEV_PORTAL_TOKEN` removed from the schema. `HUBSPOT_CLIENT_ID` + `HUBSPOT_CLIENT_SECRET` stay (they drive OAuth + the existing Step 4 signed-request verification).
 
-## 17. Slice 4 Tenant Settings And Secret Hygiene
+## 19. Slice 4 Tenant Settings And Secret Hygiene
 
 Slice 4 adds a tenant-scoped settings control plane:
 
@@ -427,7 +427,7 @@ Slice 4 adds a tenant-scoped settings control plane:
 - backend settings routes at `GET /api/settings` and `PUT /api/settings`
 - orchestration layer in `apps/api/src/lib/settings-service.ts`
 
-### 17.1 Read model is secret-safe
+### 19.1 Read model is secret-safe
 
 Settings reads return a presence-only model:
 
@@ -440,7 +440,7 @@ This is enforced in two places:
 - `packages/validators/src/settings.ts` rejects response payloads that drift from the presence-only shape
 - route tests in `apps/api/src/routes/__tests__/settings.test.ts` assert that API responses do not contain the submitted secret strings
 
-### 17.2 Secret writes are replace-only
+### 19.2 Secret writes are replace-only
 
 The write contract is explicit:
 
@@ -451,7 +451,7 @@ The write contract is explicit:
 
 `packages/validators/src/settings.ts` normalizes blank inputs to `undefined`, and `apps/api/src/lib/settings-service.ts` preserves the existing ciphertext when no new plaintext secret is supplied.
 
-### 17.3 Storage and encryption
+### 19.3 Storage and encryption
 
 All provider and LLM secrets written through the settings API are encrypted at rest with the existing tenant-bound AES-256-GCM envelope from `apps/api/src/lib/encryption.ts`.
 
@@ -461,7 +461,7 @@ All provider and LLM secrets written through the settings API are encrypted at r
 
 The settings UI never receives decrypted secrets and only shows generic "Stored key on file" indicators.
 
-### 17.4 Tenant isolation and cache invalidation
+### 19.4 Tenant isolation and cache invalidation
 
 Settings writes run through the same request-scoped tenant DB handle used by the rest of the API:
 
@@ -472,7 +472,7 @@ Settings writes run through the same request-scoped tenant DB handle used by the
 
 After every settings write, `updateSettings()` calls `invalidateTenantConfig(tenantId)` so cached provider and LLM config cannot stay stale. The regression in `apps/api/src/routes/__tests__/settings.test.ts` proves that a cached old config is replaced immediately after `PUT /api/settings`.
 
-### 17.5 UI guidance for unconfigured tenants
+### 19.5 UI guidance for unconfigured tenants
 
 Slice 4 does not guess at a deep-link into HubSpot settings from the CRM record tab. Official HubSpot docs confirm the supported path is:
 
@@ -482,7 +482,7 @@ Slice 4 does not guess at a deep-link into HubSpot settings from the CRM record 
 
 The CRM-card `UnconfiguredState` now tells the user exactly to follow that path. This keeps the state actionable without relying on an undocumented internal URL shape.
 
-### 17.6 Packaging and upload
+### 19.6 Packaging and upload
 
 The HubSpot upload wrapper now bundles both shipped UI extension entrypoints before upload:
 

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -419,6 +419,78 @@ Verified limitations (HubSpot docs + Exa research, 2026-04-15):
 - `scripts/seed-hubspot-test-portal.ts`: user first installs the app into their test portal via the install flow (one-click on HubSpot's side); seed script then reads the stored tenant token and proceeds. No env-variable token path.
 - `packages/config/src/env.ts`: `HUBSPOT_DEV_PORTAL_TOKEN` removed from the schema. `HUBSPOT_CLIENT_ID` + `HUBSPOT_CLIENT_SECRET` stay (they drive OAuth + the existing Step 4 signed-request verification).
 
+## 17. Slice 4 Tenant Settings And Secret Hygiene
+
+Slice 4 adds a tenant-scoped settings control plane:
+
+- HubSpot settings UI extension at `apps/hubspot-project/src/app/settings/`
+- backend settings routes at `GET /api/settings` and `PUT /api/settings`
+- orchestration layer in `apps/api/src/lib/settings-service.ts`
+
+### 17.1 Read model is secret-safe
+
+Settings reads return a presence-only model:
+
+- signal-provider sections expose `enabled` + `hasApiKey`
+- LLM config exposes `provider`, `model`, optional `endpointUrl`, and `hasApiKey`
+- no plaintext `apiKey` is ever returned by the API
+
+This is enforced in two places:
+
+- `packages/validators/src/settings.ts` rejects response payloads that drift from the presence-only shape
+- route tests in `apps/api/src/routes/__tests__/settings.test.ts` assert that API responses do not contain the submitted secret strings
+
+### 17.2 Secret writes are replace-only
+
+The write contract is explicit:
+
+- a non-empty `apiKey` replaces the stored encrypted value
+- blank/whitespace `apiKey` inputs preserve the existing encrypted value
+- secret deletion, if needed, is a separate explicit action via `clearApiKey`
+- the UI never offers a "reveal current key" flow
+
+`packages/validators/src/settings.ts` normalizes blank inputs to `undefined`, and `apps/api/src/lib/settings-service.ts` preserves the existing ciphertext when no new plaintext secret is supplied.
+
+### 17.3 Storage and encryption
+
+All provider and LLM secrets written through the settings API are encrypted at rest with the existing tenant-bound AES-256-GCM envelope from `apps/api/src/lib/encryption.ts`.
+
+- provider secrets persist in `provider_config.api_key_encrypted`
+- LLM secrets persist in `llm_config.api_key_encrypted`
+- decryption happens only in trusted backend code paths (`config-resolver`, HubSpot client, etc.)
+
+The settings UI never receives decrypted secrets and only shows generic "Stored key on file" indicators.
+
+### 17.4 Tenant isolation and cache invalidation
+
+Settings writes run through the same request-scoped tenant DB handle used by the rest of the API:
+
+- auth middleware verifies the signed HubSpot request
+- tenant middleware resolves the tenant from the signed portal
+- RLS transaction middleware injects `c.get('db')`
+- settings routes call `readSettings()` / `updateSettings()` with that scoped handle
+
+After every settings write, `updateSettings()` calls `invalidateTenantConfig(tenantId)` so cached provider and LLM config cannot stay stale. The regression in `apps/api/src/routes/__tests__/settings.test.ts` proves that a cached old config is replaced immediately after `PUT /api/settings`.
+
+### 17.5 UI guidance for unconfigured tenants
+
+Slice 4 does not guess at a deep-link into HubSpot settings from the CRM record tab. Official HubSpot docs confirm the supported path is:
+
+1. Open `Connected apps`
+2. Open the installed app
+3. Open the app's `Settings` tab
+
+The CRM-card `UnconfiguredState` now tells the user exactly to follow that path. This keeps the state actionable without relying on an undocumented internal URL shape.
+
+### 17.6 Packaging and upload
+
+The HubSpot upload wrapper now bundles both shipped UI extension entrypoints before upload:
+
+- company record card bundle → `apps/hubspot-project/src/app/cards/dist/index.js`
+- settings page bundle → `apps/hubspot-project/src/app/settings/dist/index.js`
+
+This prevents the settings page scaffold from being structurally present but operationally missing at upload time.
+
 **OAuth state tradeoff (accepted for Slice 3):**
 
 - OAuth `state` is a **stateless HMAC** over a short-lived payload (for example `nonce + expiresAt`) using `HUBSPOT_CLIENT_SECRET`.

--- a/docs/slice-4-preflight-notes.md
+++ b/docs/slice-4-preflight-notes.md
@@ -1,0 +1,151 @@
+# Slice 4 Preflight Notes
+
+Date: 2026-04-16
+
+Purpose: lock the HubSpot settings-extension implementation contract before any
+Slice 4 code begins.
+
+## Official docs verified
+
+Primary sources:
+
+- HubSpot: Create a settings page
+  - https://developers.hubspot.com/docs/apps/developer-platform/add-features/ui-extensions/extension-points/create-a-settings-page
+- HubSpot: App configuration
+  - https://developers.hubspot.com/docs/apps/developer-platform/build-apps/app-configuration
+- HubSpot: UI extensions overview
+  - https://developers.hubspot.com/docs/apps/developer-platform/add-features/ui-extensions/overview
+- HubSpot: Manage apps in HubSpot
+  - https://developers.hubspot.com/docs/apps/developer-platform/build-apps/manage-apps-in-hubspot
+
+## Verified facts
+
+1. HubSpot supports a React-based settings page on the latest developer
+   platform versions (`2025.2` and `2026.03`).
+2. A settings feature lives under `src/app/settings/`.
+3. The settings feature uses a `*-hsmeta.json` file with `type: "settings"` and
+   an `entrypoint` path under `/app/settings/...`.
+4. HubSpot’s guide expects a React component registered via `hubspot.extend()`.
+5. The docs explicitly say settings pages use the same UI extensions SDK and
+   limitations as other UI extensions.
+6. For local development, `hs project dev` only picks up changes to the React
+   file; changes to `*-hsmeta.json` or `package.json` require stop/upload/restart.
+7. If Tabs are used in settings, HubSpot recommends the `default` tab variant,
+   because the settings page is already wrapped in an enclosed tab context.
+8. App features must live under `src/app/`, and `settings/` is a first-class
+   feature directory in the app configuration reference.
+
+## Slice 4 implementation decisions
+
+### 1. Settings feature location
+
+We will add a real HubSpot settings feature under:
+
+- `apps/hubspot-project/src/app/settings/`
+
+Planned shape:
+
+- `apps/hubspot-project/src/app/settings/settings-hsmeta.json`
+- `apps/hubspot-project/src/app/settings/Settings.tsx`
+- `apps/hubspot-project/src/app/settings/package.json`
+
+### 2. Code ownership model
+
+We will NOT build the main settings React UI directly inside
+`apps/hubspot-project`.
+
+Reason:
+
+- the project already keeps real extension UI code in
+  `apps/hubspot-extension/`
+- the HubSpot project is a packaging/upload shell
+- we already solved this packaging boundary for the record-tab card in Slice 3
+
+Decision:
+
+- build the real settings UI in `apps/hubspot-extension/src/settings/`
+- bundle/copy the output into `apps/hubspot-project/src/app/settings/dist/`
+- keep a thin HubSpot-project shim entrypoint that re-exports the bundled file
+
+This mirrors the proven Slice 3 card bundling strategy and minimizes duplicate
+UI logic across the two app surfaces.
+
+### 3. Bundling strategy
+
+We will assume the settings surface needs the same explicit bundling approach as
+the card surface unless implementation proves otherwise.
+
+Decision:
+
+- add a dedicated settings entry under `apps/hubspot-extension/src/settings/`
+- produce a bundle copied into `apps/hubspot-project/src/app/settings/dist/`
+- keep the HubSpot project entrypoint as a thin re-export shim
+
+This is the safest path because:
+
+- `apps/hubspot-project` remains excluded from the pnpm workspace
+- the current repo architecture intentionally centralizes real React code in
+  `apps/hubspot-extension`
+- the record-tab surface already required a bundling bridge for this reason
+
+### 4. Runtime/backend integration
+
+For saving and reading settings, the settings extension will use the same
+backend-first architecture as the current product:
+
+- UI calls the backend
+- backend owns validation, encryption, and persistence
+- secrets remain write-only from the UI’s perspective
+
+We will not add direct client-side secret storage or any bypass around the API.
+
+### 5. Scope lock
+
+Initial Slice 4 settings scope is intentionally narrow:
+
+- signal provider enablement
+- provider API key input where required
+- default LLM provider + model
+- LLM API key input
+- optional endpoint URL for `custom`
+- thresholds:
+  - `freshnessMaxDays`
+  - `minConfidence`
+- eligibility property override:
+  - default remains `hs_is_target_account`
+
+Deferred:
+
+- audit history UI
+- team/user/admin management
+- secret reveal/download UX
+- broad dashboard/admin console features
+- any multi-workspace control plane
+
+### 6. Secret handling contract
+
+Locked behavior for Slice 4:
+
+- reads never return plaintext secrets
+- reads expose only presence state, e.g. `hasApiKey`
+- blank secret fields preserve existing encrypted values
+- new plaintext secret values replace existing encrypted values
+- if deletion is supported, it must be explicit and separate from blank input
+- no reveal-current-secret UI is in scope
+
+### 7. UX constraints
+
+- prefer grouped sections/panels over dense admin layouts
+- if tabs are needed, use the HubSpot-recommended `default` variant only
+- do not create nested enclosed tabs
+- keep the settings UX focused on getting a tenant from unconfigured to working
+
+## Resulting contract for Task 3+
+
+Backend and frontend can proceed with the following assumptions:
+
+- settings feature exists under `apps/hubspot-project/src/app/settings/`
+- primary React implementation lives in `apps/hubspot-extension/src/settings/`
+- backend remains the single source of truth for all settings writes
+- secrets are write-only and replace-only
+- Slice 4 is a configuration surface, not an admin suite

--- a/packages/config/src/domain-types.ts
+++ b/packages/config/src/domain-types.ts
@@ -174,3 +174,85 @@ export type TenantConfig = {
   hubspotPortalId: string;
   settings?: TenantSettings;
 };
+
+/**
+ * Signal providers exposed in the Slice 4 settings surface.
+ */
+export type SettingsSignalProviderName = "exa" | "news" | "hubspot-enrichment";
+
+/**
+ * Presence-only provider settings state returned by the settings API.
+ *
+ * Secrets are never returned in plaintext. `hasApiKey` reports whether a
+ * provider currently has a stored encrypted key.
+ */
+export type SettingsProviderState = {
+  enabled: boolean;
+  hasApiKey: boolean;
+};
+
+/**
+ * Wire shape returned by the settings API for signal provider sections.
+ *
+ * Keys are camelCase for ergonomic JSON/UI access; provider identifiers can
+ * still use hyphenated names elsewhere when treated as scalar values.
+ */
+export type SettingsSignalProviders = {
+  exa: SettingsProviderState;
+  news: SettingsProviderState;
+  hubspotEnrichment: SettingsProviderState;
+};
+
+/**
+ * Settings API read model for the current tenant.
+ */
+export type SettingsResponse = {
+  tenantId: string;
+  signalProviders: SettingsSignalProviders;
+  llm: {
+    provider: LlmProviderType | null;
+    model: string;
+    endpointUrl?: string;
+    hasApiKey: boolean;
+  };
+  eligibility: {
+    propertyName: string;
+  };
+  thresholds: ThresholdConfig;
+};
+
+/**
+ * Partial update for a single signal provider from the Slice 4 settings UI.
+ *
+ * `apiKey` is replace-only. Blank input is treated as "preserve existing";
+ * explicit deletion, if supported, uses `clearApiKey`.
+ */
+export type SettingsProviderUpdate = {
+  enabled?: boolean;
+  apiKey?: string;
+  clearApiKey?: boolean;
+};
+
+export type SettingsSignalProviderUpdates = {
+  exa?: SettingsProviderUpdate;
+  news?: SettingsProviderUpdate;
+  hubspotEnrichment?: SettingsProviderUpdate;
+};
+
+/**
+ * Partial update payload for tenant settings writes.
+ */
+export type SettingsUpdate = {
+  signalProviders?: SettingsSignalProviderUpdates;
+  llm?: {
+    provider?: LlmProviderType | null;
+    model?: string;
+    endpointUrl?: string;
+    apiKey?: string;
+    clearApiKey?: boolean;
+  };
+  eligibility?: {
+    propertyName?: string;
+  };
+  thresholds?: Partial<ThresholdConfig>;
+};

--- a/packages/validators/src/__tests__/settings.test.ts
+++ b/packages/validators/src/__tests__/settings.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  settingsResponseSchema,
+  settingsSignalProviderNameSchema,
+  settingsUpdateSchema,
+} from "../settings";
+
+describe("settings schemas", () => {
+  it("validates a settings response with presence-only secret fields", () => {
+    expect(
+      settingsResponseSchema.safeParse({
+        tenantId: "tenant-settings",
+        signalProviders: {
+          exa: { enabled: true, hasApiKey: true },
+          news: { enabled: false, hasApiKey: false },
+          hubspotEnrichment: { enabled: true, hasApiKey: false },
+        },
+        llm: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          endpointUrl: undefined,
+          hasApiKey: true,
+        },
+        eligibility: {
+          propertyName: "hs_is_target_account",
+        },
+        thresholds: {
+          freshnessMaxDays: 30,
+          minConfidence: 0.5,
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects plaintext secret leakage in the settings response", () => {
+    expect(
+      settingsResponseSchema.safeParse({
+        tenantId: "tenant-settings",
+        signalProviders: {
+          exa: { enabled: true, hasApiKey: true, apiKey: "should-not-leak" },
+          news: { enabled: false, hasApiKey: false },
+          hubspotEnrichment: { enabled: true, hasApiKey: false },
+        },
+        llm: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          hasApiKey: true,
+        },
+        eligibility: {
+          propertyName: "hs_is_target_account",
+        },
+        thresholds: {
+          freshnessMaxDays: 30,
+          minConfidence: 0.5,
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts an update payload that rotates a secret", () => {
+    expect(
+      settingsUpdateSchema.safeParse({
+        signalProviders: {
+          exa: { enabled: true, apiKey: "exa-key-1" },
+        },
+        llm: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          apiKey: "anthropic-key-1",
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("treats blank secret fields as preserve-existing rather than explicit delete", () => {
+    const result = settingsUpdateSchema.safeParse({
+      signalProviders: {
+        exa: { enabled: true, apiKey: "" },
+      },
+      llm: {
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        apiKey: "",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw result.error;
+
+    expect(result.data.signalProviders?.exa?.apiKey).toBeUndefined();
+    expect(result.data.llm?.apiKey).toBeUndefined();
+  });
+
+  it("requires explicit delete semantics instead of mixing clearApiKey with a new value", () => {
+    expect(
+      settingsUpdateSchema.safeParse({
+        signalProviders: {
+          exa: { apiKey: "new-key", clearApiKey: true },
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("validates the supported signal provider names", () => {
+    expect(settingsSignalProviderNameSchema.safeParse("exa").success).toBe(true);
+    expect(settingsSignalProviderNameSchema.safeParse("hubspot-enrichment").success).toBe(true);
+    expect(settingsSignalProviderNameSchema.safeParse("mock-signal").success).toBe(false);
+  });
+});

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -4,4 +4,6 @@
  * Runtime Zod v4 schemas mirroring `@hap/config` domain types. Import
  * compile-time types from `@hap/config`; import runtime schemas here.
  */
+
+export * from "./settings";
 export * from "./snapshot";

--- a/packages/validators/src/settings.ts
+++ b/packages/validators/src/settings.ts
@@ -1,0 +1,96 @@
+import type { SettingsResponse, SettingsSignalProviderName, SettingsUpdate } from "@hap/config";
+import { z } from "zod";
+import { llmProviderTypeSchema, thresholdConfigSchema } from "./snapshot";
+
+function preserveBlankSecret(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export const settingsSignalProviderNameSchema = z.enum([
+  "exa",
+  "news",
+  "hubspot-enrichment",
+]) satisfies z.ZodType<SettingsSignalProviderName>;
+
+export const settingsProviderStateSchema = z
+  .object({
+    enabled: z.boolean(),
+    hasApiKey: z.boolean(),
+  })
+  .strict();
+
+export const settingsResponseSchema = z
+  .object({
+    tenantId: z.string().min(1),
+    signalProviders: z
+      .object({
+        exa: settingsProviderStateSchema,
+        news: settingsProviderStateSchema,
+        hubspotEnrichment: settingsProviderStateSchema,
+      })
+      .strict(),
+    llm: z
+      .object({
+        provider: llmProviderTypeSchema.nullable(),
+        model: z.string(),
+        endpointUrl: z.string().url().optional(),
+        hasApiKey: z.boolean(),
+      })
+      .strict(),
+    eligibility: z
+      .object({
+        propertyName: z.string().min(1),
+      })
+      .strict(),
+    thresholds: thresholdConfigSchema,
+  })
+  .strict() satisfies z.ZodType<SettingsResponse>;
+
+const providerUpdateSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.preprocess(preserveBlankSecret, z.string().min(1).optional()),
+    clearApiKey: z.boolean().optional(),
+  })
+  .strict()
+  .refine((value) => !(value.clearApiKey && value.apiKey), {
+    message: "clearApiKey cannot be combined with apiKey",
+    path: ["clearApiKey"],
+  });
+
+const llmUpdateSchema = z
+  .object({
+    provider: llmProviderTypeSchema.nullable().optional(),
+    model: z.string().min(1).optional(),
+    endpointUrl: z.preprocess(preserveBlankSecret, z.string().url().optional()),
+    apiKey: z.preprocess(preserveBlankSecret, z.string().min(1).optional()),
+    clearApiKey: z.boolean().optional(),
+  })
+  .strict()
+  .refine((value) => !(value.clearApiKey && value.apiKey), {
+    message: "clearApiKey cannot be combined with apiKey",
+    path: ["clearApiKey"],
+  });
+
+export const settingsUpdateSchema = z
+  .object({
+    signalProviders: z
+      .object({
+        exa: providerUpdateSchema.optional(),
+        news: providerUpdateSchema.optional(),
+        hubspotEnrichment: providerUpdateSchema.optional(),
+      })
+      .strict()
+      .optional(),
+    llm: llmUpdateSchema.optional(),
+    eligibility: z
+      .object({
+        propertyName: z.string().min(1).optional(),
+      })
+      .strict()
+      .optional(),
+    thresholds: thresholdConfigSchema.partial().optional(),
+  })
+  .strict() satisfies z.ZodType<SettingsUpdate>;

--- a/scripts/bundle-hubspot-card.ts
+++ b/scripts/bundle-hubspot-card.ts
@@ -1,37 +1,79 @@
-import { execFile } from "node:child_process";
-import { cp, mkdir, stat } from "node:fs/promises";
+import { cp, mkdir, rm, stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import react from "@vitejs/plugin-react";
+import { build } from "vite";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const extensionDir = resolve(rootDir, "apps/hubspot-extension");
-const extensionDistDir = resolve(extensionDir, "dist");
-const projectDistDir = resolve(rootDir, "apps/hubspot-project/src/app/cards/dist");
+const tempBundleRoot = resolve(extensionDir, ".bundle-artifacts");
+
+type BundleTarget = {
+  name: "card" | "settings";
+  entry: string;
+  outDir: string;
+  projectDistDir: string;
+};
+
+const bundleTargets: BundleTarget[] = [
+  {
+    name: "card",
+    entry: resolve(extensionDir, "src/hubspot-card-entry.tsx"),
+    outDir: resolve(tempBundleRoot, "card"),
+    projectDistDir: resolve(rootDir, "apps/hubspot-project/src/app/cards/dist"),
+  },
+  {
+    name: "settings",
+    entry: resolve(extensionDir, "src/settings/settings-entry.tsx"),
+    outDir: resolve(tempBundleRoot, "settings"),
+    projectDistDir: resolve(rootDir, "apps/hubspot-project/src/app/settings/dist"),
+  },
+];
 
 async function ensureFile(path: string) {
   await stat(path);
 }
 
-async function main() {
-  await execFileAsync("pnpm", ["--filter", "@hap/hubspot-extension", "build"], {
-    cwd: rootDir,
+async function buildTarget(target: BundleTarget) {
+  await rm(target.outDir, { recursive: true, force: true });
+
+  await build({
+    configFile: false,
+    root: extensionDir,
+    plugins: [react()],
+    build: {
+      emptyOutDir: true,
+      outDir: target.outDir,
+      lib: {
+        entry: target.entry,
+        formats: ["es"],
+      },
+      rollupOptions: {
+        output: {
+          entryFileNames: "index.js",
+        },
+      },
+    },
   });
 
-  const bundlePath = resolve(extensionDistDir, "index.js");
+  const bundlePath = resolve(target.outDir, "index.js");
   await ensureFile(bundlePath);
 
-  await mkdir(projectDistDir, { recursive: true });
-  await cp(bundlePath, resolve(projectDistDir, "index.js"));
+  await mkdir(target.projectDistDir, { recursive: true });
+  await cp(bundlePath, resolve(target.projectDistDir, "index.js"));
 
-  const cssPath = resolve(extensionDistDir, "index.css");
+  const cssPath = resolve(target.outDir, "style.css");
   try {
     await ensureFile(cssPath);
-    await cp(cssPath, resolve(projectDistDir, "index.css"));
+    await cp(cssPath, resolve(target.projectDistDir, "index.css"));
   } catch {
     // No stylesheet emitted for this bundle.
+  }
+}
+
+async function main() {
+  for (const target of bundleTargets) {
+    await buildTarget(target);
   }
 }
 

--- a/scripts/hs-project-upload.ts
+++ b/scripts/hs-project-upload.ts
@@ -27,7 +27,7 @@ function repoRoot(): string {
 }
 
 function runBundle(root: string): void {
-  console.log("[hs-upload] bundling HubSpot card");
+  console.log("[hs-upload] bundling HubSpot card and settings page");
   execFileSync("pnpm", ["tsx", "scripts/bundle-hubspot-card.ts"], {
     cwd: root,
     stdio: "inherit",


### PR DESCRIPTION
## Summary
- add tenant-scoped settings read/write APIs and settings service with encrypted secret handling
- add the HubSpot settings extension UI, fetch/save hook, and unconfigured recovery guidance
- extend bundling/upload so both the card and settings page are built before upload

## Validation
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm db:migrate
- pnpm tsx scripts/bundle-hubspot-card.ts

## Notes
- secrets are write-only on the API and UI surface
- blank secret fields preserve existing encrypted values
- review fix included: selecting `None` for the LLM provider now explicitly clears tenant LLM config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tenant-scoped settings with secret-safe reads, encrypted writes, and a HubSpot settings UI. Exposes `GET`/`PUT` `/api/settings`, bundles the settings page, and improves unconfigured guidance.

- **New Features**
  - Tenant settings API (`GET`/`PUT` at `/api/settings`) with presence-only secrets, thresholds, eligibility, and cache invalidation.
  - Settings service updates provider and LLM config, encrypts keys, preserves secrets on blank input, supports `custom` LLM endpoints, and can clear the current LLM API key via `clearApiKey`.
  - Validation via `@hap/validators` with matching types in `@hap/config`, plus tests for service, routes, and UI.
  - HubSpot settings UI (`apps/hubspot-extension/src/settings`) with save flow and “Stored key on file” indicators; registered as a settings feature in the project.
  - Build now bundles both the card and settings page before upload; CRM card unconfigured state directs users to Connected apps → Settings.

- **Bug Fixes**
  - Selecting “None” for the LLM provider disables and clears the tenant’s LLM config.

<sup>Written for commit aa44ee571340614bce1a0ecb152270a69c91fda8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

