### PR TITLE
Slice 5: production and marketplace readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,15 @@ HUBSPOT_APP_ID=
 # Legacy — Slice 2 does NOT use this. Leave blank.
 HUBSPOT_DEVELOPER_API_KEY=
 
-# --- OAuth redirect (Slice 3) ---
-# Only needed if you run the API on a non-default host/port.
-# Default: http://localhost:3000/oauth/callback
-# HUBSPOT_OAUTH_REDIRECT_URI=http://localhost:3000/oauth/callback
+# --- OAuth redirect (Slice 5) ---
+# In local development the API may fall back to:
+#   http://localhost:3000/oauth/callback
+# In production/staging this MUST be set explicitly to an HTTPS callback URL.
+# Example staging value:
+# HUBSPOT_OAUTH_REDIRECT_URI=https://hap-signal-workspace-staging.vercel.app/oauth/callback
+# Example production value:
+# HUBSPOT_OAUTH_REDIRECT_URI=https://hap-signal-workspace.vercel.app/oauth/callback
+# HUBSPOT_OAUTH_REDIRECT_URI=
 
 # --- API Server ---
 PORT=3001

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ supabase/.temp
 
 # HubSpot
 .hubspot/
+apps/hubspot-project/hsprofile.*.json
+!apps/hubspot-project/hsprofile.*.example.json
+apps/hubspot-project/local.json
 
 # Claude Code
 .claude/*

--- a/PLANNING_INDEX.md
+++ b/PLANNING_INDEX.md
@@ -3,40 +3,56 @@
 Local destination: `/Users/romeoman/Documents/Dev/HubSpot/Account Plan App`
 
 ## Current status
-This index is the top-level map for the planning bundle.
+
+This index is the top-level map for the planning bundle that is actually
+present in this repository today.
 
 Use it to find:
-- the ChatPRD-aligned local copies
-- the local-only review and planning artifacts
-- the Taskmaster execution inputs
-- the most important ChatPRD source links
+
+- the repo-local planning files that exist now
+- the execution-facing task, preflight, and security docs
+- the current slice plans under `.claude/tasks/`
+- the most important upstream ChatPRD source links
 
 Transcript work remains deferred.
 
 ---
 
-## 1. Core ChatPRD-aligned local copies
+## 1. Present local planning files
+
+Currently present under `planning/`:
 
 - `planning/chatprd/AI_CODING_RULES_AND_STANDARDS.md`
-- `planning/chatprd/PRODUCT_BRIEF_FOR_AI_DEVELOPMENT.md`
-- `planning/chatprd/IMPLEMENTATION_PLAN.md`
-- `planning/chatprd/REPO_DRAFT_AND_EXECUTION_CHECKLIST.md`
-- `planning/chatprd/SECURITY_PERMISSION_GATE.md`
-- `planning/chatprd/SPEC_FOR_AI_PROTOTYPING.md`
-
-## 2. Local planning and review artifacts
-
-- `planning/local/ENGINEERING_REVIEW_TEST_PLAN.md`
-- `planning/local/LOCAL_REPO_DRAFT_AND_CHECKLIST.md`
-- `planning/local/LOCAL_IMPLEMENTATION_PLAN_WITH_AUTOPLAN_REVIEW.md`
-- `planning/local/OFFICE_HOURS_DESIGN_DOC.md`
-- `planning/local/SECURITY_PERMISSION_GATE.md`
-- `planning/local/SPEC_FOR_AI_PROTOTYPING.md`
-- `planning/local/QA_AND_VERIFICATION_PLAN.md`
-- `planning/local/TASKMASTER_EXECUTION_PRD.md`
 - `planning/local/AI_CODING_RULES_AND_STANDARDS.md`
-- `planning/local/DOC_STACK_REVIEW_NOTES.md`
+- `planning/local/TASKMASTER_EXECUTION_PRD.md`
 - `planning/local/STACK_HOSTING_AND_TEST_ENV_NOTES.md`
+
+Important:
+
+- older versions of this index referenced additional ChatPRD mirror files that
+  are not currently present at those exact local paths
+- that is a path-maintenance issue, not a product-direction issue
+- use the upstream ChatPRD links below for those source documents
+
+---
+
+## 2. Active execution artifacts in-repo
+
+- `CLAUDE.md`
+- `AGENTS.md`
+- `.taskmaster/docs/prd.md`
+- `docs/security/SECURITY.md`
+- `docs/slice-3-preflight-notes.md`
+- `docs/slice-4-preflight-notes.md`
+- `docs/phase-5-doc-alignment.md`
+- `.claude/tasks/2026-04-16-slice-3-phase-3-rls-card-bundling.md`
+- `.claude/tasks/2026-04-16-slice-4-settings-configuration.md`
+- `.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md`
+- `docs/superpowers/plans/2026-04-14-slice-1-core-domain.md`
+- `docs/superpowers/plans/2026-04-15-slice-2-live-integrations.md`
+- `docs/superpowers/plans/2026-04-15-slice-3-oauth-public-app.md`
+
+---
 
 ## 3. Taskmaster execution inputs
 
@@ -44,31 +60,23 @@ Transcript work remains deferred.
 - `planning/local/TASKMASTER_EXECUTION_PRD.md`
 
 Purpose:
-- `.taskmaster/docs/prd.md` is the execution-facing PRD for `task-master parse-prd`
-- the local copy exists so the execution PRD remains visible in the planning bundle even before repo bootstrap is complete
 
-## 4. Repo-level Claude Code contract
-
-- `CLAUDE.md`
-
-Purpose:
-- this is the concise repo-level operating contract for Claude Code
-- it references the planning files instead of duplicating the full planning stack
-- it enforces stack rules, modular/config-driven architecture, current-doc checks, verification discipline, and the TDD rule
+- `.taskmaster/docs/prd.md` is the execution-facing PRD for Taskmaster
+- the local planning copy stays useful for repo-native execution context
 
 ---
 
-## 5. Recommended reading order
+## 4. Recommended reading order
 
-If someone is joining the project or starting repo bootstrap, read in this order:
+If someone is joining active implementation now, read in this order:
 
-1. `planning/chatprd/IMPLEMENTATION_PLAN.md`
-2. `planning/chatprd/SECURITY_PERMISSION_GATE.md`
-3. `planning/local/QA_AND_VERIFICATION_PLAN.md`
-4. `planning/chatprd/AI_CODING_RULES_AND_STANDARDS.md`
-5. `CLAUDE.md`
-6. `.taskmaster/docs/prd.md`
-7. `planning/chatprd/REPO_DRAFT_AND_EXECUTION_CHECKLIST.md`
+1. `.claude/tasks/<current-slice>.md`
+2. `CLAUDE.md`
+3. `AGENTS.md`
+4. `docs/security/SECURITY.md`
+5. `.taskmaster/docs/prd.md`
+6. `planning/chatprd/AI_CODING_RULES_AND_STANDARDS.md`
+7. `planning/local/TASKMASTER_EXECUTION_PRD.md`
 
 ---
 
@@ -99,32 +107,23 @@ https://app.chatprd.ai/chat/1ebac952-f6d6-461b-8c4b-982e49146e8b?doc=7aed1d8b-2b
 
 ## 6. Important notes
 
-- The engineering review test plan remains the best implementation-facing test artifact.
-- The QA & Verification Plan is the cross-functional trust and release gate.
-- The Security / Permission Gate should be treated as binding for install, retention, permission, and suppression decisions.
-- The Taskmaster execution PRD is intentionally thinner than the full doc stack and should not replace upstream planning documents.
-- If any conflict appears between local mirrors and ChatPRD, use the document precedence rules from the AI Coding Rules & Standards.
+- The planning direction is still sound.
+- The main maintenance issue has been stale local path references, not missing product intent.
+- `CLAUDE.md`, `AGENTS.md`, `docs/security/SECURITY.md`, and the active
+  `.claude/tasks/` slice plan are the most reliable repo-local execution guides.
+- The Taskmaster execution PRD is intentionally thinner than the full planning
+  stack and should not replace upstream planning documents.
+- If any conflict appears between repo-local mirrors and ChatPRD, use the
+  precedence rules from the AI Coding Rules & Standards.
 
 ---
 
-## 7. Current honest assessment
+## 7. Maintenance rule
 
-The planning stack is strong, but not perfectly polished.
+Treat this index as a maintained map, not a historical dump.
 
-Strongest documents:
-- AI Coding Rules & Standards
-- Security / Permission Gate
-- Product Brief for AI Development
-- Spec for AI Prototyping
-- CLAUDE.md as the repo-level Claude Code contract
+Update it whenever:
 
-Still worth tightening over time:
-- QA & Verification Plan
-- Repo Draft & Execution Checklist
-
-Important:
-- the index is now clear and usable, but it should still be updated any time a new binding planning file is added
-- CLAUDE.md and `.taskmaster/docs/prd.md` now both include explicit full-path references to the active planning files so local agents do not miss them
-
-See:
-- `planning/local/DOC_STACK_REVIEW_NOTES.md`
+- a new binding slice plan is added
+- a repo-local planning mirror is added or removed
+- a current execution document changes location

--- a/README.md
+++ b/README.md
@@ -34,6 +34,27 @@ pnpm dev:api
 pnpm dev:extension
 ```
 
+### HubSpot profiles
+
+HubSpot app uploads now require an explicit config profile. Start from the
+committed templates in `apps/hubspot-project/`:
+
+- `hsprofile.local.example.json`
+- `hsprofile.staging.example.json`
+- `hsprofile.production.example.json`
+
+Then copy one to a real `hsprofile.<env>.json` file and upload with:
+
+```bash
+pnpm tsx scripts/hs-project-upload.ts --profile local
+```
+
+For local extension development, also copy
+`apps/hubspot-project/local.json.example` to `apps/hubspot-project/local.json`.
+HubSpot requires `hubspot.fetch()` URLs to stay HTTPS, so the local proxy
+remaps the local profile's `API_ORIGIN` back to `http://localhost:3001` while
+running `hs project dev`.
+
 ### Commands
 
 | Command              | Description                 |

--- a/apps/api/src/__tests__/snapshot-route.test.ts
+++ b/apps/api/src/__tests__/snapshot-route.test.ts
@@ -12,6 +12,9 @@ const DATABASE_URL =
 const db = createDatabase(DATABASE_URL);
 
 const PORTAL_PREFIX = `snaptest-${randomUUID().slice(0, 8)}-`;
+const TEST_LOCAL_REDIRECT_URI = "http://localhost:3000/oauth/callback";
+const TEST_PRODUCTION_REDIRECT_URI =
+  "https://hap-signal-workspace-staging.vercel.app/oauth/callback";
 
 function portalId() {
   return `${PORTAL_PREFIX}${randomUUID().slice(0, 8)}`;
@@ -20,6 +23,7 @@ function portalId() {
 beforeAll(() => {
   process.env.NODE_ENV = "test";
   process.env.DATABASE_URL = DATABASE_URL;
+  process.env.HUBSPOT_OAUTH_REDIRECT_URI = TEST_LOCAL_REDIRECT_URI;
 });
 
 afterAll(() => {
@@ -62,7 +66,9 @@ describe("POST /api/snapshot/:companyId", () => {
   it("returns 401 when no Authorization header is provided in production mode", async () => {
     // Temporarily flip out of bypass mode to confirm auth is wired.
     const prev = process.env.NODE_ENV;
+    const prevRedirectUri = process.env.HUBSPOT_OAUTH_REDIRECT_URI;
     process.env.NODE_ENV = "production";
+    process.env.HUBSPOT_OAUTH_REDIRECT_URI = TEST_PRODUCTION_REDIRECT_URI;
     process.env.API_TOKENS = "tok-real:portal-real";
     try {
       const app = await loadApp();
@@ -70,6 +76,11 @@ describe("POST /api/snapshot/:companyId", () => {
       expect(res.status).toBe(401);
     } finally {
       process.env.NODE_ENV = prev;
+      if (prevRedirectUri === undefined) {
+        delete process.env.HUBSPOT_OAUTH_REDIRECT_URI;
+      } else {
+        process.env.HUBSPOT_OAUTH_REDIRECT_URI = prevRedirectUri;
+      }
     }
   });
 

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("@hono/node-server");
+});
 
 describe("API health endpoint", () => {
   it("should be importable", async () => {
@@ -14,5 +19,35 @@ describe("API health endpoint", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.status).toBe("ok");
     expect(body.timestamp).toBeDefined();
+  });
+
+  it("does not auto-start the HTTP server inside Vitest, even when simulating production mode", async () => {
+    const serveSpy = vi.fn();
+    vi.doMock("@hono/node-server", () => ({
+      serve: serveSpy,
+    }));
+
+    const previousNodeEnv = process.env.NODE_ENV;
+    const previousRedirectUri = process.env.HUBSPOT_OAUTH_REDIRECT_URI;
+    process.env.NODE_ENV = "production";
+    process.env.HUBSPOT_OAUTH_REDIRECT_URI =
+      "https://hap-signal-workspace-staging.vercel.app/oauth/callback";
+
+    try {
+      const mod = await import("./index");
+      expect(mod.default).toBeDefined();
+      expect(serveSpy).not.toHaveBeenCalled();
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+      if (previousRedirectUri === undefined) {
+        delete process.env.HUBSPOT_OAUTH_REDIRECT_URI;
+      } else {
+        process.env.HUBSPOT_OAUTH_REDIRECT_URI = previousRedirectUri;
+      }
+    }
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,4 @@
+import { resolveHubSpotOAuthRedirectUri } from "@hap/config";
 import { createDatabase } from "@hap/db";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
@@ -108,7 +109,7 @@ app.route(
     config: {
       clientId: process.env.HUBSPOT_CLIENT_ID ?? "",
       clientSecret: process.env.HUBSPOT_CLIENT_SECRET ?? "",
-      redirectUri: process.env.HUBSPOT_OAUTH_REDIRECT_URI ?? "http://localhost:3000/oauth/callback",
+      redirectUri: resolveHubSpotOAuthRedirectUri(),
       scopes: ["crm.objects.companies.read", "crm.objects.contacts.read"],
       stateTtlSeconds: 600,
     },
@@ -145,8 +146,10 @@ app.use("/api/*", nonceMiddleware());
 app.route("/api/settings", settingsRoutes);
 app.route("/api/snapshot", snapshotRoutes);
 
-// Only start server when run directly (not when imported by tests).
-if (process.env.NODE_ENV !== "test") {
+// Only start the real HTTP server outside test runners. Some tests
+// temporarily simulate production mode while importing this module, so the
+// guard must not rely on NODE_ENV alone.
+if (process.env.NODE_ENV !== "test" && process.env.VITEST !== "true") {
   const port = Number(process.env.PORT) || 3001;
   console.log(`API server starting on port ${port}`);
   serve({ fetch: app.fetch, port });

--- a/apps/api/src/lib/__tests__/oauth.test.ts
+++ b/apps/api/src/lib/__tests__/oauth.test.ts
@@ -146,4 +146,15 @@ describe("buildAuthorizeUrl", () => {
       }),
     ).toThrow(/scope/i);
   });
+
+  it("rejects non-localhost http redirect URIs", () => {
+    expect(() =>
+      buildAuthorizeUrl({
+        clientId: "id",
+        redirectUri: "http://app.example.com/oauth/callback",
+        scopes: ["crm.objects.companies.read"],
+        state: "s",
+      }),
+    ).toThrow(/https|localhost/i);
+  });
 });

--- a/apps/api/src/lib/oauth.ts
+++ b/apps/api/src/lib/oauth.ts
@@ -156,6 +156,14 @@ export function buildAuthorizeUrl(args: {
   if (args.scopes.length === 0) {
     throw new Error("buildAuthorizeUrl: at least one scope is required");
   }
+  const redirect = new URL(args.redirectUri);
+  const redirectIsLocalhostHttp =
+    redirect.protocol === "http:" && redirect.hostname === "localhost";
+  if (redirect.protocol !== "https:" && !redirectIsLocalhostHttp) {
+    throw new Error(
+      "buildAuthorizeUrl: redirectUri must use https, or http only when the hostname is localhost",
+    );
+  }
   const params = new URLSearchParams();
   params.set("client_id", args.clientId);
   params.set("redirect_uri", args.redirectUri);

--- a/apps/api/src/routes/__tests__/oauth.test.ts
+++ b/apps/api/src/routes/__tests__/oauth.test.ts
@@ -185,6 +185,39 @@ describe("GET /oauth/callback — happy paths", () => {
     await db.delete(schema.tenants).where(eq(schema.tenants.id, tenantId));
   });
 
+  it("renders setup guidance on the success page when HubSpot does not provide a returnUrl", async () => {
+    const ident = identityResponseForPortal(`${PORTAL_PREFIX}${randomUUID().slice(0, 4)}`);
+    const exchange = loadCassette("oauth-token-exchange.json");
+
+    const state = signState({
+      secret: CONFIG.clientSecret,
+      ttlSeconds: CONFIG.stateTtlSeconds,
+    });
+    const routes = createOAuthRoutes({
+      config: CONFIG,
+      db,
+      fetch: fakeFetchSequence([
+        { status: exchange.response.status, body: exchange.response.body },
+        { status: ident.status, body: ident.body },
+      ]),
+    });
+
+    const res = await routes.request(`/callback?code=auth-code&state=${encodeURIComponent(state)}`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Install successful");
+    expect(body).toContain("open the app settings in HubSpot");
+
+    const tenantRows = await db
+      .select()
+      .from(schema.tenants)
+      .where(eq(schema.tenants.hubspotPortalId, ident.portalIdAsText));
+    const tenantId = tenantRows[0]?.id;
+    if (tenantId) {
+      await db.delete(schema.tenants).where(eq(schema.tenants.id, tenantId));
+    }
+  });
+
   it("updates the existing tenants row on a second install (no duplicate)", async () => {
     const ident = identityResponseForPortal(`${PORTAL_PREFIX}${randomUUID().slice(0, 4)}`);
     const exchange = loadCassette("oauth-token-exchange.json");

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -263,7 +263,7 @@ export function createOAuthRoutes(deps: OAuthDeps) {
     return c.html(
       htmlError(
         "Install successful",
-        `Signal-First Account Workspace is now installed on portal ${identity.hubDomain}. You can close this tab.`,
+        `Signal-First Account Workspace is now installed on portal ${identity.hubDomain}. Next, open the app settings in HubSpot to finish setup. You can close this tab when you are done.`,
       ),
       200,
     );

--- a/apps/hubspot-extension/src/hubspot-card-entry.test.tsx
+++ b/apps/hubspot-extension/src/hubspot-card-entry.test.tsx
@@ -1,12 +1,18 @@
 import { createRenderer } from "@hubspot/ui-extensions/testing";
-import { describe, expect, it, vi } from "vitest";
+import { useEffect, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { collectAllText } from "./features/snapshot/components/__tests__/test-utils";
 import * as snapshotApi from "./features/snapshot/hooks/api-fetcher";
+import * as companyHooks from "./features/snapshot/hooks/use-company-context";
 import * as snapshotHooks from "./features/snapshot/hooks/use-snapshot";
 import CardEntrypoint from "./hubspot-card-entry";
 import { ExtensionRoot } from "./shared/extension-root";
 
 describe("HubSpot card bundle entry", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("exports a default entry component for HubSpot card bundling", () => {
     expect(CardEntrypoint).toBeTypeOf("function");
   });
@@ -86,7 +92,64 @@ describe("HubSpot card bundle entry", () => {
         fetcher: expect.any(Function),
       }),
     );
+  });
 
-    createFetcherSpy.mockRestore();
+  it("reuses the same default snapshot fetcher across rerenders", async () => {
+    const renderer = createRenderer("crm.record.tab");
+    const fetchCrmObjectProperties = vi.fn();
+    const stubFetcher = vi.fn(async () => null);
+    const createFetcherSpy = vi
+      .spyOn(snapshotApi, "createHubSpotApiFetcher")
+      .mockReturnValue(stubFetcher);
+    vi.spyOn(companyHooks, "useCompanyContext").mockReturnValue({
+      companyId: "123",
+      objectType: "0-2",
+      portalId: "456",
+      properties: {},
+      loading: false,
+      error: undefined,
+    });
+    const useSnapshotSpy = vi.spyOn(snapshotHooks, "useSnapshot").mockReturnValue({
+      snapshot: null,
+      loading: true,
+      error: undefined,
+      refetch: vi.fn(),
+    });
+
+    renderer.mocks.context.variables = {
+      API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+    };
+
+    const RerenderHarness = () => {
+      const [, setTick] = useState(0);
+
+      useEffect(() => {
+        const timeoutId = setTimeout(() => {
+          setTick(1);
+        }, 0);
+
+        return () => {
+          clearTimeout(timeoutId);
+        };
+      }, []);
+
+      return (
+        <ExtensionRoot
+          context={renderer.mocks.context}
+          fetchCrmObjectProperties={fetchCrmObjectProperties}
+        />
+      );
+    };
+
+    renderer.render(<RerenderHarness />);
+
+    expect(createFetcherSpy).toHaveBeenCalledTimes(1);
+    expect(useSnapshotSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(useSnapshotSpy.mock.calls[0]?.[0].fetcher).toBe(stubFetcher);
+
+    useSnapshotSpy.mockClear();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(createFetcherSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/hubspot-extension/src/hubspot-card-entry.test.tsx
+++ b/apps/hubspot-extension/src/hubspot-card-entry.test.tsx
@@ -1,6 +1,7 @@
 import { createRenderer } from "@hubspot/ui-extensions/testing";
 import { describe, expect, it, vi } from "vitest";
 import { collectAllText } from "./features/snapshot/components/__tests__/test-utils";
+import * as snapshotApi from "./features/snapshot/hooks/api-fetcher";
 import * as snapshotHooks from "./features/snapshot/hooks/use-snapshot";
 import CardEntrypoint from "./hubspot-card-entry";
 import { ExtensionRoot } from "./shared/extension-root";
@@ -49,19 +50,25 @@ describe("HubSpot card bundle entry", () => {
     });
   });
 
-  it("does not force the v1 placeholder fetcher when no snapshotFetcher prop is provided", () => {
+  it("uses the HubSpot profile API origin when no snapshotFetcher prop is provided", () => {
     const renderer = createRenderer("crm.record.tab");
     const fetchCrmObjectProperties = vi.fn(async () => ({
       name: "Acme Inc",
       domain: "acme.test",
       hs_is_target_account: "true",
     }));
+    const createFetcherSpy = vi
+      .spyOn(snapshotApi, "createHubSpotApiFetcher")
+      .mockReturnValue(vi.fn(async () => null));
     const useSnapshotSpy = vi.spyOn(snapshotHooks, "useSnapshot").mockReturnValue({
       snapshot: null,
       loading: true,
       error: undefined,
       refetch: vi.fn(),
     });
+    renderer.mocks.context.variables = {
+      API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+    };
 
     renderer.render(
       <ExtensionRoot
@@ -70,11 +77,16 @@ describe("HubSpot card bundle entry", () => {
       />,
     );
 
+    expect(createFetcherSpy).toHaveBeenCalledWith({
+      baseUrl: "https://hap-signal-workspace-staging.vercel.app",
+    });
     expect(useSnapshotSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         companyId: expect.any(String),
-        fetcher: undefined,
+        fetcher: expect.any(Function),
       }),
     );
+
+    createFetcherSpy.mockRestore();
   });
 });

--- a/apps/hubspot-extension/src/index.test.tsx
+++ b/apps/hubspot-extension/src/index.test.tsx
@@ -1,7 +1,9 @@
 import { Alert, Text } from "@hubspot/ui-extensions";
 import { createRenderer } from "@hubspot/ui-extensions/testing";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { collectAllText } from "./features/snapshot/components/__tests__/test-utils";
+import * as companyHooks from "./features/snapshot/hooks/use-company-context";
+import * as snapshotHooks from "./features/snapshot/hooks/use-snapshot";
 import { Extension } from "./index";
 
 /**
@@ -11,6 +13,10 @@ import { Extension } from "./index";
  * placeholder Text nodes depending on lifecycle state.
  */
 describe("HubSpot crm.record.tab extension smoke test", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("creates a crm.record.tab renderer", () => {
     const renderer = createRenderer("crm.record.tab");
     expect(renderer.render).toBeTypeOf("function");
@@ -18,8 +24,21 @@ describe("HubSpot crm.record.tab extension smoke test", () => {
 
   it("renders the Loading placeholder while properties/snapshot are pending", () => {
     const renderer = createRenderer("crm.record.tab");
-    // Never-resolving fetcher keeps `useCompanyContext` in loading state.
-    const fetchCrmObjectProperties = vi.fn(() => new Promise<Record<string, string>>(() => {}));
+    const fetchCrmObjectProperties = vi.fn();
+    vi.spyOn(companyHooks, "useCompanyContext").mockReturnValue({
+      companyId: String(renderer.mocks.context.crm.objectId),
+      objectType: String(renderer.mocks.context.crm.objectTypeId),
+      portalId: String(renderer.mocks.context.portal.id),
+      properties: {},
+      loading: true,
+      error: undefined,
+    });
+    vi.spyOn(snapshotHooks, "useSnapshot").mockReturnValue({
+      snapshot: null,
+      loading: true,
+      error: undefined,
+      refetch: vi.fn(),
+    });
     renderer.render(
       <Extension
         context={renderer.mocks.context}

--- a/apps/hubspot-extension/src/settings/settings-entry.test.tsx
+++ b/apps/hubspot-extension/src/settings/settings-entry.test.tsx
@@ -1,0 +1,28 @@
+import { createRenderer } from "@hubspot/ui-extensions/testing";
+import { describe, expect, it, vi } from "vitest";
+import * as settingsApi from "./api-fetcher";
+import SettingsEntry from "./settings-entry";
+
+describe("HubSpot settings bundle entry", () => {
+  it("uses the HubSpot profile API origin when present in context.variables", () => {
+    const renderer = createRenderer("settings");
+    const fetcherSpy = vi
+      .spyOn(settingsApi, "createSettingsFetcher")
+      .mockReturnValue(vi.fn(async () => null));
+    const updaterSpy = vi
+      .spyOn(settingsApi, "createSettingsUpdater")
+      .mockReturnValue(vi.fn(async () => null));
+
+    renderer.mocks.context.variables = {
+      API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+    };
+
+    renderer.render(<SettingsEntry context={renderer.mocks.context} />);
+
+    expect(fetcherSpy).toHaveBeenCalledWith("https://hap-signal-workspace-staging.vercel.app");
+    expect(updaterSpy).toHaveBeenCalledWith("https://hap-signal-workspace-staging.vercel.app");
+
+    fetcherSpy.mockRestore();
+    updaterSpy.mockRestore();
+  });
+});

--- a/apps/hubspot-extension/src/settings/settings-entry.test.tsx
+++ b/apps/hubspot-extension/src/settings/settings-entry.test.tsx
@@ -1,9 +1,13 @@
 import { createRenderer } from "@hubspot/ui-extensions/testing";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import * as settingsApi from "./api-fetcher";
 import SettingsEntry from "./settings-entry";
 
 describe("HubSpot settings bundle entry", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("uses the HubSpot profile API origin when present in context.variables", () => {
     const renderer = createRenderer("settings");
     const fetcherSpy = vi
@@ -21,8 +25,5 @@ describe("HubSpot settings bundle entry", () => {
 
     expect(fetcherSpy).toHaveBeenCalledWith("https://hap-signal-workspace-staging.vercel.app");
     expect(updaterSpy).toHaveBeenCalledWith("https://hap-signal-workspace-staging.vercel.app");
-
-    fetcherSpy.mockRestore();
-    updaterSpy.mockRestore();
   });
 });

--- a/apps/hubspot-extension/src/settings/settings-entry.tsx
+++ b/apps/hubspot-extension/src/settings/settings-entry.tsx
@@ -1,8 +1,22 @@
+import type { ExtensionPointApiContext } from "@hubspot/ui-extensions";
 import { hubspot } from "@hubspot/ui-extensions";
+import { createSettingsFetcher, createSettingsUpdater } from "./api-fetcher";
 import { HubSpotSettingsPage } from "./settings-page";
 
-export default function HubSpotSettingsEntry() {
-  return <HubSpotSettingsPage />;
+type HubSpotSettingsEntryProps = {
+  context: ExtensionPointApiContext<"settings">;
+};
+
+export default function HubSpotSettingsEntry({ context }: HubSpotSettingsEntryProps) {
+  const apiBaseUrl = (context as { variables?: Record<string, unknown> }).variables?.API_ORIGIN;
+  const resolvedBaseUrl = typeof apiBaseUrl === "string" ? apiBaseUrl : undefined;
+
+  return (
+    <HubSpotSettingsPage
+      fetchSettings={createSettingsFetcher(resolvedBaseUrl)}
+      updateSettings={createSettingsUpdater(resolvedBaseUrl)}
+    />
+  );
 }
 
-hubspot.extend<"settings">(() => <HubSpotSettingsEntry />);
+hubspot.extend<"settings">(({ context }) => <HubSpotSettingsEntry context={context} />);

--- a/apps/hubspot-extension/src/shared/extension-root.tsx
+++ b/apps/hubspot-extension/src/shared/extension-root.tsx
@@ -4,6 +4,7 @@ import {
   Text,
 } from "@hubspot/ui-extensions";
 import { SnapshotStateRenderer } from "../features/snapshot/components/snapshot-state-renderer";
+import { createHubSpotApiFetcher } from "../features/snapshot/hooks/api-fetcher";
 import { useCompanyContext } from "../features/snapshot/hooks/use-company-context";
 import { type SnapshotFetcher, useSnapshot } from "../features/snapshot/hooks/use-snapshot";
 
@@ -18,10 +19,16 @@ export const ExtensionRoot = ({
   fetchCrmObjectProperties,
   snapshotFetcher,
 }: ExtensionRootProps) => {
+  const apiBaseUrl = (context as { variables?: Record<string, unknown> }).variables?.API_ORIGIN;
+  const resolvedFetcher =
+    snapshotFetcher ??
+    createHubSpotApiFetcher({
+      baseUrl: typeof apiBaseUrl === "string" ? apiBaseUrl : undefined,
+    });
   const company = useCompanyContext(context, fetchCrmObjectProperties);
   const snapshotState = useSnapshot({
     companyId: company.companyId,
-    fetcher: snapshotFetcher,
+    fetcher: resolvedFetcher,
   });
 
   if (company.loading || snapshotState.loading) {

--- a/apps/hubspot-extension/src/shared/extension-root.tsx
+++ b/apps/hubspot-extension/src/shared/extension-root.tsx
@@ -3,6 +3,7 @@ import {
   type ExtensionPointApiContext,
   Text,
 } from "@hubspot/ui-extensions";
+import { useMemo } from "react";
 import { SnapshotStateRenderer } from "../features/snapshot/components/snapshot-state-renderer";
 import { createHubSpotApiFetcher } from "../features/snapshot/hooks/api-fetcher";
 import { useCompanyContext } from "../features/snapshot/hooks/use-company-context";
@@ -20,11 +21,15 @@ export const ExtensionRoot = ({
   snapshotFetcher,
 }: ExtensionRootProps) => {
   const apiBaseUrl = (context as { variables?: Record<string, unknown> }).variables?.API_ORIGIN;
-  const resolvedFetcher =
-    snapshotFetcher ??
-    createHubSpotApiFetcher({
-      baseUrl: typeof apiBaseUrl === "string" ? apiBaseUrl : undefined,
-    });
+  const resolvedBaseUrl = typeof apiBaseUrl === "string" ? apiBaseUrl : undefined;
+  const defaultFetcher = useMemo(
+    () =>
+      createHubSpotApiFetcher({
+        baseUrl: resolvedBaseUrl,
+      }),
+    [resolvedBaseUrl],
+  );
+  const resolvedFetcher = snapshotFetcher ?? defaultFetcher;
   const company = useCompanyContext(context, fetchCrmObjectProperties);
   const snapshotState = useSnapshot({
     companyId: company.companyId,

--- a/apps/hubspot-project/UPLOAD.md
+++ b/apps/hubspot-project/UPLOAD.md
@@ -3,10 +3,11 @@
 ## Quick reference
 
 ```bash
-pnpm tsx scripts/hs-project-upload.ts
+pnpm tsx scripts/hs-project-upload.ts --profile local
 ```
 
 That script copies `apps/hubspot-project/` to a temporary directory outside any git worktree, then runs `hs project upload` from there.
+An explicit HubSpot config profile is required.
 
 ## Why this indirection
 
@@ -27,11 +28,50 @@ The wrapper script removes the worktree variable from the equation.
 For active card development with hot reload, use:
 
 ```bash
+cp apps/hubspot-project/local.json.example apps/hubspot-project/local.json
 cd apps/hubspot-project
-CLIENT_SECRET="$HUBSPOT_CLIENT_SECRET" hs project dev
+CLIENT_SECRET="$HUBSPOT_CLIENT_SECRET" hs project dev --profile local
 ```
 
 `hs project dev` does NOT use the same upload-and-build pipeline as `hs project upload` and works fine from inside the worktree.
+The `local.json` proxy is required because HubSpot's `hubspot.fetch()` URLs
+must stay HTTPS and cannot target `localhost` directly. The proxy remaps the
+local profile's `API_ORIGIN` to `http://localhost:3001` only for local
+development.
+
+## Config profiles
+
+Slice 5 standardizes HubSpot app configuration through config profiles instead
+of hardcoded environment-specific JSON.
+
+Committed templates:
+
+- `apps/hubspot-project/hsprofile.local.example.json`
+- `apps/hubspot-project/hsprofile.staging.example.json`
+- `apps/hubspot-project/hsprofile.production.example.json`
+- `apps/hubspot-project/local.json.example`
+
+Create real local profile files by copying the templates and removing the
+`.example` suffix. Real `hsprofile.*.json` files are gitignored because they
+contain account IDs and environment-specific values.
+
+The app config now expects these profile variables:
+
+- `OAUTH_REDIRECT_URI`
+- `API_ORIGIN`
+
+Example flows:
+
+```bash
+cp apps/hubspot-project/hsprofile.local.example.json apps/hubspot-project/hsprofile.local.json
+cp apps/hubspot-project/local.json.example apps/hubspot-project/local.json
+pnpm tsx scripts/hs-project-upload.ts --profile local
+```
+
+```bash
+cp apps/hubspot-project/hsprofile.staging.example.json apps/hubspot-project/hsprofile.staging.json
+pnpm tsx scripts/hs-project-upload.ts --profile staging
+```
 
 ## Manual fallback
 
@@ -40,28 +80,24 @@ If the wrapper script breaks, copy and run by hand:
 ```bash
 TMP=$(mktemp -d)
 rsync -a --exclude node_modules --exclude '.git*' apps/hubspot-project/ "$TMP/"
-cd "$TMP" && hs project upload
+cd "$TMP" && hs project upload --profile staging
 ```
 
 ## Slice 3 follow-up
 
 `@todo Slice 3` — file an issue against `@hubspot/cli` reproducing the worktree upload failure with a minimal repro, and remove this indirection if/when the CLI handles worktrees correctly.
 
-## Slice 3 auth migration (required before multi-portal distribution)
+## Current Slice 5 production contract
 
-The current `app-hsmeta.json` declares `auth.type: "static"` + `distribution: "private"`. HubSpot only lets this be installed on the **dev portal that created it** — it cannot be published or installed on customer portals.
+The app is already on the OAuth marketplace model. The remaining production
+readiness contract is:
 
-For multi-portal / marketplace distribution, Slice 3 migrates to:
+- `app-hsmeta.json` uses profile variables instead of a hardcoded localhost redirect
+- the selected HubSpot profile supplies `OAUTH_REDIRECT_URI` and `API_ORIGIN`
+- staging/production installs must use HTTPS callback URLs
+- the API-side `HUBSPOT_OAUTH_REDIRECT_URI` must match the active deployed origin
 
-```json
-"auth": {
-  "type": "oauth",
-  "redirectUrls": ["https://<api-origin>/oauth/callback"],
-  "requiredScopes": [...]
-},
-"distribution": "marketplace"   // or "private" with allowlist for pilot
-```
+See also:
 
-Full migration plan + DB schema + endpoint design: see `docs/security/SECURITY.md` §16.
-
-`@todo Slice 3`: migrate `app-hsmeta.json` to OAuth + marketplace distribution once the pilot allowlist or marketplace listing is ready.
+- `docs/slice-5-preflight-notes.md`
+- `docs/security/SECURITY.md`

--- a/apps/hubspot-project/__validate__/scaffold.test.ts
+++ b/apps/hubspot-project/__validate__/scaffold.test.ts
@@ -14,6 +14,9 @@ import settingsHsmeta from "../src/app/settings/settings-hsmeta.json";
 // still picked up by vitest (root config: include "**/*.test.ts").
 
 describe("HubSpot project scaffold (Slice 3 Task 5)", () => {
+  const OAUTH_REDIRECT_URI_VARIABLE = `\${OAUTH_REDIRECT_URI}`;
+  const API_ORIGIN_VARIABLE = `\${API_ORIGIN}`;
+
   it("app-hsmeta.json uses OAuth marketplace auth (Slice 3 migration from static/private)", () => {
     expect(appHsmeta.type).toBe("app");
     expect(appHsmeta.config.distribution).toBe("marketplace");
@@ -22,8 +25,7 @@ describe("HubSpot project scaffold (Slice 3 Task 5)", () => {
 
   it("app-hsmeta.json has redirectUrls with localhost for dev", () => {
     const urls = (appHsmeta.config.auth as { redirectUrls?: string[] }).redirectUrls ?? [];
-    expect(urls.length).toBeGreaterThan(0);
-    expect(urls.some((u: string) => u.includes("localhost"))).toBe(true);
+    expect(urls).toEqual([OAUTH_REDIRECT_URI_VARIABLE]);
   });
 
   it("app-hsmeta.json permittedUrls.fetch includes https://api.hubapi.com for OAuth token exchange", () => {
@@ -31,17 +33,44 @@ describe("HubSpot project scaffold (Slice 3 Task 5)", () => {
   });
 
   it("app-hsmeta.json permittedUrls.fetch includes the default API origin that api-fetcher.ts uses (Step 11 anti-regression)", () => {
-    // This string is intentionally duplicated here and in
-    // `apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts`
-    // (`DEFAULT_API_BASE_URL`). If they drift, the extension will call an
-    // origin HubSpot blocks at the outbound proxy and every snapshot load
-    // will fail silently. This test keeps them aligned.
-    //
-    // We cannot import `DEFAULT_API_BASE_URL` directly because this
-    // __validate__ package is isolated from the extension workspace; a
-    // hard-coded literal is the correct way to catch drift.
-    const EXPECTED_DEFAULT_API_BASE_URL = "https://hap-signal-workspace.vercel.app";
-    expect(appHsmeta.config.permittedUrls.fetch).toContain(EXPECTED_DEFAULT_API_BASE_URL);
+    expect(appHsmeta.config.permittedUrls.fetch).toContain(API_ORIGIN_VARIABLE);
+  });
+
+  it("ships committed HubSpot profile templates for local, staging, and production", () => {
+    const expectedProfiles = [
+      "../hsprofile.local.example.json",
+      "../hsprofile.staging.example.json",
+      "../hsprofile.production.example.json",
+    ];
+
+    for (const relPath of expectedProfiles) {
+      const profilePath = resolve(import.meta.dirname, relPath);
+      const profile = JSON.parse(readFileSync(profilePath, "utf8")) as {
+        accountId: number;
+        variables?: Record<string, string>;
+      };
+
+      expect(typeof profile.accountId).toBe("number");
+      expect(profile.variables?.OAUTH_REDIRECT_URI).toBeDefined();
+      expect(profile.variables?.API_ORIGIN).toBeDefined();
+    }
+  });
+
+  it("ships a local proxy example that remaps the local profile API origin to localhost:3001", () => {
+    const localProfilePath = resolve(import.meta.dirname, "../hsprofile.local.example.json");
+    const localProxyPath = resolve(import.meta.dirname, "../local.json.example");
+
+    const localProfile = JSON.parse(readFileSync(localProfilePath, "utf8")) as {
+      variables?: Record<string, string>;
+    };
+    const localProxy = JSON.parse(readFileSync(localProxyPath, "utf8")) as {
+      proxy?: Record<string, string>;
+    };
+
+    const localApiOrigin = localProfile.variables?.API_ORIGIN;
+    expect(localApiOrigin).toBeDefined();
+    expect(localApiOrigin?.startsWith("https://")).toBe(true);
+    expect(localProxy.proxy?.[localApiOrigin ?? ""]).toBe("http://localhost:3001");
   });
 
   it("app-hsmeta.json scopes match the wedge (companies + contacts read)", () => {
@@ -98,6 +127,8 @@ describe("HubSpot project scaffold (Slice 3 Task 5)", () => {
     const settingsEntrySource = readFileSync(settingsEntryPath, "utf8");
 
     expect(settingsEntrySource).toContain('hubspot.extend<"settings">');
-    expect(settingsEntrySource).toContain("export default function HubSpotSettingsEntry()");
+    expect(settingsEntrySource).toContain("export default function HubSpotSettingsEntry");
+    expect(settingsEntrySource).toContain("createSettingsFetcher");
+    expect(settingsEntrySource).toContain("createSettingsUpdater");
   });
 });

--- a/apps/hubspot-project/hsprofile.local.example.json
+++ b/apps/hubspot-project/hsprofile.local.example.json
@@ -1,0 +1,7 @@
+{
+  "accountId": 12345678,
+  "variables": {
+    "OAUTH_REDIRECT_URI": "http://localhost:3000/oauth/callback",
+    "API_ORIGIN": "https://hap-signal-workspace-staging.vercel.app"
+  }
+}

--- a/apps/hubspot-project/hsprofile.production.example.json
+++ b/apps/hubspot-project/hsprofile.production.example.json
@@ -1,0 +1,7 @@
+{
+  "accountId": 12345678,
+  "variables": {
+    "OAUTH_REDIRECT_URI": "https://hap-signal-workspace.vercel.app/oauth/callback",
+    "API_ORIGIN": "https://hap-signal-workspace.vercel.app"
+  }
+}

--- a/apps/hubspot-project/hsprofile.staging.example.json
+++ b/apps/hubspot-project/hsprofile.staging.example.json
@@ -1,0 +1,7 @@
+{
+  "accountId": 12345678,
+  "variables": {
+    "OAUTH_REDIRECT_URI": "https://hap-signal-workspace-staging.vercel.app/oauth/callback",
+    "API_ORIGIN": "https://hap-signal-workspace-staging.vercel.app"
+  }
+}

--- a/apps/hubspot-project/local.json.example
+++ b/apps/hubspot-project/local.json.example
@@ -1,0 +1,5 @@
+{
+  "proxy": {
+    "https://hap-signal-workspace-staging.vercel.app": "http://localhost:3001"
+  }
+}

--- a/apps/hubspot-project/src/app/app-hsmeta.json
+++ b/apps/hubspot-project/src/app/app-hsmeta.json
@@ -7,17 +7,13 @@
     "distribution": "marketplace",
     "auth": {
       "type": "oauth",
-      "redirectUrls": ["http://localhost:3000/oauth/callback"],
+      "redirectUrls": ["${OAUTH_REDIRECT_URI}"],
       "requiredScopes": ["crm.objects.companies.read", "crm.objects.contacts.read"],
       "optionalScopes": [],
       "conditionallyRequiredScopes": []
     },
     "permittedUrls": {
-      "fetch": [
-        "https://api.hubapi.com",
-        "https://hap-signal-workspace.vercel.app",
-        "https://hap-signal-workspace-staging.vercel.app"
-      ],
+      "fetch": ["https://api.hubapi.com", "${API_ORIGIN}"],
       "iframe": [],
       "img": []
     },

--- a/docs/phase-5-doc-alignment.md
+++ b/docs/phase-5-doc-alignment.md
@@ -1,0 +1,111 @@
+# Phase 5 Doc Alignment
+
+Date: 2026-04-17
+
+Purpose: identify the planning and execution documents that are actually present
+in the repository now, call out stale path references, and define the active
+source-of-truth stack for Slice 5.
+
+## Summary
+
+The planning foundation is still valid and should continue guiding execution.
+The main issue is not product-direction drift. The issue is **path drift**:
+some older planning-index entries refer to ChatPRD mirror files that are no
+longer present at those exact local paths.
+
+That means:
+
+- we should keep using the planning/PRD stack
+- we should not invent direction outside it
+- we should treat the currently present local files as the active source of truth
+- we should clean the stale path references during Slice 5
+
+## Present and active
+
+These files are present and should be treated as current, reliable guides for
+Slice 5 planning and execution:
+
+- `CLAUDE.md`
+- `AGENTS.md`
+- `PLANNING_INDEX.md`
+- `.taskmaster/docs/prd.md`
+- `planning/chatprd/AI_CODING_RULES_AND_STANDARDS.md`
+- `planning/local/TASKMASTER_EXECUTION_PRD.md`
+- `planning/local/AI_CODING_RULES_AND_STANDARDS.md`
+- `planning/local/STACK_HOSTING_AND_TEST_ENV_NOTES.md`
+- `docs/security/SECURITY.md`
+- `docs/slice-3-preflight-notes.md`
+- `docs/slice-4-preflight-notes.md`
+- `.claude/tasks/2026-04-16-slice-3-phase-3-rls-card-bundling.md`
+- `.claude/tasks/2026-04-16-slice-4-settings-configuration.md`
+- `.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md`
+- `docs/superpowers/plans/2026-04-14-slice-1-core-domain.md`
+- `docs/superpowers/plans/2026-04-15-slice-2-live-integrations.md`
+- `docs/superpowers/plans/2026-04-15-slice-3-oauth-public-app.md`
+
+## Referenced by index but not present at the listed path
+
+These are the clearest stale path cases discovered during the audit:
+
+- `planning/chatprd/PRODUCT_BRIEF_FOR_AI_DEVELOPMENT.md`
+- `planning/chatprd/IMPLEMENTATION_PLAN.md`
+- `planning/chatprd/REPO_DRAFT_AND_EXECUTION_CHECKLIST.md`
+- `planning/chatprd/SECURITY_PERMISSION_GATE.md`
+- `planning/chatprd/SPEC_FOR_AI_PROTOTYPING.md`
+
+Also missing from `planning/local/` despite being referenced by the index:
+
+- `planning/local/ENGINEERING_REVIEW_TEST_PLAN.md`
+- `planning/local/LOCAL_REPO_DRAFT_AND_CHECKLIST.md`
+- `planning/local/LOCAL_IMPLEMENTATION_PLAN_WITH_AUTOPLAN_REVIEW.md`
+- `planning/local/OFFICE_HOURS_DESIGN_DOC.md`
+- `planning/local/SECURITY_PERMISSION_GATE.md`
+- `planning/local/SPEC_FOR_AI_PROTOTYPING.md`
+- `planning/local/QA_AND_VERIFICATION_PLAN.md`
+- `planning/local/DOC_STACK_REVIEW_NOTES.md`
+
+This does **not** mean those ideas are invalid. It means the local mirror/index
+no longer matches the files that actually exist in this repository.
+
+## Slice 5 source-of-truth stack
+
+For Slice 5, use this order:
+
+1. explicit user instructions
+2. `.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md`
+3. `CLAUDE.md`
+4. `AGENTS.md`
+5. `docs/security/SECURITY.md`
+6. `docs/slice-3-preflight-notes.md`
+7. `docs/slice-4-preflight-notes.md`
+8. `.taskmaster/docs/prd.md`
+9. `planning/chatprd/AI_CODING_RULES_AND_STANDARDS.md`
+10. `planning/local/TASKMASTER_EXECUTION_PRD.md`
+11. `PLANNING_INDEX.md` as a map, but only after verifying referenced files exist
+
+## Slice 5 sanity check
+
+The Slice 5 plan is aligned with the active doc stack:
+
+- it preserves the locked wedge
+- it does not introduce dashboard or transcript scope creep
+- it follows the already-documented post-Slice-4 reality
+- it targets a real remaining gap in shipped code: production/staging and pilot readiness
+
+The strongest concrete motivators are already present in repo state:
+
+- `apps/hubspot-project/src/app/app-hsmeta.json` still includes
+  `http://localhost:3000/oauth/callback`
+- `docs/slice-3-preflight-notes.md` explicitly calls out the unresolved
+  production-domain/listing gap
+- Taskmaster's current board is exhausted, so the next execution pass requires
+  a fresh slice plan rather than the original `master` task set
+
+## Action for Slice 5
+
+During Slice 5, clean the planning-map drift without changing the underlying
+product direction:
+
+- update `PLANNING_INDEX.md` so it reflects files that actually exist
+- avoid referencing missing mirror docs as if they are available locally
+- keep using the present security/preflight/slice plans as the operational guide

--- a/docs/qa/slice-5-pilot-walkthrough.md
+++ b/docs/qa/slice-5-pilot-walkthrough.md
@@ -1,0 +1,73 @@
+# Slice 5 Pilot Walkthrough
+
+Date: 2026-04-17
+
+Purpose: provide a repeatable pilot-validation checklist for two-portal install
+and configuration testing.
+
+## Goal
+
+Prove that two separate HubSpot portals can:
+
+1. install the app
+2. complete settings configuration
+3. load the company-record card successfully
+4. remain tenant-isolated throughout the flow
+
+## Preconditions
+
+- staging or production API is deployed and reachable over HTTPS
+- `HUBSPOT_OAUTH_REDIRECT_URI` matches the deployed API origin
+- HubSpot app config has been uploaded with the correct profile:
+  - `local`
+  - `staging`
+  - or `production`
+- real `hsprofile.<env>.json` file exists locally for the target environment
+- at least two HubSpot portals are available for testing
+
+## Portal A flow
+
+1. Open the app install URL from HubSpot.
+2. Choose Portal A.
+3. Complete OAuth consent.
+4. If HubSpot returns to the app, confirm the install completes without error.
+5. Open the app's Settings page in HubSpot.
+6. Save valid tenant settings:
+   - at least one signal provider enabled
+   - required API keys present
+   - LLM provider/model configured or intentionally disabled
+7. Open a company record that should qualify for the wedge.
+8. Confirm the card loads and does not stay in `unconfigured`.
+
+## Portal B flow
+
+Repeat the same steps in Portal B with a different tenant configuration where
+possible, for example:
+
+- different enabled signal providers
+- different thresholds
+- different LLM provider/model
+
+## Validation checklist
+
+- Portal A install succeeds
+- Portal B install succeeds
+- Portal A settings save succeeds
+- Portal B settings save succeeds
+- Portal A card loads with Portal A config
+- Portal B card loads with Portal B config
+- Portal A does not reflect Portal B configuration
+- Portal B does not reflect Portal A configuration
+- no redirect returns to `localhost` during staging/production testing
+- no API call is blocked by `permittedUrls.fetch`
+
+## Failure notes to capture
+
+For every failed pilot run, record:
+
+- environment/profile used
+- portal id
+- exact install or settings step that failed
+- visible error message
+- request id / correlation id if available
+- whether the failure is config, backend, HubSpot app config, or UX

--- a/docs/runbooks/production-deploy.md
+++ b/docs/runbooks/production-deploy.md
@@ -1,0 +1,82 @@
+# Production Deploy Runbook
+
+Date: 2026-04-17
+
+Purpose: define the minimum repeatable deployment and HubSpot upload path for
+Slice 5 production readiness.
+
+## 1. Prepare environment
+
+Set deploy-time environment variables for the API:
+
+- `DATABASE_URL`
+- `HUBSPOT_CLIENT_ID`
+- `HUBSPOT_CLIENT_SECRET`
+- `ROOT_KEK`
+- `HUBSPOT_OAUTH_REDIRECT_URI`
+
+Production/staging note:
+
+- `HUBSPOT_OAUTH_REDIRECT_URI` must be HTTPS
+- do not allow the API to rely on localhost fallback outside local development
+
+## 2. Verify local repo state
+
+Run:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm test
+pnpm typecheck
+pnpm db:migrate
+```
+
+## 3. Build and upload the HubSpot project
+
+Create or update the real HubSpot profile file for the target environment:
+
+- `apps/hubspot-project/hsprofile.staging.json`
+- or `apps/hubspot-project/hsprofile.production.json`
+
+Then upload:
+
+```bash
+pnpm tsx scripts/hs-project-upload.ts --profile staging
+```
+
+or
+
+```bash
+pnpm tsx scripts/hs-project-upload.ts --profile production
+```
+
+The upload wrapper will:
+
+1. bundle the card and settings page
+2. copy `apps/hubspot-project/` to a temp directory
+3. run `hs project upload` from outside the git worktree
+
+## 4. Deploy the API
+
+Deploy the API to the matching environment and confirm:
+
+- the deployed origin matches `API_ORIGIN` in the selected HubSpot profile
+- the deployed callback matches `HUBSPOT_OAUTH_REDIRECT_URI`
+
+## 5. Post-deploy smoke checks
+
+1. Open the app install URL.
+2. Complete OAuth in the target portal.
+3. Confirm the callback returns to the correct HTTPS origin.
+4. Open the app Settings page and save valid config.
+5. Open a company record and confirm the card loads successfully.
+
+## 6. Rollback guidance
+
+If the deploy is unhealthy:
+
+1. revert the API deployment to the last known-good release
+2. confirm the previous HTTPS callback is still valid
+3. if needed, re-upload the HubSpot project with the prior stable profile values
+4. repeat the smoke checks

--- a/docs/security/slice-5-audit.md
+++ b/docs/security/slice-5-audit.md
@@ -1,0 +1,66 @@
+# Slice 5 Security Audit
+
+Date: 2026-04-17
+
+Scope: production and marketplace readiness for the OAuth install path, HubSpot
+profile contract, extension API origins, and deploy-time environment handling.
+
+## Verdict
+
+- OAuth redirect handling: PASS
+- Post-install return URL handling: PASS
+- HubSpot profile and upload contract: PASS
+- Secrets and environment docs: PASS
+- Local development fetch contract: PASS
+
+## Notes
+
+### OAuth redirect handling — PASS
+
+- `packages/config/src/env.ts` now resolves `HUBSPOT_OAUTH_REDIRECT_URI`
+  through `resolveHubSpotOAuthRedirectUri()`.
+- Production refuses to fall back to localhost when
+  `HUBSPOT_OAUTH_REDIRECT_URI` is unset.
+- Non-localhost `http://` redirect URIs are rejected.
+- `apps/api/src/index.ts` now uses the resolver directly instead of a silent
+  localhost fallback.
+- `apps/api/src/lib/oauth.ts` rejects invalid non-HTTPS authorize redirect
+  URIs before building the HubSpot install URL.
+
+### Post-install return URL handling — PASS
+
+- `apps/api/src/routes/oauth.ts` still validates HubSpot-provided `returnUrl`
+  values against HubSpot-owned domains before redirecting.
+- Invalid or missing `returnUrl` values fall back to a local success page
+  rather than redirecting to arbitrary destinations.
+
+### HubSpot profile and upload contract — PASS
+
+- `apps/hubspot-project/src/app/app-hsmeta.json` now uses profile variables for
+  `redirectUrls` and `permittedUrls.fetch`.
+- `scripts/hs-project-upload.ts` requires an explicit `--profile` so uploads
+  cannot silently use the wrong config.
+- Committed profile templates exist for local, staging, and production.
+
+### Secrets and environment docs — PASS
+
+- `.env.example` documents staging and production callback expectations without
+  introducing plaintext secrets.
+- `docs/runbooks/production-deploy.md` and `docs/qa/slice-5-pilot-walkthrough.md`
+  align on the required environment variables and deployed-origin checks.
+
+### Local development fetch contract — PASS
+
+- HubSpot's current UI extension docs require `hubspot.fetch()` URLs to stay
+  HTTPS and forbid `localhost`.
+- Slice 5 originally documented running the local API without shipping the
+  corresponding local proxy contract.
+- This is now fixed by shipping `apps/hubspot-project/local.json.example`,
+  ignoring real `local.json`, and documenting the required proxy setup in
+  `README.md` and `apps/hubspot-project/UPLOAD.md`.
+
+## Residual accepted risk
+
+- The local proxy contract is a development-only convenience path. Production
+  installs still depend on real HTTPS origins and matching deploy-time
+  callback configuration.

--- a/docs/slice-5-preflight-notes.md
+++ b/docs/slice-5-preflight-notes.md
@@ -1,0 +1,131 @@
+# Slice 5 Preflight Notes
+
+Date: 2026-04-17
+
+Purpose: lock the production and marketplace-readiness contract before Slice 5
+implementation begins.
+
+## Official docs verified
+
+Primary sources reviewed on 2026-04-17:
+
+- HubSpot: App configuration
+  - https://developers.hubspot.com/docs/apps/developer-platform/build-apps/app-configuration
+- HubSpot: Manage apps in HubSpot
+  - https://developers.hubspot.com/docs/apps/developer-platform/build-apps/manage-apps-in-hubspot
+- HubSpot: Working with OAuth
+  - https://developers.hubspot.com/docs/apps/developer-platform/build-apps/authentication/oauth/working-with-oauth
+- HubSpot: Fetching data for UI extensions
+  - https://developers.hubspot.com/docs/apps/developer-platform/add-features/ui-extensions/fetching-data
+- HubSpot: Build with config profiles
+  - https://developers.hubspot.com/docs/developer-tooling/local-development/build-with-config-profiles
+- HubSpot: Listing your app
+  - https://developers.hubspot.com/docs/apps/developer-platform/list-apps/listing-your-app/listing-your-app
+
+## Verified facts
+
+1. Multi-account installs and marketplace distribution require `distribution:
+   "marketplace"` plus `auth.type: "oauth"`. This is already true in the repo's
+   `app-hsmeta.json`.
+2. Every OAuth app must define at least one `redirectUrls` entry. Production
+   redirect URLs must use HTTPS. `http://localhost` is the only allowed
+   non-HTTPS exception and is for testing only.
+3. HubSpot's app management UI reads the live redirect URLs from the top-level
+   `app-hsmeta.json`, and changes take effect after `hs project upload`.
+4. Marketplace listing setup uses redirect URLs from app settings as selectable
+   install-button URLs. This means localhost-only redirect configuration is not
+   enough for a real pilot or listing path.
+5. UI extensions may only call URLs that appear in `permittedUrls.fetch`.
+   These URLs must be valid HTTPS URLs and cannot be `localhost`.
+6. HubSpot supports config profiles and variable substitution in `*-hsmeta.json`
+   files. `hs project upload -p <profile>` and `hs project dev -p <profile>`
+   apply the selected profile's variables at build time.
+7. Config profiles are explicitly suitable for switching redirect URL domains
+   between environments.
+
+## Current repo findings
+
+1. `apps/hubspot-project/src/app/app-hsmeta.json` is partially production-ready:
+   - good: `distribution: "marketplace"`
+   - good: `auth.type: "oauth"`
+   - gap: `redirectUrls` is still only `http://localhost:3000/oauth/callback`
+2. The app already whitelists deployed HTTPS API origins in
+   `permittedUrls.fetch`:
+   - `https://hap-signal-workspace.vercel.app`
+   - `https://hap-signal-workspace-staging.vercel.app`
+3. The frontend snapshot fetcher defaults to the production HTTPS API origin:
+   `apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts`
+   currently uses `https://hap-signal-workspace.vercel.app`.
+4. The API still defaults the OAuth redirect URI to localhost when
+   `HUBSPOT_OAUTH_REDIRECT_URI` is unset:
+   - `apps/api/src/index.ts`
+   - `.env.example`
+5. Existing scaffold tests intentionally lock the current dev-localhost redirect
+   behavior, so Slice 5 will need to update those tests as part of the config
+   contract change.
+6. `apps/hubspot-project/UPLOAD.md` already documents the intended end-state:
+   `redirectUrls: ["https://<api-origin>/oauth/callback"]`, but the committed
+   app config has not caught up yet.
+
+## Resulting Slice 5 decisions
+
+### 1. Slice 5 should use HubSpot config profiles
+
+This is now the preferred implementation path for environment-specific app
+config, not ad hoc manual editing.
+
+Reason:
+
+- HubSpot officially supports profile variables in `*-hsmeta.json`
+- redirect URLs are a documented profile-variable use case
+- the repo already needs local, staging, and production distinctions
+
+### 2. Redirect URLs must stop being localhost-only
+
+Slice 5 should move the app config to a profile-based redirect contract such as:
+
+- local profile → `http://localhost:3000/oauth/callback`
+- staging profile → `https://<staging-origin>/oauth/callback`
+- production profile → `https://<production-origin>/oauth/callback`
+
+Exact variable names can be chosen during implementation, but the core decision
+is locked: the shipped app config cannot remain localhost-only.
+
+### 3. Production readiness is app-config plus API-config work
+
+Changing `app-hsmeta.json` alone is not sufficient. Slice 5 must keep these in
+sync:
+
+- HubSpot `app-hsmeta.json` redirect URLs
+- `permittedUrls.fetch`
+- API-side `HUBSPOT_OAUTH_REDIRECT_URI` handling
+- deploy/runbook documentation
+
+### 4. Slice 5 remains narrow
+
+This slice is limited to:
+
+- production/staging origin readiness
+- OAuth callback and install-flow hardening
+- first-run onboarding guidance
+- two-portal pilot validation
+- deploy/runbook and doc-stack cleanup
+
+This slice does NOT introduce:
+
+- a new end-user product surface
+- billing
+- marketplace listing assets/copy submission
+- broader admin analytics
+
+## Acceptance gate for implementation
+
+Slice 5 implementation may proceed with these invariants:
+
+1. We will use HubSpot config profiles for environment-specific app config.
+2. We will remove the localhost-only assumption from the shipped OAuth app
+   configuration.
+3. We will keep `permittedUrls.fetch` aligned with actual deployed HTTPS API
+   origins.
+4. We will treat production readiness as both code and documentation work.
+5. We will keep the wedge unchanged and avoid adding unrelated product scope.

--- a/packages/config/src/__tests__/env.test.ts
+++ b/packages/config/src/__tests__/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { loadEnv } from "../env";
+import { loadEnv, resolveHubSpotOAuthRedirectUri } from "../env";
 
 /**
  * Env validator tests (Slice 3). Legacy static HubSpot token env removed;
@@ -104,5 +104,46 @@ describe("loadEnv: required var errors", () => {
   it("throws when ROOT_KEK decodes to wrong length (64 bytes, not 32)", () => {
     const kek64 = Buffer.alloc(64, 1).toString("base64");
     expect(() => loadEnv({ ...VALID_ENV, ROOT_KEK: kek64 })).toThrow(/ROOT_KEK/);
+  });
+});
+
+describe("resolveHubSpotOAuthRedirectUri", () => {
+  it("defaults to localhost in non-production when unset", () => {
+    expect(resolveHubSpotOAuthRedirectUri({ NODE_ENV: "development" })).toBe(
+      "http://localhost:3000/oauth/callback",
+    );
+  });
+
+  it("throws in production when HUBSPOT_OAUTH_REDIRECT_URI is missing", () => {
+    expect(() => resolveHubSpotOAuthRedirectUri({ NODE_ENV: "production" })).toThrow(
+      /HUBSPOT_OAUTH_REDIRECT_URI/,
+    );
+  });
+
+  it("throws for non-localhost http redirect URIs", () => {
+    expect(() =>
+      resolveHubSpotOAuthRedirectUri({
+        NODE_ENV: "production",
+        HUBSPOT_OAUTH_REDIRECT_URI: "http://app.example.com/oauth/callback",
+      }),
+    ).toThrow(/https|localhost/i);
+  });
+
+  it("accepts localhost http for testing", () => {
+    expect(
+      resolveHubSpotOAuthRedirectUri({
+        NODE_ENV: "development",
+        HUBSPOT_OAUTH_REDIRECT_URI: "http://localhost:3000/oauth/callback",
+      }),
+    ).toBe("http://localhost:3000/oauth/callback");
+  });
+
+  it("accepts https redirect URIs for staging and production", () => {
+    expect(
+      resolveHubSpotOAuthRedirectUri({
+        NODE_ENV: "production",
+        HUBSPOT_OAUTH_REDIRECT_URI: "https://hap-signal-workspace.vercel.app/oauth/callback",
+      }),
+    ).toBe("https://hap-signal-workspace.vercel.app/oauth/callback");
   });
 });

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -80,6 +80,48 @@ const envSchema = z.object({
 /** Validated, typed Slice 3 runtime environment. */
 export type Env = z.infer<typeof envSchema>;
 
+const DEFAULT_LOCAL_OAUTH_REDIRECT_URI = "http://localhost:3000/oauth/callback";
+
+function isAllowedOAuthRedirectUri(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === "https:") return true;
+    return parsed.protocol === "http:" && parsed.hostname === "localhost";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the OAuth redirect URI for the current environment.
+ *
+ * Rules:
+ * - Production must set HUBSPOT_OAUTH_REDIRECT_URI explicitly.
+ * - Non-production may fall back to localhost for developer convenience.
+ * - Non-localhost HTTP redirect URIs are rejected in every environment.
+ */
+export function resolveHubSpotOAuthRedirectUri(
+  source: Record<string, string | undefined> = process.env,
+): string {
+  const configured = source.HUBSPOT_OAUTH_REDIRECT_URI;
+  if (!configured) {
+    if (source.NODE_ENV === "production") {
+      throw new Error(
+        "HUBSPOT_OAUTH_REDIRECT_URI must be set in production; refusing to fall back to localhost.",
+      );
+    }
+    return DEFAULT_LOCAL_OAUTH_REDIRECT_URI;
+  }
+
+  if (!isAllowedOAuthRedirectUri(configured)) {
+    throw new Error(
+      "HUBSPOT_OAUTH_REDIRECT_URI must use https, or http only when the hostname is localhost.",
+    );
+  }
+
+  return configured;
+}
+
 /**
  * Parse and validate the runtime environment.
  *

--- a/scripts/__tests__/hs-project-upload.test.ts
+++ b/scripts/__tests__/hs-project-upload.test.ts
@@ -32,7 +32,14 @@ describe("hs-project-upload", () => {
       }),
     });
 
-    expect(() => buildUploadRunner(deps)([])).toThrow(/bundle failed/);
+    expect(() => buildUploadRunner(deps)(["--profile", "dev"])).toThrow(/bundle failed/);
+    expect(deps.runUpload).not.toHaveBeenCalled();
+  });
+
+  it("requires an explicit HubSpot profile for upload", () => {
+    const deps = makeDeps();
+
+    expect(() => buildUploadRunner(deps)([])).toThrow(/--profile/);
     expect(deps.runUpload).not.toHaveBeenCalled();
   });
 });

--- a/scripts/hs-project-upload.ts
+++ b/scripts/hs-project-upload.ts
@@ -45,6 +45,15 @@ export interface UploadDeps {
 
 export function buildUploadRunner(deps: UploadDeps) {
   return (args: string[]): number => {
+    const hasProfile =
+      args.includes("--profile") ||
+      args.includes("-p") ||
+      args.some((arg) => arg.startsWith("--profile=")) ||
+      args.some((arg) => arg.startsWith("-p="));
+    if (!hasProfile) {
+      throw new Error("hs project upload requires --profile <name>");
+    }
+
     const root = deps.repoRoot();
     const src = join(root, PROJECT_DIR);
     const tmp = deps.makeTempDir();


### PR DESCRIPTION
## Summary
- add HubSpot config-profile based production/staging/local app configuration
- harden OAuth redirect handling and installer success flow for non-local deployments
- wire card/settings entrypoints to profile-driven API origins and document the pilot/deploy contract
- add local proxy support for HubSpot extension development plus Slice 5 security audit notes

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm db:migrate`
- `pnpm tsx scripts/bundle-hubspot-card.ts`
- full repo test verification completed file-by-file across all 68 test files
- focused reruns after final fixes:
  - `pnpm test apps/api/src/__tests__/snapshot-route.test.ts apps/hubspot-extension/src/index.test.tsx`

## Notes
- `.taskmaster/tasks/tasks.json` remains local-only and is not part of this PR.
- final test verification used per-file Vitest execution to avoid the worker/heap instability seen with a monolithic `pnpm test` run in this environment while still covering every test file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the HubSpot app to profile-driven config, enforces HTTPS OAuth redirects for staging/production, and adds a local HTTPS proxy for extension dev. The extension reads `API_ORIGIN` from the selected profile, and the API validates callbacks to enable pilot and marketplace installs without localhost fallbacks.

- **New Features**
  - Config profiles: added `hsprofile.local/staging/production.example.json`; `app-hsmeta.json` now uses `${OAUTH_REDIRECT_URI}` and `${API_ORIGIN}`; upload script requires `--profile`; real `hsprofile.*.json` and `local.json` are gitignored.
  - Local dev proxy: `local.json.example` remaps the profile `API_ORIGIN` to `http://localhost:3001`; docs updated in README and `apps/hubspot-project/UPLOAD.md`.
  - OAuth hardening: `resolveHubSpotOAuthRedirectUri()` in `@hap/config`; production requires explicit HTTPS; non-localhost `http` is rejected; API uses the resolver; authorize URL builder validates scheme; improved success copy when `returnUrl` is missing; tests added.
  - Extension wiring: card and settings read `context.variables.API_ORIGIN`; default fetcher is memoized and built with the profile base URL; tests cover both entrypoints and fetcher reuse.
  - Test/runtime: API won’t auto-start under Vitest (`VITEST` guard); scaffold tests validate profile placeholders and local proxy; env and oauth tests extended.
  - Docs: added production runbook, pilot walkthrough, preflight notes, doc-alignment notes, and a security audit; `.env.example` clarified for staging/production HTTPS.

- **Migration**
  - Set `HUBSPOT_OAUTH_REDIRECT_URI` (HTTPS) in staging/production.
  - Create real `hsprofile.<env>.json` from examples and upload with: pnpm tsx scripts/hs-project-upload.ts --profile <env>.
  - For local dev, copy `local.json.example` and run HubSpot dev with: hs project dev --profile local.
  - Ensure `API_ORIGIN` in the selected profile matches the deployed API origin; redeploy if needed.

<sup>Written for commit f6eca629d89ae93c06e2fa8b8451bd5889286564. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Slice 5: Production and Marketplace Readiness - Release Notes

## Overview
This release hardens the application for production deployment and HubSpot marketplace distribution by introducing **environment-specific config profiles**, **strict OAuth redirect validation**, and **parameterized API origins**. The changes ensure tenant isolation, prevent silent localhost fallbacks in production, and establish a clear contract between API and HubSpot extension layers across local/staging/production environments.

---

## 🔐 Critical Security & Config Changes

### OAuth Redirect URI Hardening
- **Production Safety**: `HUBSPOT_OAUTH_REDIRECT_URI` is now **mandatory in production mode** — localhost fallback is explicitly blocked
- **Validation Policy**: 
  - ✅ HTTPS URLs accepted everywhere
  - ✅ `http://localhost:*` accepted only in development
  - ❌ HTTP non-localhost URIs rejected with error message
- **Environment-Specific Behavior**:
  - `NODE_ENV=development`: Falls back to `http://localhost:3000/oauth/callback` if env var unset
  - `NODE_ENV=production`: Throws error if `HUBSPOT_OAUTH_REDIRECT_URI` missing

### HubSpot App Config Profiles
Three committed profile templates now parameterize OAuth and API origin settings:

| Profile | Location | OAuth Redirect | API Origin |
|---------|----------|-----------------|-----------|
| **Local** | `hsprofile.local.example.json` | `http://localhost:3000/oauth/callback` | `https://hap-signal-workspace-staging.vercel.app` |
| **Staging** | `hsprofile.staging.example.json` | `https://hap-signal-workspace-staging.vercel.app/oauth/callback` | `https://hap-signal-workspace-staging.vercel.app` |
| **Production** | `hsprofile.production.example.json` | `https://hap-signal-workspace.vercel.app/oauth/callback` | `https://hap-signal-workspace.vercel.app` |

---

## 📊 Data Flow Architecture Changes

### Pre-Slice 5: Hard-coded Redirect URIs
```mermaid
graph LR
    HS["HubSpot Install<br/>(app-hsmeta.json)"]
    HS -->|Hard-coded URLs| API["API OAuth Handler<br/>(localhost fallback)"]
    API -->|Returns to<br/>localhost| Browser["Browser"]
    
    style HS fill:#ffcccc
    style API fill:#ffcccc
    style Browser fill:#fff
```

### Post-Slice 5: Profile-Driven Configuration
```mermaid
graph TD
    subgraph "Deployment Setup"
        PROFILE["🔑 Config Profile<br/>(hsprofile.env.json)"]
        ENV["Environment Variables<br/>(OAUTH_REDIRECT_URI,<br/>API_ORIGIN)"]
    end
    
    subgraph "HubSpot Extension Layer"
        CARD["💳 Card Entry<br/>(hubspot-card-entry.tsx)"]
        SETTINGS["⚙️ Settings Entry<br/>(settings-entry.tsx)"]
    end
    
    subgraph "API Layer"
        OAUTH["🔐 OAuth Handler<br/>(oauth.ts)"]
        CONFIG["📋 Config Resolution<br/>(resolveHubSpotOAuthRedirectUri)"]
    end
    
    subgraph "Runtime Execution"
        PROFILE -->|--profile local/staging/production| ENV
        ENV -->|Injects API_ORIGIN| CARD
        ENV -->|Injects API_ORIGIN| SETTINGS
        CARD -->|Fetch via API_ORIGIN| OAUTH
        SETTINGS -->|Fetch via API_ORIGIN| OAUTH
        CONFIG -->|Validates redirectUri| OAUTH
        OAUTH -->|Callback to<br/>OAUTH_REDIRECT_URI| HS["HubSpot"]
    end
    
    style PROFILE fill:#ccffcc
    style OAUTH fill:#ccffcc
    style CONFIG fill:#ccffcc
    style ENV fill:#ffffcc
```

### Local Development Proxy Contract
```mermaid
graph LR
    EXT["HubSpot Extension<br/>(requires HTTPS)"]
    EXT -->|hubspot.fetch<br/>to staging origin| PROXY["Local Proxy<br/>(local.json)"]
    PROXY -->|Remaps to<br/>localhost:3001| API["Local API<br/>(http://localhost:3001)"]
    
    style PROXY fill:#cce5ff
    style EXT fill:#fff
    style API fill:#fff
```

---

## 🛠️ Implementation Details by Layer

### API Layer (`packages/config` + `apps/api`)

**New Function**: `resolveHubSpotOAuthRedirectUri(source?: Env)`
- **Non-production (development)**: Returns `http://localhost:3000/oauth/callback` if `HUBSPOT_OAUTH_REDIRECT_URI` unset
- **Production mode**: Throws error if `HUBSPOT_OAUTH_REDIRECT_URI` missing (no fallback)
- **Validation**: Accepts HTTPS anywhere; accepts HTTP only for `localhost` hostname

**Changes to `buildAuthorizeUrl` in `apps/api/src/lib/oauth.ts`**:
- Now parses `redirectUri` as `URL` object before building HubSpot authorize link
- Validates URL scheme: accepts `https:` everywhere, `http:` only for `localhost`
- Rejects mismatches before constructing HubSpot authorize query params (fails fast)

**Server Startup Guard** (`apps/api/src/index.ts`):
- Previously: Server started only when `NODE_ENV !== "test"`
- Now: Server starts only when `NODE_ENV !== "test"` **AND** `VITEST !== "true"`
- Prevents Vitest test runs from spawning HTTP server (improves stability)

### HubSpot Extension Layer (`apps/hubspot-extension`)

**Settings Entry Transformation** (`settings-entry.tsx`):
- Now receives `context: ExtensionPointApiContext<"settings">`
- Derives optional `resolvedBaseUrl` from `context.variables.API_ORIGIN`
- Passes resolved origin to `createSettingsFetcher(resolvedBaseUrl)` and `createSettingsUpdater(resolvedBaseUrl)`
- Profile variable injection enables environment-specific API targets without hardcoding

**Card Entry Transformation** (`hubspot-card-entry.tsx`):
- Automatically creates default fetcher via `createHubSpotApiFetcher({ baseUrl: API_ORIGIN })` 
- Falls back to auto-created fetcher if no `snapshotFetcher` prop provided
- API_ORIGIN comes from `context.variables.API_ORIGIN` (injected by HubSpot CLI profile)

**Extension Root Hub** (`extension-root.tsx`):
- Imports `createHubSpotApiFetcher` for dependency injection
- Resolves API base URL from `context.variables.API_ORIGIN`
- Passes resolved fetcher to snapshot hooks (enables context-aware API calls)

### HubSpot Project Layer (`apps/hubspot-project`)

**app-hsmeta.json Changes**:
```diff
- "redirectUrls": ["http://localhost:3000/oauth/callback"],
+ "redirectUrls": ["${OAUTH_REDIRECT_URI}"],

- "permittedUrls.fetch": ["https://api.hubapi.com", "https://hap-signal-workspace-staging.vercel.app", "https://hap-signal-workspace.vercel.app"]
+ "permittedUrls.fetch": ["https://api.hubapi.com", "${API_ORIGIN}"]
```
- Placeholders are replaced by HubSpot CLI when uploading with `--profile`
- Enables single app config file to target multiple environments

**Upload Script Enforcement** (`scripts/hs-project-upload.ts`):
- `pnpm tsx scripts/hs-project-upload.ts --profile <local|staging|production>` (flag **mandatory**)
- Supports both `--profile=name` and `-p=name` formats
- Throws error immediately if `--profile` missing (before bundling/uploading)
- Forces deliberate environment selection, prevents accidental profile mix-ups

---

## 📚 Documentation & Validation Additions

### New Security & Deployment Documentation
| Document | Purpose | Key Content |
|----------|---------|------------|
| `docs/security/slice-5-audit.md` | Security verification gate | OAuth validation, redirect handling, profile contract, secrets handling, residual risk analysis |
| `docs/runbooks/production-deploy.md` | Deployment checklist | Required env vars, upload sequence, verification steps, rollback procedure |
| `docs/qa/slice-5-pilot-walkthrough.md` | Multi-tenant QA process | Two-portal installation test, settings config, card rendering validation, failure capture template |
| `docs/slice-5-preflight-notes.md` | Pre-implementation decisions | Factual constraints verified, design rationale, acceptance gates with implementation invariants |
| `docs/phase-5-doc-alignment.md` | Documentation audit | Active source-of-truth stack, maintenance rules for keeping docs synchronized |

### Configuration & Example Files
| File | Purpose | Status |
|------|---------|--------|
| `.env.example` | OAuth redirect guidance (updated Slice 3 → Slice 5) | Examples for local/staging/production |
| `apps/hubspot-project/hsprofile.*.example.json` | Profile templates (local/staging/production) | Committed, examples only |
| `apps/hubspot-project/local.json.example` | Local proxy mapping configuration | Enables HTTPS-compliant dev fetch calls |
| `apps/hubspot-project/UPLOAD.md` | HubSpot profile & local dev workflow | Updated with profile contract details |
| `.gitignore` | Ignores real `hsprofile.*.json` and `local.json` | Real files are environment-local only |
| `README.md` | HubSpot profiles section added | Describes profile setup and upload command |

---

## ✅ Testing & Validation Strategy

### Test Enhancements by Module

**OAuth Route Tests** (`apps/api/src/routes/__tests__/oauth.test.ts`)
- ✅ **New**: Happy-path install without `returnUrl` (fallback to local success page)
- ✅ Verifies success HTML instructs user to "open app settings in HubSpot" (post-install guidance)

**OAuth Lib Tests** (`apps/api/src/lib/__tests__/oauth.test.ts`)
- ✅ **New**: Rejects non-localhost HTTP redirect URIs
- ✅ Validates error regex pattern `/https|localhost/i` (clear rejection message)

**API Index Tests** (`apps/api/src/index.test.ts`)
- ✅ **New**: Vitest mocks `@hono/node-server` serve function
- ✅ Verifies server does NOT start in production mode when `VITEST=true`
- ✅ Global `afterEach` resets Vitest module state and unmocks server to prevent test leakage

**Snapshot Route Tests** (`apps/api/src/__tests__/snapshot-route.test.ts`)
- ✅ Injects local redirect URI in normal test flow (`http://localhost:3000/oauth/callback`)
- ✅ Temporarily overrides to production URI for production-specific tests
- ✅ Restores env var state after assertions (includes deletion if originally undefined)

**HubSpot Extension Tests**
| Test File | New/Updated | Coverage |
|-----------|------------|----------|
| `hubspot-card-entry.test.tsx` | Updated | Verifies `API_ORIGIN` injected, `createHubSpotApiFetcher` called with `baseUrl: <API_ORIGIN>` |
| `settings-entry.test.tsx` | **New** | Validates settings fetcher/updater receive injected `API_ORIGIN` |
| `index.test.tsx` | Updated | Mocks hooks with controlled states (loading/snapshot/error), avoids promise-based deadlocks |

**HubSpot Project Validation** (`apps/hubspot-project/__validate__/scaffold.test.ts`)
- ✅ Asserts `redirectUrls` uses `${OAUTH_REDIRECT_URI}` placeholder (not hard-coded URL)
- ✅ Asserts `permittedUrls.fetch` uses `${API_ORIGIN}` placeholder
- ✅ **New**: Loads & validates all three profile templates (local/staging/production)
- ✅ **New**: Tests local proxy mapping JSON structure
- ✅ **New**: Validates settings entry has `createSettingsFetcher` and `createSettingsUpdater`

**Upload Script Tests** (`scripts/__tests__/hs-project-upload.test.ts`)
- ✅ **New**: Requires explicit `--profile` flag — throws `/--profile/` error if missing
- ✅ Does not call `runUpload` if bundling fails
- ✅ Updated existing test to use `["--profile", "dev"]` instead of empty args

### Test Execution & Stability
- **68 test files validated** via per-file Vitest execution (avoids worker/heap instability with monolithic `pnpm test` run)
- **Validation commands** (all passing):
  - `pnpm install --frozen-lockfile`
  - `pnpm lint`
  - `pnpm typecheck`
  - `pnpm db:migrate`
  - `pnpm tsx scripts/bundle-hubspot-card.ts`
  - File-by-file test execution: `pnpm test <file.test.ts>`

### Test Lock Strategy (Data-Driven Development)
Every production constraint is locked by tests:

```mermaid
graph TD
    A["Production Constraint:<br/>No localhost fallback"] -->|Tested by| B["env.test.ts<br/>resolveHubSpotOAuthRedirectUri<br/>production case"]
    
    C["Redirect URI Validation:<br/>HTTPS or localhost only"] -->|Tested by| D["oauth.test.ts<br/>rejects non-localhost HTTP"]
    
    E["Profile Parameterization:<br/>app-hsmeta uses placeholders"] -->|Tested by| F["scaffold.test.ts<br/>redirectUrls assertion"]
    
    G["Extension Integration:<br/>API_ORIGIN injected"] -->|Tested by| H["hubspot-card-entry.test.tsx<br/>settings-entry.test.tsx"]
    
    I["Upload Safety:<br/>--profile required"] -->|Tested by| J["hs-project-upload.test.ts<br/>requires --profile flag"]
    
    style B fill:#ccffcc
    style D fill:#ccffcc
    style F fill:#ccffcc
    style H fill:#ccffcc
    style J fill:#ccffcc
```

---

## 🚀 Deployment & Developer Experience

### For Developers (Local Setup)
1. **Copy profile template**: `cp apps/hubspot-project/hsprofile.local.example.json apps/hubspot-project/hsprofile.local.json`
2. **Copy proxy config**: `cp apps/hubspot-project/local.json.example apps/hubspot-project/local.json`
   - *(Required because `hubspot.fetch()` must be HTTPS, but local API is HTTP)*
3. **Upload HubSpot project**: `pnpm tsx scripts/hs-project-upload.ts --profile local`
4. **Start dev server**: `hs project dev --profile local`
   - *(HubSpot CLI auto-injects profile variables into extension context)*

### For Staging/Production Deployment
1. **Set environment variable**: `export HUBSPOT_OAUTH_REDIRECT_URI="https://<your-domain>/oauth/callback"`
   - *(Must match the profile's OAUTH_REDIRECT_URI value)*
2. **Select deployment profile**: `hsprofile.staging.json` or `hsprofile.production.json`
3. **Upload HubSpot project**: `pnpm tsx scripts/hs-project-upload.ts --profile staging`
4. **Run smoke tests**:
   - Complete OAuth install flow → callback must reach expected origin (not localhost)
   - Save settings → verify persistence
   - Load card on company record → verify rendering

### Rollback Procedure (if issues detected)
1. **Revert API deployment** (restores prior OAuth redirect)
2. **Preserve HubSpot callback validity** by re-uploading with prior profile if needed
3. **Rerun smoke checks** to confirm recovery

---

## 🔄 Key Behavioral Changes Summary

| Aspect | Before | After | Impact |
|--------|--------|-------|--------|
| **OAuth Redirect** | Hard-coded in `app-hsmeta.json` + localhost fallback | Profile-parameterized `${OAUTH_REDIRECT_URI}` + env var validation | Production now rejects localhost, prevents accidental mis-deployments |
| **API Origin** | Hard-coded Vercel URLs in extension & config | Profile-parameterized `${API_ORIGIN}` + runtime injection | Extension layer dynamically receives origin, adapts fetcher URLs per environment |
| **HubSpot Upload** | No explicit profile required | `--profile` flag mandatory | Forces deliberate environment selection, prevents staging→production mix-ups |
| **Local Dev Network** | Only localhost supported | Proxy remapping via `local.json` | Enables HTTPS-compliant `hubspot.fetch()` calls to local API |
| **Server Startup** | Skipped if `NODE_ENV=test` | Skipped if `NODE_ENV=test` OR `VITEST=true` | Prevents Vitest runs from starting HTTP server, eliminates test-runner conflicts |
| **Settings/Card Rendering** | No origin context passed | `context.variables.API_ORIGIN` injected | Extension knows which API to call, supports multi-tenant isolation |

---

## 🎯 Traceability & Acceptance Criteria

### Test Coverage Matrix

| Implementation | Test File | Test Case | Assertion |
|----------------|-----------|-----------|-----------|
| OAuth redirect validation | `oauth.test.ts` | rejects non-localhost http redirect URIs | Throws `/https\|localhost/i` |
| Config resolution (non-prod) | `env.test.ts` | default to localhost in development | Returns `http://localhost:3000/oauth/callback` |
| Config resolution (production) | `env.test.ts` | missing redirectUri in production | Throws error mentioning `HUBSPOT_OAUTH_REDIRECT_URI` |
| Profile parameterization | `scaffold.test.ts` | app-hsmeta redirectUrls | Equals `["${OAUTH_REDIRECT_URI}"]` |
| Profile parameterization | `scaffold.test.ts` | app-hsmeta permittedUrls.fetch | Contains `${API_ORIGIN}` |
| Settings entry integration | `settings-entry.test.tsx` | API_ORIGIN injected | `createSettingsFetcher` called with `API_ORIGIN` |
| Card entry integration | `hubspot-card-entry.test.tsx` | API_ORIGIN provided | `createHubSpotApiFetcher` called with `baseUrl: API_ORIGIN` |
| Upload enforcement | `hs-project-upload.test.ts` | requires profile | Throws `/--profile/` error when flag missing |
| Server startup guard | `index.test.ts` | production + vitest | Server does not start when `VITEST=true` |

### Security Audit Trail
**`docs/security/slice-5-audit.md`** documents:
- ✅ OAuth redirect handling (config resolution, validation, no silent localhost fallback)
- ✅ Post-install return URL handling (validates HubSpot domains, falls back to local page)
- ✅ HubSpot profile and upload contract (parameterized config, requires `--profile`)
- ✅ Secrets and environment documentation (.env.example, runbooks align without plaintext secrets)
- ✅ Local development fetch contract (local.json enables HTTPS, production uses true HTTPS origins)
- ⚠️ **Accepted Residual Risk**: Local proxy is development-only; production installs rely on HTTPS origins and deploy-time callback matching

### QA Validation Process
**`docs/qa/slice-5-pilot-walkthrough.md`** provides repeatable multi-portal test:
- Two separate HubSpot portals install the app
- Each portal configures settings independently
- Card renders for each portal with correct configuration (no cross-portal contamination)
- Failure tracking template captures environment, portal ID, step, visible error, request IDs

---

## 📋 Slice 5 Acceptance Gates

✅ **All gates verified**:
1. OAuth redirect URI is required in production (no localhost fallback)
2. Profile-driven configuration replaces hard-coded values
3. Extension layer receives API origin from context (multi-tenant ready)
4. HubSpot upload requires explicit `--profile` argument
5. Local development proxy enables HTTPS-compliant fetch calls
6. Test coverage locks all production constraints
7. Security audit documents all validation points and residual risks
8. Deployment runbook provides repeatable production process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->