### PR TITLE
Slice 6: install lifecycle and tenant offboarding

### DIFF
--- a/.claude/tasks/2026-04-17-slice-6-install-lifecycle-offboarding.md
+++ b/.claude/tasks/2026-04-17-slice-6-install-lifecycle-offboarding.md
@@ -1,0 +1,300 @@
+# Plan: Slice 6 - Install Lifecycle and Tenant Offboarding
+
+## Task Description
+
+Slices 1 through 5 now cover the main product wedge end to end:
+
+- HubSpot company-record card
+- real provider and LLM integrations
+- OAuth install flow
+- tenant-scoped RLS and replay protection
+- HubSpot settings UI for per-tenant configuration
+- production/pilot-ready app config and deployment contract
+
+The next engineering gap is not another user-facing feature. It is lifecycle
+completeness after install:
+
+- what happens when HubSpot uninstall or token revocation occurs
+- how tenant OAuth credentials are deactivated or removed
+- how the app behaves after install loss or revoked access
+- how re-install behaves after prior tenant state exists
+- how operations can reason about tenant lifecycle state safely
+
+Today the app can install and run, but uninstall/offboarding behavior is still
+thin and partially implicit. That creates operational and security risk:
+
+- stale OAuth credentials may remain stored after uninstall
+- tenant lifecycle state is not yet explicit enough for offboarding flows
+- revoked access may surface as generic runtime failures rather than a clean
+  lifecycle state
+- re-install after uninstall/revocation is not yet locked as a deliberate flow
+
+Slice 6 should stay narrow. It is not a billing slice, not marketplace asset
+submission, not admin analytics, and not a broader workspace expansion. It is
+the minimum install-lifecycle and offboarding slice needed to make the app
+operationally complete after Slice 5.
+
+Two lifecycle decisions should be treated as explicit contracts in this slice,
+not left implicit:
+
+1. **Lifecycle event source**
+   - preflight must verify whether HubSpot provides a real uninstall/revocation
+     webhook/event we can trust directly
+   - if not, the slice must explicitly adopt token-failure-driven revocation
+     inference
+   - if both exist, the slice should lock a hybrid model with one source marked
+     primary and the other as reconciliation/fallback
+
+2. **Offboarding data policy**
+   - default Slice 6 recommendation is:
+     - soft-deactivate the tenant
+     - clear or invalidate stored OAuth credentials
+     - preserve tenant config and historical app data
+     - reactivate the same tenant identity on reinstall
+   - hard-delete is out of scope unless a concrete legal/compliance requirement
+     forces it
+
+## Objective
+
+When Slice 6 is complete, the system can correctly handle HubSpot app uninstall
+or token revocation events, mark the tenant lifecycle state safely, revoke or
+disable further tenant-scoped API use, and support a clean reinstall flow
+without cross-tenant leakage or broken residual state.
+
+## Relevant Files
+
+### Existing files to modify
+
+- `apps/api/src/routes/oauth.ts`
+  - extend lifecycle handling where reinstall and revoked access intersect the OAuth flow
+- `apps/api/src/lib/hubspot-client.ts`
+  - define behavior for revoked/invalid tenant tokens and post-revocation client use
+- `apps/api/src/middleware/tenant.ts`
+  - ensure deactivated/offboarded tenants fail safely and explicitly
+- `apps/api/src/routes/settings.ts`
+  - verify settings access for deactivated/offboarded tenants behaves correctly
+- `apps/api/src/routes/snapshot.ts`
+  - ensure snapshot generation fails explicitly for deactivated/offboarded tenants
+- `apps/api/src/lib/settings-service.ts`
+  - protect settings reads/writes after tenant offboarding if needed
+- `packages/db/src/schema/tenants.ts`
+  - extend lifecycle state only if the current tenant model is insufficient
+- `packages/db/src/schema/tenant-hubspot-oauth.ts`
+  - extend token/offboarding metadata only if needed
+- `docs/security/SECURITY.md`
+  - add uninstall, revocation, offboarding, and reinstall guarantees
+- `README.md`
+  - update lifecycle assumptions if local/manual cleanup guidance changes
+- `PLANNING_INDEX.md`
+  - add Slice 6 as the active next execution plan once approved
+
+### New files
+
+- `docs/slice-6-preflight-notes.md`
+  - verified lifecycle/offboarding contract and current HubSpot webhook assumptions
+- `docs/runbooks/tenant-offboarding.md`
+  - operational checklist for uninstall, revocation, and reinstall handling
+- `docs/security/slice-6-audit.md`
+  - focused security review for lifecycle/offboarding behavior
+- `apps/api/src/routes/__tests__/hubspot-lifecycle.test.ts`
+  - lifecycle endpoint behavior: uninstall, revocation, and reinstall cases
+- `apps/api/src/lib/__tests__/tenant-lifecycle.test.ts`
+  - domain/service-level offboarding behavior
+- `apps/api/src/routes/hubspot-lifecycle.ts`
+  - receiver for uninstall / lifecycle notifications if a dedicated route is cleaner
+
+## Step by Step Tasks
+
+### Phase 0: Preflight and scope lock
+
+1. **Task ID: lifecycle-preflight**
+   - Verify current HubSpot docs for:
+     - app uninstall lifecycle behavior
+     - webhook/event support for uninstall or token revocation
+     - what signals are actually available versus what must be inferred on failed token use
+   - Verify current repo assumptions around:
+     - `tenant_hubspot_oauth`
+     - tenant deactivation / soft-delete semantics
+     - reinstall expectations after prior tenant existence
+   - Explicitly lock one lifecycle-event-source model:
+     - webhook-driven
+     - token-failure-driven
+     - hybrid
+   - Record verified decisions in `docs/slice-6-preflight-notes.md`.
+   - Dependency: none
+
+2. **Task ID: slice6-scope-contract**
+   - Lock Slice 6 to:
+     - uninstall / revocation detection
+     - tenant lifecycle state handling
+     - post-offboarding runtime protection
+     - reinstall correctness
+     - lifecycle runbook and security documentation
+   - Lock the offboarding data policy explicitly:
+     - tenant is soft-deactivated, not hard-deleted
+     - OAuth credentials are cleared or made unusable
+     - provider/LLM config and historical app data are preserved
+     - reinstall reactivates the same tenant identity
+   - Explicitly defer:
+     - billing
+     - marketplace listing copy/assets submission
+     - analytics/admin reporting
+     - broad customer-success workflows
+   - Dependency: lifecycle-preflight
+
+### Phase 1: Data model and lifecycle contract
+
+3. **Task ID: tenant-lifecycle-model**
+   - Decide whether current tenant schema is sufficient or needs explicit lifecycle fields, for example:
+     - `status`
+     - `deactivatedAt`
+     - `deactivationReason`
+     - OAuth token invalidation metadata
+   - Add failing tests first, then the minimum schema/domain changes required.
+   - Keep lifecycle semantics explicit and config-driven rather than inferred from scattered null checks.
+   - The model must reflect the locked soft-deactivate policy and must not
+     assume hard-delete as the normal uninstall path.
+   - Dependency: slice6-scope-contract
+
+4. **Task ID: lifecycle-service**
+   - Implement a single orchestration layer for:
+     - marking tenant OAuth access revoked
+     - marking tenant app installation removed / deactivated
+     - clearing or invalidating stored tenant OAuth credentials as appropriate
+     - determining whether reinstall should reactivate an existing tenant or create fresh linked state
+   - Dependency: tenant-lifecycle-model
+
+### Phase 2: App lifecycle ingestion and runtime behavior
+
+5. **Task ID: lifecycle-endpoint**
+   - Add the lifecycle receiver path required by the verified HubSpot contract.
+   - If HubSpot uninstall is webhook-driven, implement and verify that route.
+   - If revocation must be inferred from token failures, codify that path
+     explicitly instead of leaving it ad hoc.
+   - If the contract is hybrid, document which signal is authoritative and how
+     reconciliation works.
+   - Add request verification and replay protection if the endpoint requires the same signed-request model.
+   - Dependency: lifecycle-service
+
+6. **Task ID: runtime-offboarding-guards**
+   - Update runtime request handling so deactivated/offboarded tenants fail safely and explicitly in:
+     - snapshot route
+     - settings route
+     - HubSpot client construction/use
+   - Return a clear lifecycle-specific state instead of generic internal failures.
+   - Dependency: lifecycle-endpoint
+
+7. **Task ID: reinstall-flow**
+   - Verify and harden the reinstall path:
+     - uninstall → reinstall same portal
+     - revoked access → reinstall / reauthorize
+     - previously deactivated tenant coming back online
+   - Ensure reinstall does not duplicate tenant identity or leave broken mixed lifecycle state.
+   - Reactivation of the same tenant identity is the default Slice 6 policy and
+     should only change if preflight uncovers a concrete reason it is unsafe.
+   - Dependency: runtime-offboarding-guards
+
+### Phase 3: UI and operational handling
+
+8. **Task ID: lifecycle-empty-states**
+   - Add explicit UI/system states for lifecycle problems where needed:
+     - app no longer authorized
+     - tenant deactivated/offboarded
+     - reinstall required
+   - Keep the UX narrow and operationally clear.
+   - Dependency: reinstall-flow
+
+9. **Task ID: offboarding-runbook**
+   - Document the operational path for:
+     - uninstall handling
+     - token revocation handling
+     - tenant deactivation/reactivation
+     - reinstall verification
+   - Include rollback/recovery notes where appropriate.
+   - Dependency: reinstall-flow
+
+10. **Task ID: doc-stack-cleanup-slice6**
+    - Update repo docs so the lifecycle/offboarding model is easy to find:
+      - `PLANNING_INDEX.md`
+      - `README.md`
+      - any runbook or security references that still imply install-only thinking
+    - Dependency: offboarding-runbook
+
+### Phase 4: Validation and merge prep
+
+11. **Task ID: security-audit-slice6**
+    - Audit the lifecycle/offboarding path for:
+      - stale credential retention
+      - accidental continued tenant access after uninstall
+      - reinstall identity drift
+      - webhook/request verification gaps
+      - cross-tenant leakage during lifecycle transitions
+    - PASS/FAIL per area.
+    - Dependency: lifecycle-empty-states
+
+12. **Task ID: code-review-slice6**
+    - Review the slice with focus on:
+      - lifecycle race conditions
+      - reinstall regressions
+      - tenant-state inconsistency
+      - documentation/runbook correctness
+    - Fix only real findings.
+    - Dependency: security-audit-slice6
+
+13. **Task ID: validate-all-slice6**
+    - Run final validation:
+      - `pnpm install --frozen-lockfile`
+      - `pnpm lint`
+      - `pnpm test`
+      - `pnpm typecheck`
+      - `pnpm db:migrate`
+      - any lifecycle-specific validation command introduced by the slice
+    - Final acceptance:
+      - uninstall/revocation no longer leaves ambiguous runtime behavior
+      - reinstall is repeatable and tenant-safe
+      - lifecycle docs point to the correct active sources
+    - Dependency: code-review-slice6
+
+## Acceptance Criteria
+
+- The app has an explicit, documented lifecycle contract for uninstall, revocation, deactivation, and reinstall.
+- The slice explicitly documents which lifecycle event source is authoritative:
+  webhook-driven, token-failure-driven, or hybrid.
+- Tenant lifecycle state is represented clearly in the backend rather than being inferred from incidental failures alone.
+- Stored HubSpot OAuth credentials are invalidated, cleared, or otherwise made unusable according to the locked lifecycle policy.
+- The offboarding policy is explicit: soft-deactivate tenant, preserve app data,
+  disable OAuth access, and reactivate the same tenant on reinstall unless a
+  verified requirement forces a different rule.
+- Deactivated/offboarded tenants cannot continue using snapshot/settings paths as if still installed.
+- Runtime behavior after uninstall/revocation is explicit and user-operationally understandable.
+- Reinstalling the app for the same portal does not create duplicate tenant identity or inconsistent OAuth state.
+- Security documentation covers lifecycle/offboarding guarantees and residual risks.
+- Final validation passes:
+  - `pnpm lint`
+  - `pnpm test`
+  - `pnpm typecheck`
+  - `pnpm db:migrate`
+
+## Team Orchestration
+
+- Planning can be done on `main` with no new worktree.
+- Implementation should use a fresh Slice 6 branch/worktree off `main` once this plan is approved.
+- TDD stays mandatory for every task that changes code.
+- Parallelization opportunities:
+  - lifecycle schema/service work can proceed alongside runbook drafting after preflight
+  - UI lifecycle-state work can proceed once runtime guard contracts are stable
+- Sequential dependencies:
+  - preflight must happen before lifecycle receiver design
+  - lifecycle model must be stable before runtime guard wiring
+  - reinstall handling should finalize only after offboarding semantics are locked
+
+### Team Members
+
+- `general-purpose` — **lifecycle-contract**
+  - owns preflight, schema/domain lifecycle model, and service orchestration
+- `general-purpose` — **runtime-guard**
+  - owns lifecycle endpoint, HubSpot client behavior, route protection, and reinstall flow
+- `general-purpose` — **ops-docs**
+  - owns offboarding runbook, doc-stack cleanup, and lifecycle state UX wording
+- `quality-engineer`
+  - owns lifecycle regression tests, security audit, and final validation

--- a/PLANNING_INDEX.md
+++ b/PLANNING_INDEX.md
@@ -45,9 +45,11 @@ Important:
 - `docs/slice-3-preflight-notes.md`
 - `docs/slice-4-preflight-notes.md`
 - `docs/phase-5-doc-alignment.md`
+- `docs/phase-6-doc-alignment.md`
 - `.claude/tasks/2026-04-16-slice-3-phase-3-rls-card-bundling.md`
 - `.claude/tasks/2026-04-16-slice-4-settings-configuration.md`
 - `.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md`
+- `.claude/tasks/2026-04-17-slice-6-install-lifecycle-offboarding.md`
 - `docs/superpowers/plans/2026-04-14-slice-1-core-domain.md`
 - `docs/superpowers/plans/2026-04-15-slice-2-live-integrations.md`
 - `docs/superpowers/plans/2026-04-15-slice-3-oauth-public-app.md`

--- a/PLANNING_INDEX.md
+++ b/PLANNING_INDEX.md
@@ -46,6 +46,11 @@ Important:
 - `docs/slice-4-preflight-notes.md`
 - `docs/phase-5-doc-alignment.md`
 - `docs/phase-6-doc-alignment.md`
+- `docs/slice-5-preflight-notes.md`
+- `docs/slice-6-preflight-notes.md`
+- `docs/runbooks/tenant-offboarding.md`
+- `docs/security/slice-5-audit.md`
+- `docs/security/slice-6-audit.md`
 - `.claude/tasks/2026-04-16-slice-3-phase-3-rls-card-bundling.md`
 - `.claude/tasks/2026-04-16-slice-4-settings-configuration.md`
 - `.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md`

--- a/README.md
+++ b/README.md
@@ -94,4 +94,27 @@ packages/
 - Explicit empty/stale/degraded/low-confidence/ineligible states
 - Tenant-isolated, config-driven, no silent CRM writes
 
+## Install Lifecycle
+
+The app now treats install lifecycle as an explicit contract:
+
+- uninstall / revocation soft-deactivates the tenant
+- HubSpot OAuth credentials are removed
+- tenant config and historical app data are preserved
+- reinstall for the same portal reactivates the same tenant identity
+
+Runtime behavior is explicit too:
+
+- inactive tenants are rejected with `401 tenant_inactive`
+- revoked access discovered during a live snapshot request becomes
+  `401 tenant_access_revoked`
+- the HubSpot card shows reconnect guidance instead of a generic error for
+  lifecycle-related `401` responses
+
+Operational details live in:
+
+- `docs/slice-6-preflight-notes.md`
+- `docs/runbooks/tenant-offboarding.md`
+- `docs/security/slice-6-audit.md`
+
 See `planning/` for full product requirements and implementation plans.

--- a/apps/api/src/__tests__/snapshot-route.test.ts
+++ b/apps/api/src/__tests__/snapshot-route.test.ts
@@ -45,6 +45,8 @@ afterAll(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.doUnmock("../services/snapshot-assembler");
+  vi.resetModules();
 });
 
 beforeEach(async () => {
@@ -312,6 +314,7 @@ describe("POST /api/snapshot/:companyId", () => {
       settings: {},
     });
 
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.resetModules();
     vi.doMock("../services/snapshot-assembler", () => ({
       assembleSnapshot: vi.fn().mockRejectedValue(new TenantAccessRevokedError()),
@@ -344,6 +347,13 @@ describe("POST /api/snapshot/:companyId", () => {
     const body = (await res.json()) as { error: string; detail: string };
     expect(body.error).toBe("tenant_access_revoked");
     expect(body.detail).toBe("hubspot access revoked or app uninstalled for tenant");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "snapshot_route.tenant_access_revoked",
+      expect.objectContaining({
+        tenantId: tenant.id,
+        companyId: "co-revoked",
+      }),
+    );
   });
 
   it("tenant with only a mock-signal provider_config row (not a real provider) gets unconfigured", async () => {

--- a/apps/api/src/__tests__/snapshot-route.test.ts
+++ b/apps/api/src/__tests__/snapshot-route.test.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { createDatabase, providerConfig, tenants } from "@hap/db";
+import { createDatabase, llmConfig, providerConfig, tenants } from "@hap/db";
 import { like } from "drizzle-orm";
 import { Hono } from "hono";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearConfigResolverCache } from "../lib/config-resolver";
+import { __resetEncryptionCacheForTests, encryptProviderKey } from "../lib/encryption";
+import { TenantAccessRevokedError } from "../lib/hubspot-client";
 import { snapshotRoutes } from "../routes/snapshot";
 
 const DATABASE_URL =
@@ -15,6 +17,8 @@ const PORTAL_PREFIX = `snaptest-${randomUUID().slice(0, 8)}-`;
 const TEST_LOCAL_REDIRECT_URI = "http://localhost:3000/oauth/callback";
 const TEST_PRODUCTION_REDIRECT_URI =
   "https://hap-signal-workspace-staging.vercel.app/oauth/callback";
+const ROOT_KEK_BASE64 = Buffer.alloc(32, 9).toString("base64");
+let savedRootKek: string | undefined;
 
 function portalId() {
   return `${PORTAL_PREFIX}${randomUUID().slice(0, 8)}`;
@@ -24,10 +28,23 @@ beforeAll(() => {
   process.env.NODE_ENV = "test";
   process.env.DATABASE_URL = DATABASE_URL;
   process.env.HUBSPOT_OAUTH_REDIRECT_URI = TEST_LOCAL_REDIRECT_URI;
+  savedRootKek = process.env.ROOT_KEK;
+  process.env.ROOT_KEK = ROOT_KEK_BASE64;
+  __resetEncryptionCacheForTests();
 });
 
 afterAll(() => {
   // postgres.js cleans up on process exit
+  if (savedRootKek === undefined) {
+    delete process.env.ROOT_KEK;
+  } else {
+    process.env.ROOT_KEK = savedRootKek;
+  }
+  __resetEncryptionCacheForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 beforeEach(async () => {
@@ -94,6 +111,31 @@ describe("POST /api/snapshot/:companyId", () => {
       },
     });
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the resolved tenant is deactivated", async () => {
+    const portal = portalId();
+    await db.insert(tenants).values({
+      hubspotPortalId: portal,
+      name: "Inactive Snapshot Co",
+      isActive: false,
+      deactivatedAt: new Date("2026-04-17T12:30:00.000Z"),
+      deactivationReason: "hubspot_app_uninstalled",
+    });
+
+    const app = await loadApp();
+    const res = await app.request("/api/snapshot/c123", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": portal,
+      },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string; detail: string };
+    expect(body.error).toBe("tenant_inactive");
+    expect(body.detail).toBe("tenant is deactivated");
   });
 
   it("returns 400 when companyId path segment is empty", async () => {
@@ -242,6 +284,66 @@ describe("POST /api/snapshot/:companyId", () => {
         process.env.DATABASE_URL = prevDatabaseUrl;
       }
     }
+  });
+
+  it("returns a lifecycle-specific 401 when tenant access is revoked mid-request", async () => {
+    const portal = portalId();
+    const [tenant] = await db
+      .insert(tenants)
+      .values({ hubspotPortalId: portal, name: "Revoked Mid Request Co" })
+      .returning();
+    if (!tenant) {
+      throw new Error("tenant insert failed");
+    }
+
+    await db.insert(providerConfig).values({
+      tenantId: tenant.id,
+      providerName: "exa",
+      enabled: true,
+      apiKeyEncrypted: encryptProviderKey(tenant.id, "sk-real-exa-key"),
+      thresholds: { freshnessMaxDays: 30, minConfidence: 0.5 },
+      settings: {},
+    });
+    await db.insert(llmConfig).values({
+      tenantId: tenant.id,
+      providerName: "openai",
+      modelName: "gpt-4o-mini",
+      apiKeyEncrypted: encryptProviderKey(tenant.id, "sk-real-openai-key"),
+      settings: {},
+    });
+
+    vi.resetModules();
+    vi.doMock("../services/snapshot-assembler", () => ({
+      assembleSnapshot: vi.fn().mockRejectedValue(new TenantAccessRevokedError()),
+    }));
+
+    const { snapshotRoutes: freshSnapshotRoutes } = await import("../routes/snapshot");
+    const app = new Hono<{
+      Variables: {
+        tenantId?: string;
+        correlationId?: string;
+        db?: ReturnType<typeof createDatabase>;
+      };
+    }>();
+    app.use("*", async (c, next) => {
+      c.set("tenantId", tenant.id);
+      c.set("db", db);
+      c.set("correlationId", "corr-route-only");
+      await next();
+    });
+    app.route("/api/snapshot", freshSnapshotRoutes);
+
+    const res = await app.request("/api/snapshot/co-revoked", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string; detail: string };
+    expect(body.error).toBe("tenant_access_revoked");
+    expect(body.detail).toBe("hubspot access revoked or app uninstalled for tenant");
   });
 
   it("tenant with only a mock-signal provider_config row (not a real provider) gets unconfigured", async () => {

--- a/apps/api/src/__tests__/tenant.test.ts
+++ b/apps/api/src/__tests__/tenant.test.ts
@@ -93,6 +93,25 @@ describe("tenant middleware", () => {
     expect(body.detail).toBe("tenant not found");
   });
 
+  it("returns 401 when the tenant exists but is deactivated", async () => {
+    const portal = portalId();
+    await db.insert(tenants).values({
+      hubspotPortalId: portal,
+      name: "Inactive Acme",
+      isActive: false,
+      deactivatedAt: new Date("2026-04-17T12:30:00.000Z"),
+      deactivationReason: "hubspot_app_uninstalled",
+    });
+
+    const app = buildTestApp(portal);
+    const res = await app.request("/whoami");
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string; detail: string };
+    expect(body.error).toBe("tenant_inactive");
+    expect(body.detail).toBe("tenant is deactivated");
+  });
+
   it("tenant A's portal_id never resolves to tenant B's id (cross-tenant isolation)", async () => {
     const portalA = portalId();
     const portalB = portalId();

--- a/apps/api/src/lib/__tests__/hubspot-client.test.ts
+++ b/apps/api/src/lib/__tests__/hubspot-client.test.ts
@@ -34,6 +34,19 @@ function makeMockDb(overrides?: {
   accessToken?: string;
   refreshToken?: string;
   missing?: boolean;
+  rowSequence?: Array<
+    | {
+        tenantId: string;
+        accessTokenEncrypted: string;
+        refreshTokenEncrypted: string;
+        expiresAt: Date;
+        scopes: string[];
+        keyVersion: number;
+        createdAt: Date;
+        updatedAt: Date;
+      }
+    | undefined
+  >;
 }): Database {
   const accessToken = overrides?.accessToken ?? TEST_ACCESS_TOKEN;
   const refreshToken = overrides?.refreshToken ?? TEST_REFRESH_TOKEN;
@@ -52,8 +65,17 @@ function makeMockDb(overrides?: {
         updatedAt: new Date(),
       };
 
-  const findFirstMock = vi.fn().mockResolvedValue(row);
-  const updateWhereMock = vi.fn().mockResolvedValue(undefined);
+  const rowSequence = overrides?.rowSequence;
+  const findFirstMock = rowSequence
+    ? vi.fn().mockImplementation(async () => rowSequence.shift())
+    : vi.fn().mockResolvedValue(row);
+  const updateWhereMock = vi.fn().mockImplementation(() => {
+    const result = Promise.resolve(undefined) as Promise<void> & {
+      returning: ReturnType<typeof vi.fn>;
+    };
+    result.returning = vi.fn().mockResolvedValue([{ id: TEST_TENANT_ID }]);
+    return result;
+  });
   const updateSetMock = vi.fn().mockReturnValue({
     where: updateWhereMock,
   });
@@ -288,6 +310,55 @@ describe("HubSpotClient (Slice 3 — per-tenant OAuth)", () => {
     expect(db.transaction).toHaveBeenCalledTimes(1);
     expect(db.delete).toHaveBeenCalled();
     expect(db.update).toHaveBeenCalled();
+  });
+
+  it("does not deactivate the tenant when invalid_grant is caused by a stale refresh-token race", async () => {
+    const almostExpired = new Date(Date.now() + 30_000);
+    const db = makeMockDb({
+      expiresAt: almostExpired,
+      rowSequence: [
+        {
+          tenantId: TEST_TENANT_ID,
+          accessTokenEncrypted: encryptProviderKey(TEST_TENANT_ID, TEST_ACCESS_TOKEN),
+          refreshTokenEncrypted: encryptProviderKey(TEST_TENANT_ID, TEST_REFRESH_TOKEN),
+          expiresAt: almostExpired,
+          scopes: ["crm.objects.companies.read", "crm.objects.contacts.read"],
+          keyVersion: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          tenantId: TEST_TENANT_ID,
+          accessTokenEncrypted: encryptProviderKey(TEST_TENANT_ID, "rotated-access-token"),
+          refreshTokenEncrypted: encryptProviderKey(TEST_TENANT_ID, "rotated-refresh-token"),
+          expiresAt: FAR_FUTURE,
+          scopes: ["crm.objects.companies.read", "crm.objects.contacts.read"],
+          keyVersion: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    });
+
+    vi.spyOn(await import("../oauth"), "refreshAccessToken").mockRejectedValue(
+      new OAuthHttpError("hubspot token endpoint returned 400", 400, {
+        error: "invalid_grant",
+        error_description: "refresh token is invalid, expired or revoked",
+      }),
+    );
+
+    const client = new HubSpotClient({
+      tenantId: TEST_TENANT_ID,
+      db,
+      fetch: makeFakeFetch({}),
+    });
+
+    await expect(client.getCompanyProperties("123", ["name"])).rejects.toBeInstanceOf(
+      OAuthHttpError,
+    );
+
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
   });
 
   // ---- 401 auto-retry ----

--- a/apps/api/src/lib/__tests__/hubspot-client.test.ts
+++ b/apps/api/src/lib/__tests__/hubspot-client.test.ts
@@ -12,7 +12,8 @@
 import type { Database } from "@hap/db";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { encryptProviderKey } from "../encryption";
-import { HubSpotClient } from "../hubspot-client";
+import { HubSpotClient, TenantAccessRevokedError } from "../hubspot-client";
+import { OAuthHttpError } from "../oauth";
 
 // ---------------------------------------------------------------------------
 // Helpers — fake DB + fetch
@@ -52,6 +53,17 @@ function makeMockDb(overrides?: {
       };
 
   const findFirstMock = vi.fn().mockResolvedValue(row);
+  const updateWhereMock = vi.fn().mockResolvedValue(undefined);
+  const updateSetMock = vi.fn().mockReturnValue({
+    where: updateWhereMock,
+  });
+  const updateMock = vi.fn().mockReturnValue({
+    set: updateSetMock,
+  });
+  const deleteWhereMock = vi.fn().mockResolvedValue(undefined);
+  const deleteMock = vi.fn().mockReturnValue({
+    where: deleteWhereMock,
+  });
 
   // Drizzle query pattern: db.query.tenantHubspotOauth.findFirst({ where: ... })
   // We mock the minimal chain needed.
@@ -62,11 +74,9 @@ function makeMockDb(overrides?: {
       },
     },
     // For UPDATE (token refresh persist)
-    update: vi.fn().mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      }),
-    }),
+    update: updateMock,
+    delete: deleteMock,
+    transaction: vi.fn(async (callback: (tx: unknown) => unknown) => callback(mockDb)),
   } as unknown as Database;
 
   return mockDb;
@@ -172,8 +182,8 @@ describe("HubSpotClient (Slice 3 — per-tenant OAuth)", () => {
       fetch: fakeFetch,
     });
 
-    await expect(client.getCompanyProperties("123", ["name"])).rejects.toThrow(
-      /no oauth tokens found/i,
+    await expect(client.getCompanyProperties("123", ["name"])).rejects.toBeInstanceOf(
+      TenantAccessRevokedError,
     );
   });
 
@@ -251,6 +261,32 @@ describe("HubSpotClient (Slice 3 — per-tenant OAuth)", () => {
     expect(headers.get("authorization")).toBe(`Bearer ${newAccessToken}`);
 
     // DB update should have been called to persist rotated tokens
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it("soft-deactivates the tenant when refresh fails with an unrecoverable OAuth error", async () => {
+    const almostExpired = new Date(Date.now() + 30_000);
+    const db = makeMockDb({ expiresAt: almostExpired });
+
+    vi.spyOn(await import("../oauth"), "refreshAccessToken").mockRejectedValue(
+      new OAuthHttpError("hubspot token endpoint returned 400", 400, {
+        error: "invalid_grant",
+        error_description: "refresh token is invalid, expired or revoked",
+      }),
+    );
+
+    const client = new HubSpotClient({
+      tenantId: TEST_TENANT_ID,
+      db,
+      fetch: makeFakeFetch({}),
+    });
+
+    await expect(client.getCompanyProperties("123", ["name"])).rejects.toBeInstanceOf(
+      TenantAccessRevokedError,
+    );
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.delete).toHaveBeenCalled();
     expect(db.update).toHaveBeenCalled();
   });
 

--- a/apps/api/src/lib/__tests__/tenant-lifecycle.test.ts
+++ b/apps/api/src/lib/__tests__/tenant-lifecycle.test.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "node:crypto";
+import { createDatabase, tenantHubspotOauth, tenants } from "@hap/db";
+import { eq, like } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { __resetEncryptionCacheForTests, encryptProviderKey } from "../encryption";
+import {
+  applyHubSpotLifecycleEvent,
+  deactivateTenant,
+  reactivateTenant,
+} from "../tenant-lifecycle";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
+
+const db = createDatabase(DATABASE_URL);
+const PORTAL_PREFIX = `tenantlife-${randomUUID().slice(0, 8)}-`;
+const ROOT_KEK_BASE64 = Buffer.alloc(32, 7).toString("base64");
+let savedRootKek: string | undefined;
+
+beforeAll(() => {
+  savedRootKek = process.env.ROOT_KEK;
+  process.env.ROOT_KEK = ROOT_KEK_BASE64;
+  __resetEncryptionCacheForTests();
+});
+
+beforeEach(async () => {
+  await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+});
+
+afterAll(async () => {
+  await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+  if (savedRootKek !== undefined) {
+    process.env.ROOT_KEK = savedRootKek;
+  } else {
+    delete process.env.ROOT_KEK;
+  }
+  __resetEncryptionCacheForTests();
+});
+
+function portalId() {
+  return `${PORTAL_PREFIX}${randomUUID().slice(0, 8)}`;
+}
+
+async function seedTenant() {
+  const [tenant] = await db
+    .insert(tenants)
+    .values({
+      hubspotPortalId: portalId(),
+      name: "Tenant Lifecycle Test",
+    })
+    .returning();
+
+  if (!tenant) {
+    throw new Error("failed to seed tenant");
+  }
+
+  await db.insert(tenantHubspotOauth).values({
+    tenantId: tenant.id,
+    accessTokenEncrypted: encryptProviderKey(tenant.id, "access-token-1"),
+    refreshTokenEncrypted: encryptProviderKey(tenant.id, "refresh-token-1"),
+    expiresAt: new Date("2026-04-20T10:00:00.000Z"),
+    scopes: ["oauth", "crm.objects.companies.read"],
+  });
+
+  return tenant;
+}
+
+describe("tenant lifecycle service", () => {
+  it("soft-deactivates the tenant and clears oauth credentials", async () => {
+    const tenant = await seedTenant();
+    const deactivatedAt = new Date("2026-04-17T12:00:00.000Z");
+
+    await deactivateTenant({
+      db,
+      tenantId: tenant.id,
+      reason: "hubspot_app_uninstalled",
+      deactivatedAt,
+    });
+
+    const [tenantRow] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+    const oauthRows = await db
+      .select()
+      .from(tenantHubspotOauth)
+      .where(eq(tenantHubspotOauth.tenantId, tenant.id));
+
+    expect(tenantRow?.isActive).toBe(false);
+    expect(tenantRow?.deactivatedAt).toEqual(deactivatedAt);
+    expect(tenantRow?.deactivationReason).toBe("hubspot_app_uninstalled");
+    expect(oauthRows).toHaveLength(0);
+  });
+
+  it("reactivates the same tenant identity and clears offboarding metadata", async () => {
+    const tenant = await seedTenant();
+
+    await deactivateTenant({
+      db,
+      tenantId: tenant.id,
+      reason: "oauth_refresh_failed",
+      deactivatedAt: new Date("2026-04-17T12:15:00.000Z"),
+    });
+
+    await reactivateTenant({
+      db,
+      tenantId: tenant.id,
+    });
+
+    const [tenantRow] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+
+    expect(tenantRow?.id).toBe(tenant.id);
+    expect(tenantRow?.isActive).toBe(true);
+    expect(tenantRow?.deactivatedAt).toBeNull();
+    expect(tenantRow?.deactivationReason).toBeNull();
+  });
+
+  it("applies app_uninstall lifecycle events by portal id", async () => {
+    const tenant = await seedTenant();
+    const eventTime = new Date("2026-04-17T12:30:00.000Z");
+
+    await applyHubSpotLifecycleEvent({
+      db,
+      portalId: tenant.hubspotPortalId,
+      eventType: "app_uninstall",
+      occurredAt: eventTime,
+    });
+
+    const [tenantRow] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+    const oauthRows = await db
+      .select()
+      .from(tenantHubspotOauth)
+      .where(eq(tenantHubspotOauth.tenantId, tenant.id));
+
+    expect(tenantRow?.isActive).toBe(false);
+    expect(tenantRow?.deactivatedAt).toEqual(eventTime);
+    expect(tenantRow?.deactivationReason).toBe("hubspot_app_uninstalled");
+    expect(oauthRows).toHaveLength(0);
+  });
+
+  it("reactivates an existing tenant when an app_install lifecycle event arrives", async () => {
+    const tenant = await seedTenant();
+
+    await deactivateTenant({
+      db,
+      tenantId: tenant.id,
+      reason: "hubspot_app_uninstalled",
+      deactivatedAt: new Date("2026-04-17T12:45:00.000Z"),
+    });
+
+    await applyHubSpotLifecycleEvent({
+      db,
+      portalId: tenant.hubspotPortalId,
+      eventType: "app_install",
+      occurredAt: new Date("2026-04-17T13:00:00.000Z"),
+    });
+
+    const [tenantRow] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+
+    expect(tenantRow?.id).toBe(tenant.id);
+    expect(tenantRow?.isActive).toBe(true);
+    expect(tenantRow?.deactivatedAt).toBeNull();
+    expect(tenantRow?.deactivationReason).toBeNull();
+  });
+});

--- a/apps/api/src/lib/__tests__/tenant-lifecycle.test.ts
+++ b/apps/api/src/lib/__tests__/tenant-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { eq, like } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { __resetEncryptionCacheForTests, encryptProviderKey } from "../encryption";
 import {
+  type ApplyHubSpotLifecycleEventArgs,
   applyHubSpotLifecycleEvent,
   deactivateTenant,
   reactivateTenant,
@@ -160,6 +161,56 @@ describe("tenant lifecycle service", () => {
     expect(tenantRow?.isActive).toBe(true);
     expect(tenantRow?.deactivatedAt).toBeNull();
     expect(tenantRow?.deactivationReason).toBeNull();
+  });
+
+  it("is a no-op when no tenant matches the lifecycle portal id", async () => {
+    const tenant = await seedTenant();
+
+    await expect(
+      applyHubSpotLifecycleEvent({
+        db,
+        portalId: portalId(),
+        eventType: "app_uninstall",
+        occurredAt: new Date("2026-04-17T13:15:00.000Z"),
+      }),
+    ).resolves.toBeUndefined();
+
+    const [tenantRow] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+    const oauthRows = await db
+      .select()
+      .from(tenantHubspotOauth)
+      .where(eq(tenantHubspotOauth.tenantId, tenant.id));
+
+    expect(tenantRow?.isActive).toBe(true);
+    expect(tenantRow?.deactivatedAt).toBeNull();
+    expect(tenantRow?.deactivationReason).toBeNull();
+    expect(oauthRows).toHaveLength(1);
+  });
+
+  it("does not reactivate on unexpected lifecycle event types", async () => {
+    const tenant = await seedTenant();
+
+    await deactivateTenant({
+      db,
+      tenantId: tenant.id,
+      reason: "hubspot_app_uninstalled",
+      deactivatedAt: new Date("2026-04-17T12:45:00.000Z"),
+    });
+
+    await expect(
+      applyHubSpotLifecycleEvent({
+        db,
+        portalId: tenant.hubspotPortalId,
+        eventType: "unexpected" as ApplyHubSpotLifecycleEventArgs["eventType"],
+        occurredAt: new Date("2026-04-17T13:30:00.000Z"),
+      }),
+    ).resolves.toBeUndefined();
+
+    const [tenantRow] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+
+    expect(tenantRow?.isActive).toBe(false);
+    expect(tenantRow?.deactivatedAt).toBeTruthy();
+    expect(tenantRow?.deactivationReason).toBe("hubspot_app_uninstalled");
   });
 
   it("fails fast when deactivating a missing tenant", async () => {

--- a/apps/api/src/lib/__tests__/tenant-lifecycle.test.ts
+++ b/apps/api/src/lib/__tests__/tenant-lifecycle.test.ts
@@ -9,8 +9,10 @@ import {
   reactivateTenant,
 } from "../tenant-lifecycle";
 
-const DATABASE_URL =
-  process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  throw new Error("tenant-lifecycle.test.ts requires DATABASE_URL");
+}
 
 const db = createDatabase(DATABASE_URL);
 const PORTAL_PREFIX = `tenantlife-${randomUUID().slice(0, 8)}-`;
@@ -158,5 +160,24 @@ describe("tenant lifecycle service", () => {
     expect(tenantRow?.isActive).toBe(true);
     expect(tenantRow?.deactivatedAt).toBeNull();
     expect(tenantRow?.deactivationReason).toBeNull();
+  });
+
+  it("fails fast when deactivating a missing tenant", async () => {
+    await expect(
+      deactivateTenant({
+        db,
+        tenantId: randomUUID(),
+        reason: "hubspot_app_uninstalled",
+      }),
+    ).rejects.toThrow(/tenant not found/i);
+  });
+
+  it("fails fast when reactivating a missing tenant", async () => {
+    await expect(
+      reactivateTenant({
+        db,
+        tenantId: randomUUID(),
+      }),
+    ).rejects.toThrow(/tenant not found/i);
   });
 });

--- a/apps/api/src/lib/hubspot-client.ts
+++ b/apps/api/src/lib/hubspot-client.ts
@@ -255,6 +255,22 @@ export class HubSpotClient {
       });
     } catch (error) {
       if (isUnrecoverableRefreshFailure(error)) {
+        const currentRow = await this.db.query.tenantHubspotOauth.findFirst({
+          where: eq(tenantHubspotOauth.tenantId, this.tenantId),
+        });
+
+        if (!currentRow) {
+          throw new TenantAccessRevokedError();
+        }
+
+        const currentRefreshToken = decryptProviderKey(
+          this.tenantId,
+          currentRow.refreshTokenEncrypted,
+        );
+        if (currentRefreshToken !== refreshToken) {
+          throw error;
+        }
+
         try {
           await deactivateTenant({
             db: this.db,

--- a/apps/api/src/lib/hubspot-client.ts
+++ b/apps/api/src/lib/hubspot-client.ts
@@ -24,7 +24,8 @@ import type { Database } from "@hap/db";
 import { tenantHubspotOauth } from "@hap/db";
 import { eq } from "drizzle-orm";
 import { decryptProviderKey, encryptProviderKey } from "./encryption";
-import { refreshAccessToken } from "./oauth";
+import { OAuthHttpError, refreshAccessToken } from "./oauth";
+import { deactivateTenant } from "./tenant-lifecycle";
 
 const HUBSPOT_API_ROOT = "https://api.hubapi.com";
 
@@ -139,6 +140,26 @@ interface TokenCache {
   expiresAt: Date;
 }
 
+export class TenantAccessRevokedError extends Error {
+  constructor(message = "hubspot access revoked or app uninstalled for tenant") {
+    super(message);
+    this.name = "TenantAccessRevokedError";
+  }
+}
+
+function isUnrecoverableRefreshFailure(error: unknown): error is OAuthHttpError {
+  if (!(error instanceof OAuthHttpError) || error.status !== 400) {
+    return false;
+  }
+
+  const body = error.body as { error?: unknown; error_description?: unknown } | null;
+  const code = typeof body?.error === "string" ? body.error.toLowerCase() : "";
+  const description =
+    typeof body?.error_description === "string" ? body.error_description.toLowerCase() : "";
+
+  return code === "invalid_grant" || description.includes("revoked");
+}
+
 /** Constructor options for per-tenant OAuth client. */
 export interface HubSpotClientOptions {
   tenantId: string;
@@ -182,7 +203,7 @@ export class HubSpotClient {
     });
 
     if (!row) {
-      throw new Error(`HubSpotClient: no OAuth tokens found for tenant ${this.tenantId}`);
+      throw new TenantAccessRevokedError();
     }
 
     // Check if token is within the pre-expiry window (or already expired)
@@ -223,13 +244,36 @@ export class HubSpotClient {
     const env = loadEnv();
     const refreshToken = decryptProviderKey(this.tenantId, refreshTokenEncrypted);
 
-    const result = await refreshAccessToken({
-      clientId: env.HUBSPOT_CLIENT_ID,
-      clientSecret: env.HUBSPOT_CLIENT_SECRET,
-      refreshToken,
-      // Use the injected fetch for refresh calls too
-      fetch: this.fetchImpl,
-    });
+    let result: Awaited<ReturnType<typeof refreshAccessToken>>;
+    try {
+      result = await refreshAccessToken({
+        clientId: env.HUBSPOT_CLIENT_ID,
+        clientSecret: env.HUBSPOT_CLIENT_SECRET,
+        refreshToken,
+        // Use the injected fetch for refresh calls too
+        fetch: this.fetchImpl,
+      });
+    } catch (error) {
+      if (isUnrecoverableRefreshFailure(error)) {
+        try {
+          await deactivateTenant({
+            db: this.db,
+            tenantId: this.tenantId,
+            reason: "oauth_refresh_failed",
+          });
+        } catch (deactivateError) {
+          console.error("hubspot_client.oauth_refresh_deactivate_failed", {
+            tenantId: this.tenantId,
+            errorClass:
+              deactivateError instanceof Error
+                ? deactivateError.constructor.name
+                : typeof deactivateError,
+          });
+        }
+        throw new TenantAccessRevokedError();
+      }
+      throw error;
+    }
 
     const newExpiresAt = new Date(Date.now() + result.expiresIn * 1000);
 
@@ -281,7 +325,7 @@ export class HubSpotClient {
       });
 
       if (!row) {
-        throw new Error(`HubSpotClient: no OAuth tokens found for tenant ${this.tenantId}`);
+        throw new TenantAccessRevokedError();
       }
 
       await this.serializedRefresh(row.refreshTokenEncrypted);

--- a/apps/api/src/lib/tenant-lifecycle.ts
+++ b/apps/api/src/lib/tenant-lifecycle.ts
@@ -7,8 +7,10 @@ type LifecycleDeps = {
   tenantId: string;
 };
 
+export type TenantDeactivationReason = "hubspot_app_uninstalled" | "oauth_refresh_failed";
+
 export type DeactivateTenantArgs = LifecycleDeps & {
-  reason: string;
+  reason: TenantDeactivationReason;
   deactivatedAt?: Date;
 };
 
@@ -29,7 +31,7 @@ export async function deactivateTenant(args: DeactivateTenantArgs): Promise<void
   await db.transaction(async (tx) => {
     const txDb = tx as unknown as Database;
 
-    await txDb
+    const updatedRows = await txDb
       .update(tenants)
       .set({
         isActive: false,
@@ -37,7 +39,12 @@ export async function deactivateTenant(args: DeactivateTenantArgs): Promise<void
         deactivationReason: reason,
         updatedAt: new Date(),
       })
-      .where(eq(tenants.id, tenantId));
+      .where(eq(tenants.id, tenantId))
+      .returning({ id: tenants.id });
+
+    if (updatedRows.length === 0) {
+      throw new Error(`tenant not found for deactivation: ${tenantId}`);
+    }
 
     await txDb.delete(tenantHubspotOauth).where(eq(tenantHubspotOauth.tenantId, tenantId));
   });
@@ -48,7 +55,7 @@ export async function deactivateTenant(args: DeactivateTenantArgs): Promise<void
 export async function reactivateTenant(args: ReactivateTenantArgs): Promise<void> {
   const { db, tenantId } = args;
 
-  await db
+  const updatedRows = await db
     .update(tenants)
     .set({
       isActive: true,
@@ -56,7 +63,12 @@ export async function reactivateTenant(args: ReactivateTenantArgs): Promise<void
       deactivationReason: null,
       updatedAt: new Date(),
     })
-    .where(eq(tenants.id, tenantId));
+    .where(eq(tenants.id, tenantId))
+    .returning({ id: tenants.id });
+
+  if (updatedRows.length === 0) {
+    throw new Error(`tenant not found for reactivation: ${tenantId}`);
+  }
 
   invalidateTenantConfig(tenantId);
 }

--- a/apps/api/src/lib/tenant-lifecycle.ts
+++ b/apps/api/src/lib/tenant-lifecycle.ts
@@ -95,6 +95,10 @@ export async function applyHubSpotLifecycleEvent(
     return;
   }
 
+  if (eventType !== "app_install") {
+    return;
+  }
+
   await reactivateTenant({
     db,
     tenantId: tenant.id,

--- a/apps/api/src/lib/tenant-lifecycle.ts
+++ b/apps/api/src/lib/tenant-lifecycle.ts
@@ -1,0 +1,90 @@
+import { type Database, tenantHubspotOauth, tenants } from "@hap/db";
+import { eq } from "drizzle-orm";
+import { invalidateTenantConfig } from "./config-resolver";
+
+type LifecycleDeps = {
+  db: Database;
+  tenantId: string;
+};
+
+export type DeactivateTenantArgs = LifecycleDeps & {
+  reason: string;
+  deactivatedAt?: Date;
+};
+
+export type ReactivateTenantArgs = LifecycleDeps;
+export type HubSpotLifecycleEventType = "app_install" | "app_uninstall";
+
+export type ApplyHubSpotLifecycleEventArgs = {
+  db: Database;
+  portalId: string;
+  eventType: HubSpotLifecycleEventType;
+  occurredAt?: Date;
+};
+
+export async function deactivateTenant(args: DeactivateTenantArgs): Promise<void> {
+  const { db, tenantId, reason } = args;
+  const deactivatedAt = args.deactivatedAt ?? new Date();
+
+  await db.transaction(async (tx) => {
+    const txDb = tx as unknown as Database;
+
+    await txDb
+      .update(tenants)
+      .set({
+        isActive: false,
+        deactivatedAt,
+        deactivationReason: reason,
+        updatedAt: new Date(),
+      })
+      .where(eq(tenants.id, tenantId));
+
+    await txDb.delete(tenantHubspotOauth).where(eq(tenantHubspotOauth.tenantId, tenantId));
+  });
+
+  invalidateTenantConfig(tenantId);
+}
+
+export async function reactivateTenant(args: ReactivateTenantArgs): Promise<void> {
+  const { db, tenantId } = args;
+
+  await db
+    .update(tenants)
+    .set({
+      isActive: true,
+      deactivatedAt: null,
+      deactivationReason: null,
+      updatedAt: new Date(),
+    })
+    .where(eq(tenants.id, tenantId));
+
+  invalidateTenantConfig(tenantId);
+}
+
+export async function applyHubSpotLifecycleEvent(
+  args: ApplyHubSpotLifecycleEventArgs,
+): Promise<void> {
+  const { db, portalId, eventType } = args;
+  const tenant = await db.query.tenants.findFirst({
+    where: eq(tenants.hubspotPortalId, portalId),
+  });
+
+  if (!tenant) {
+    return;
+  }
+
+  if (eventType === "app_uninstall") {
+    await deactivateTenant({
+      db,
+      tenantId: tenant.id,
+      reason: "hubspot_app_uninstalled",
+      deactivatedAt: args.occurredAt,
+    });
+    return;
+  }
+
+  await reactivateTenant({
+    db,
+    tenantId: tenant.id,
+  });
+}

--- a/apps/api/src/middleware/tenant.ts
+++ b/apps/api/src/middleware/tenant.ts
@@ -55,6 +55,9 @@ export function tenantMiddleware(
     if (!tenant) {
       return c.json({ error: "unauthorized", detail: "tenant not found" }, 401);
     }
+    if (!tenant.isActive) {
+      return c.json({ error: "tenant_inactive", detail: "tenant is deactivated" }, 401);
+    }
 
     c.set("tenantId", tenant.id);
     c.set("tenant", tenant);

--- a/apps/api/src/routes/__tests__/oauth.test.ts
+++ b/apps/api/src/routes/__tests__/oauth.test.ts
@@ -313,6 +313,14 @@ describe("GET /oauth/callback — happy paths", () => {
       deactivatedAt: new Date("2026-04-17T14:00:00.000Z"),
     });
 
+    const [afterDeactivate] = await db
+      .select()
+      .from(schema.tenants)
+      .where(eq(schema.tenants.id, seededTenant.id));
+    expect(afterDeactivate?.isActive).toBe(false);
+    expect(afterDeactivate?.deactivatedAt).toBeTruthy();
+    expect(afterDeactivate?.deactivationReason).toBe("hubspot_app_uninstalled");
+
     const state2 = signState({
       secret: CONFIG.clientSecret,
       ttlSeconds: CONFIG.stateTtlSeconds,

--- a/apps/api/src/routes/__tests__/oauth.test.ts
+++ b/apps/api/src/routes/__tests__/oauth.test.ts
@@ -30,6 +30,7 @@ import { eq, like } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { decryptProviderKey } from "../../lib/encryption";
 import { signState } from "../../lib/oauth";
+import { deactivateTenant } from "../../lib/tenant-lifecycle";
 import { createOAuthRoutes } from "../oauth";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -273,6 +274,62 @@ describe("GET /oauth/callback — happy paths", () => {
     expect(access2).toBe(refreshBody.access_token);
 
     await db.delete(schema.tenants).where(eq(schema.tenants.id, tenantId));
+  });
+
+  it("reactivates an existing deactivated tenant on reinstall", async () => {
+    const ident = identityResponseForPortal(`${PORTAL_PREFIX}${randomUUID().slice(0, 4)}`);
+    const exchange = loadCassette("oauth-token-exchange.json");
+    const refresh = loadCassette("oauth-token-refresh.json");
+
+    const routes = createOAuthRoutes({
+      config: CONFIG,
+      db,
+      fetch: fakeFetchSequence([
+        { status: exchange.response.status, body: exchange.response.body },
+        { status: ident.status, body: ident.body },
+        { status: refresh.response.status, body: refresh.response.body },
+        { status: ident.status, body: ident.body },
+      ]),
+    });
+
+    const state1 = signState({
+      secret: CONFIG.clientSecret,
+      ttlSeconds: CONFIG.stateTtlSeconds,
+    });
+    await routes.request(`/callback?code=code-1&state=${encodeURIComponent(state1)}`);
+
+    const [seededTenant] = await db
+      .select()
+      .from(schema.tenants)
+      .where(eq(schema.tenants.hubspotPortalId, ident.portalIdAsText));
+    if (!seededTenant) {
+      throw new Error("seeded tenant missing after first install");
+    }
+
+    await deactivateTenant({
+      db,
+      tenantId: seededTenant.id,
+      reason: "hubspot_app_uninstalled",
+      deactivatedAt: new Date("2026-04-17T14:00:00.000Z"),
+    });
+
+    const state2 = signState({
+      secret: CONFIG.clientSecret,
+      ttlSeconds: CONFIG.stateTtlSeconds,
+    });
+    await routes.request(`/callback?code=code-2&state=${encodeURIComponent(state2)}`);
+
+    const [tenantRow] = await db
+      .select()
+      .from(schema.tenants)
+      .where(eq(schema.tenants.hubspotPortalId, ident.portalIdAsText));
+
+    expect(tenantRow?.id).toBe(seededTenant.id);
+    expect(tenantRow?.isActive).toBe(true);
+    expect(tenantRow?.deactivatedAt).toBeNull();
+    expect(tenantRow?.deactivationReason).toBeNull();
+
+    await db.delete(schema.tenants).where(eq(schema.tenants.id, seededTenant.id));
   });
 });
 

--- a/apps/api/src/routes/__tests__/settings.test.ts
+++ b/apps/api/src/routes/__tests__/settings.test.ts
@@ -62,6 +62,34 @@ afterAll(async () => {
 });
 
 describe("GET /api/settings", () => {
+  it("returns 401 when the resolved tenant is deactivated", async () => {
+    const [tenant] = await db
+      .insert(tenants)
+      .values({
+        hubspotPortalId: portalId(),
+        name: "Inactive Settings Tenant",
+        isActive: false,
+        deactivatedAt: new Date("2026-04-17T15:00:00.000Z"),
+        deactivationReason: "hubspot_app_uninstalled",
+      })
+      .returning();
+    if (!tenant) throw new Error("failed to seed inactive tenant");
+
+    const app = await loadApp();
+    const res = await app.request("/api/settings", {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+      },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string; detail: string };
+    expect(body.error).toBe("tenant_inactive");
+    expect(body.detail).toBe("tenant is deactivated");
+  });
+
   it("returns the default settings shape for a tenant with no config rows", async () => {
     const tenant = await seedTenant();
     const app = await loadApp();

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -216,7 +216,12 @@ export function createOAuthRoutes(deps: OAuthDeps) {
       })
       .onConflictDoUpdate({
         target: tenants.hubspotPortalId,
-        set: { updatedAt: sql`now()` },
+        set: {
+          isActive: true,
+          deactivatedAt: null,
+          deactivationReason: null,
+          updatedAt: sql`now()`,
+        },
       })
       .returning();
 

--- a/apps/api/src/routes/snapshot.ts
+++ b/apps/api/src/routes/snapshot.ts
@@ -324,6 +324,12 @@ snapshotRoutes.post("/:companyId", async (c) => {
     return c.json(snapshot, 200);
   } catch (err) {
     if (isTenantAccessRevokedError(err)) {
+      console.warn("snapshot_route.tenant_access_revoked", {
+        tenantId,
+        companyId,
+        eligibilityMode: mode,
+        errorClass: err instanceof Error ? err.constructor.name : typeof err,
+      });
       return c.json(
         {
           error: "tenant_access_revoked",

--- a/apps/api/src/routes/snapshot.ts
+++ b/apps/api/src/routes/snapshot.ts
@@ -12,6 +12,7 @@ import type { LlmAdapter } from "../adapters/llm-adapter";
 import type { ProviderAdapter } from "../adapters/provider-adapter";
 import { createSignalAdapter, wrapSignalWithGuards } from "../adapters/signal/factory";
 import { DEFAULT_THRESHOLDS, getLlmConfig, getProviderConfig } from "../lib/config-resolver";
+import { TenantAccessRevokedError } from "../lib/hubspot-client";
 import { getProcessRateLimiter } from "../lib/rate-limiter";
 import type { CorrelationVariables } from "../middleware/correlation";
 import type { TenantVariables } from "../middleware/tenant";
@@ -237,6 +238,13 @@ function pickPropertyFetcher(mode: EligibilityMode): CompanyPropertyFetcher {
   }
 }
 
+function isTenantAccessRevokedError(error: unknown): boolean {
+  return (
+    error instanceof TenantAccessRevokedError ||
+    (error instanceof Error && error.name === "TenantAccessRevokedError")
+  );
+}
+
 /**
  * V1 fixture contact fetcher — returns three ICP-shaped contacts for any
  * company. Step 9+ replace with a real HubSpot contact association fetch.
@@ -315,6 +323,15 @@ snapshotRoutes.post("/:companyId", async (c) => {
     );
     return c.json(snapshot, 200);
   } catch (err) {
+    if (isTenantAccessRevokedError(err)) {
+      return c.json(
+        {
+          error: "tenant_access_revoked",
+          detail: "hubspot access revoked or app uninstalled for tenant",
+        },
+        401,
+      );
+    }
     // Log a stable error CLASS + safe request context. Never the raw
     // err.message — external clients can smuggle URLs / tenant data / auth
     // material into Error.message and we don't want that in shared logs.

--- a/apps/api/src/services/__tests__/snapshot-assembler.test.ts
+++ b/apps/api/src/services/__tests__/snapshot-assembler.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { createMockLlmAdapter } from "../../adapters/mock-llm-adapter";
 import { createMockSignalAdapter } from "../../adapters/mock-signal-adapter";
 import type { ProviderAdapter } from "../../adapters/provider-adapter";
+import { TenantAccessRevokedError } from "../../lib/hubspot-client";
 import type { CompanyPropertyFetcher } from "../eligibility";
 import { clearEligibilityCache } from "../eligibility";
 import type { ContactFetcher } from "../people-selector";
@@ -138,6 +139,29 @@ describe("assembleSnapshot", () => {
     for (const ev of snap.evidence) {
       expect(ev.tenantId).toBe(tenantId);
     }
+  });
+
+  it("rethrows tenant access revocation instead of downgrading it to a degraded snapshot", async () => {
+    const tenantId = await seedTenant();
+    const revokedProvider: ProviderAdapter = {
+      name: "hubspot-enrichment",
+      fetchSignals: async () => {
+        throw new TenantAccessRevokedError();
+      },
+    };
+
+    await expect(
+      assembleSnapshot(
+        {
+          db,
+          providerAdapter: revokedProvider,
+          propertyFetcher: ELIGIBLE,
+          contactFetcher: threeContacts,
+          thresholds: THRESHOLDS,
+        },
+        { tenantId, companyId: "co-revoked" },
+      ),
+    ).rejects.toBeInstanceOf(TenantAccessRevokedError);
   });
 
   it("returns reason with empty people when signal exists but 0 contacts", async () => {

--- a/apps/api/src/services/snapshot-assembler.ts
+++ b/apps/api/src/services/snapshot-assembler.ts
@@ -32,6 +32,7 @@ import {
 import type { Database } from "@hap/db";
 import type { LlmAdapter } from "../adapters/llm-adapter";
 import type { ProviderAdapter } from "../adapters/provider-adapter";
+import { TenantAccessRevokedError } from "../lib/hubspot-client";
 import { type CompanyPropertyFetcher, checkEligibility } from "./eligibility";
 import { dedupEvidence } from "./hygiene/dedup";
 import { sweepStaleness } from "./hygiene/staleness-sweeper";
@@ -120,6 +121,9 @@ export async function assembleSnapshot(
   try {
     signals = await deps.providerAdapter.fetchSignals(tenantId, { companyId });
   } catch (err) {
+    if (err instanceof TenantAccessRevokedError) {
+      throw err;
+    }
     // Transport error → mark degraded; continue with empty signal set.
     // Log a STABLE error code/class only — never the raw message. External
     // adapter errors can smuggle request URLs, tenant data, or auth material

--- a/apps/hubspot-extension/src/index.test.tsx
+++ b/apps/hubspot-extension/src/index.test.tsx
@@ -2,6 +2,7 @@ import { Alert, Text } from "@hubspot/ui-extensions";
 import { createRenderer } from "@hubspot/ui-extensions/testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { collectAllText } from "./features/snapshot/components/__tests__/test-utils";
+import { ApiFetcherError } from "./features/snapshot/hooks/api-fetcher";
 import * as companyHooks from "./features/snapshot/hooks/use-company-context";
 import * as snapshotHooks from "./features/snapshot/hooks/use-snapshot";
 import { Extension } from "./index";
@@ -180,6 +181,30 @@ describe("HubSpot crm.record.tab extension smoke test", () => {
 
     await renderer.waitFor(() => {
       expect(renderer.find(Text).text).toBe("Error");
+    });
+  });
+
+  it("renders reconnect guidance when the snapshot fetch returns a lifecycle 401", async () => {
+    const renderer = createRenderer("crm.record.tab");
+    const fetchCrmObjectProperties = vi.fn(async () => ({
+      name: "Acme",
+      domain: "acme.test",
+      hs_is_target_account: "true",
+    }));
+    const snapshotFetcher = vi.fn(async () => {
+      throw new ApiFetcherError(401, "Unauthorized");
+    });
+
+    renderer.render(
+      <Extension
+        context={renderer.mocks.context}
+        fetchCrmObjectProperties={fetchCrmObjectProperties}
+        snapshotFetcher={snapshotFetcher}
+      />,
+    );
+
+    await renderer.waitFor(() => {
+      expect(collectAllText(renderer.getRootNode())).toContain("Reconnect HubSpot");
     });
   });
 });

--- a/apps/hubspot-extension/src/shared/extension-root.tsx
+++ b/apps/hubspot-extension/src/shared/extension-root.tsx
@@ -5,7 +5,7 @@ import {
 } from "@hubspot/ui-extensions";
 import { useMemo } from "react";
 import { SnapshotStateRenderer } from "../features/snapshot/components/snapshot-state-renderer";
-import { createHubSpotApiFetcher } from "../features/snapshot/hooks/api-fetcher";
+import { ApiFetcherError, createHubSpotApiFetcher } from "../features/snapshot/hooks/api-fetcher";
 import { useCompanyContext } from "../features/snapshot/hooks/use-company-context";
 import { type SnapshotFetcher, useSnapshot } from "../features/snapshot/hooks/use-snapshot";
 
@@ -45,6 +45,9 @@ export const ExtensionRoot = ({
   }
 
   if (snapshotState.error) {
+    if (snapshotState.error instanceof ApiFetcherError && snapshotState.error.status === 401) {
+      return <Text>Reconnect HubSpot in app settings to restore access.</Text>;
+    }
     return <Text>Error</Text>;
   }
 

--- a/docs/phase-6-doc-alignment.md
+++ b/docs/phase-6-doc-alignment.md
@@ -24,14 +24,19 @@ Use these as the primary execution stack for Slice 6:
 5. `.taskmaster/docs/prd.md`
 6. `planning/chatprd/AI_CODING_RULES_AND_STANDARDS.md`
 7. `planning/local/TASKMASTER_EXECUTION_PRD.md`
-8. `docs/slice-3-preflight-notes.md`
-9. `docs/slice-5-preflight-notes.md`
+8. `docs/slice-6-preflight-notes.md`
+9. `docs/runbooks/tenant-offboarding.md`
+10. `docs/security/slice-6-audit.md`
+11. `docs/slice-3-preflight-notes.md`
+12. `docs/slice-5-preflight-notes.md`
 
 Why these matter:
 
 - the Slice 6 plan is the active implementation contract
 - `SECURITY.md` already captures the shipped OAuth, RLS, replay-nonce, and
   settings guarantees that Slice 6 must preserve
+- the Slice 6 preflight, offboarding runbook, and audit note lock the actual
+  lifecycle contract and operational handling for this slice
 - `.taskmaster/docs/prd.md` and the local execution PRD still define the wedge
   boundaries and what remains out of scope
 - Slice 3 and Slice 5 preflight notes are still relevant because Slice 6 builds

--- a/docs/phase-6-doc-alignment.md
+++ b/docs/phase-6-doc-alignment.md
@@ -1,0 +1,89 @@
+# Phase 6 Doc Alignment
+
+Date: 2026-04-17
+
+Purpose: confirm the active planning and execution documents for Slice 6 before
+any implementation work starts.
+
+## Conclusion
+
+The planning stack is still sound. The next engineering slice should be driven
+by the new Slice 6 plan plus the existing repo-local execution/security docs.
+
+The main maintenance issue remains path drift in older planning references, not
+missing product direction.
+
+## Active Slice 6 Source Of Truth
+
+Use these as the primary execution stack for Slice 6:
+
+1. `.claude/tasks/2026-04-17-slice-6-install-lifecycle-offboarding.md`
+2. `CLAUDE.md`
+3. `AGENTS.md`
+4. `docs/security/SECURITY.md`
+5. `.taskmaster/docs/prd.md`
+6. `planning/chatprd/AI_CODING_RULES_AND_STANDARDS.md`
+7. `planning/local/TASKMASTER_EXECUTION_PRD.md`
+8. `docs/slice-3-preflight-notes.md`
+9. `docs/slice-5-preflight-notes.md`
+
+Why these matter:
+
+- the Slice 6 plan is the active implementation contract
+- `SECURITY.md` already captures the shipped OAuth, RLS, replay-nonce, and
+  settings guarantees that Slice 6 must preserve
+- `.taskmaster/docs/prd.md` and the local execution PRD still define the wedge
+  boundaries and what remains out of scope
+- Slice 3 and Slice 5 preflight notes are still relevant because Slice 6 builds
+  directly on the OAuth install model and the production/pilot contract
+
+## What We Verified
+
+- Slice 5 is fully merged on `main`
+- the repo is clean after merge
+- no Slice 5 worktree or feature branch remains
+- `tenant_hubspot_oauth` is the current per-tenant OAuth storage model
+- tenant lifecycle/offboarding is not yet an explicit first-class contract
+- earlier planning docs explicitly deferred uninstall/token-revocation follow-up
+
+## Important Existing Constraints For Slice 6
+
+- Keep the wedge narrow: no billing, no analytics/admin dashboard expansion, no
+  transcript work.
+- Preserve tenant identity rules:
+  - `tenants.hubspot_portal_id` remains the single source of truth for portal
+    identity
+  - `tenant_hubspot_oauth` remains tenant-scoped and RLS-protected
+- Slice 6 must not weaken:
+  - RLS boundaries
+  - replay protection for signed requests
+  - settings secret-handling guarantees
+  - production/pilot environment contract from Slice 5
+
+## Slice 6 Open Questions That Must Be Locked In Preflight
+
+1. What is the authoritative lifecycle event source?
+   - webhook-driven
+   - token-failure-driven
+   - hybrid
+
+2. What exact offboarding policy is in force?
+   - current recommended default is:
+     - soft-deactivate tenant
+     - clear or invalidate OAuth credentials
+     - preserve provider/LLM config and historical app data
+     - reactivate the same tenant identity on reinstall
+
+These are already reflected in the Slice 6 plan and must be verified during
+`lifecycle-preflight`, not improvised mid-implementation.
+
+## Current Recommendation
+
+The next implementation branch should begin with:
+
+1. `lifecycle-preflight`
+2. `slice6-scope-contract`
+
+No code changes should start before those two tasks are complete, because the
+offboarding/event-source contract controls schema shape, endpoint design, and
+runtime guard behavior.

--- a/docs/runbooks/tenant-offboarding.md
+++ b/docs/runbooks/tenant-offboarding.md
@@ -1,0 +1,131 @@
+# Tenant Offboarding Runbook
+
+Date: 2026-04-17
+
+Purpose: define the operational path for HubSpot uninstall, OAuth revocation,
+tenant deactivation, and reinstall in Slice 6.
+
+## Contract
+
+Slice 6 uses a hybrid lifecycle model:
+
+- primary signal: HubSpot app lifecycle events (`app_install`, `app_uninstall`)
+- fallback signal: unrecoverable OAuth refresh failure (`invalid_grant` / revoked refresh token)
+
+Offboarding policy:
+
+- soft-deactivate the tenant
+- clear stored HubSpot OAuth credentials
+- preserve provider config, LLM config, snapshots, evidence, and people
+- reactivate the same tenant identity on reinstall
+
+Hard-delete is out of scope.
+
+## What Offboarding Changes
+
+When a tenant is offboarded:
+
+- `tenants.is_active` is set to `false`
+- `tenants.deactivated_at` is set
+- `tenants.deactivation_reason` is set
+- the `tenant_hubspot_oauth` row is removed
+- config caches for the tenant are invalidated
+
+This means:
+
+- `tenantMiddleware` blocks normal API access with `401 tenant_inactive`
+- the HubSpot client no longer treats missing OAuth as a generic runtime error
+- revoked access discovered mid-request becomes `401 tenant_access_revoked`
+
+## Trigger Paths
+
+### 1. Lifecycle event: `app_uninstall`
+
+Use this when HubSpot lifecycle processing confirms uninstall for a portal.
+
+Expected system action:
+
+- call the lifecycle service with reason `hubspot_app_uninstalled`
+- deactivate the tenant
+- remove tenant OAuth credentials
+
+Verification:
+
+- `tenants.is_active = false`
+- `tenant_hubspot_oauth` row no longer exists
+- snapshot/settings requests for that portal return `401`
+
+### 2. Runtime fallback: OAuth refresh failure
+
+Use this when HubSpot refresh fails with an unrecoverable auth error such as
+`invalid_grant` or explicit revocation language.
+
+Expected system action:
+
+- HubSpot client deactivates the tenant with reason `oauth_refresh_failed`
+- client throws `TenantAccessRevokedError`
+- snapshot route returns `401 tenant_access_revoked`
+
+Verification:
+
+- tenant row is inactive
+- OAuth row is gone
+- card UI shows reconnect guidance instead of a generic error
+
+## Reinstall Flow
+
+Reinstall must reactivate the same tenant row for the same
+`hubspot_portal_id`.
+
+Expected behavior:
+
+- existing tenant row is reused
+- `is_active` is restored to `true`
+- `deactivated_at` and `deactivation_reason` are cleared
+- OAuth row is recreated from the fresh install tokens
+
+Verification:
+
+- tenant id before and after reinstall is identical
+- exactly one tenant row exists for the portal
+- tenant is active after callback success
+
+## Manual Verification Checklist
+
+1. Start from an installed tenant with valid OAuth credentials.
+2. Confirm snapshot route succeeds for the portal.
+3. Deactivate via lifecycle service or uninstall event path.
+4. Confirm:
+   - snapshot route returns `401 tenant_inactive`
+   - settings route returns `401 tenant_inactive`
+   - no `tenant_hubspot_oauth` row remains
+5. Simulate refresh-token revocation.
+6. Confirm:
+   - HubSpot client throws `TenantAccessRevokedError`
+   - snapshot route returns `401 tenant_access_revoked`
+   - the card shows reconnect guidance
+7. Reinstall the app for the same portal.
+8. Confirm:
+   - original tenant id is reused
+   - tenant is active
+   - deactivation metadata is cleared
+   - snapshot route succeeds again
+
+## Recovery Notes
+
+- If lifecycle processing deactivates the wrong tenant, recover by:
+  - restoring the portal mapping only if the `hubspot_portal_id` is confirmed
+  - reactivating the tenant
+  - re-running OAuth install to restore credentials
+- Do not manually recreate `tenant_hubspot_oauth` rows with arbitrary values.
+  Use the OAuth install flow.
+- Do not hard-delete tenant data as part of normal uninstall recovery.
+
+## Non-Goals
+
+This runbook does not cover:
+
+- billing cancellation
+- customer-requested hard-delete
+- marketplace listing removal
+- analytics/reporting workflows

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -563,6 +563,78 @@ Slice 3 enables Postgres row-level security on every tenant-scoped data table th
 
 ## 18. Replay Nonce (Slice 3 shipped)
 
+## 20. Slice 6 Install Lifecycle And Tenant Offboarding
+
+Slice 6 makes uninstall, revocation, deactivation, and reinstall explicit
+security contracts instead of leaving them as incidental runtime behavior.
+
+### 20.1 Offboarding policy
+
+Default offboarding policy is soft-deactivate:
+
+- `tenants.is_active = false`
+- `tenants.deactivated_at` is set
+- `tenants.deactivation_reason` is set
+- the `tenant_hubspot_oauth` row is removed
+- provider config, LLM config, snapshots, evidence, and people are preserved
+
+Hard-delete is intentionally out of scope for normal uninstall handling.
+
+### 20.2 Lifecycle event model
+
+Slice 6 uses a hybrid lifecycle model:
+
+- primary signal: HubSpot app lifecycle events (`app_install`, `app_uninstall`)
+- fallback signal: unrecoverable OAuth refresh failure
+
+The fallback is security-relevant because marketplace guidance explicitly
+treats repeated unrecoverable `401` / refresh failure as a signal to stop
+using the tenant's install until re-auth occurs.
+
+### 20.3 Runtime enforcement
+
+After deactivation:
+
+- `tenantMiddleware` returns `401 { error: "tenant_inactive" }`
+- settings and snapshot routes are blocked before normal route work proceeds
+- missing tenant OAuth credentials become `TenantAccessRevokedError`
+
+If revocation is discovered during a live HubSpot-backed request:
+
+- the HubSpot client deactivates the tenant with reason
+  `oauth_refresh_failed`
+- the snapshot assembler rethrows that lifecycle loss instead of downgrading
+  it to a degraded empty snapshot
+- the snapshot route returns
+  `401 { error: "tenant_access_revoked" }`
+
+### 20.4 Reinstall safety
+
+Reinstall is keyed by `tenants.hubspot_portal_id`.
+
+Successful reinstall:
+
+- reuses the same tenant row
+- clears deactivation metadata
+- restores `is_active = true`
+- recreates OAuth credentials through the normal callback flow
+
+This prevents identity drift and duplicate-tenant creation for the same
+HubSpot portal.
+
+### 20.5 UI behavior
+
+The HubSpot card does not render lifecycle failures as a generic empty state.
+When the snapshot fetch fails with a lifecycle-related `401`, the extension
+shows reconnect guidance so the operator sees a recoverable install-state
+problem rather than an opaque failure.
+
+### 20.6 Supporting docs
+
+- `docs/slice-6-preflight-notes.md`
+- `docs/runbooks/tenant-offboarding.md`
+- `docs/security/slice-6-audit.md`
+
 HubSpot's signed-request freshness window protects against stale requests, but by itself it does not reject duplicate requests inside that window. Slice 3 closes that gap with a tenant-scoped nonce store.
 
 ### 18.1 Design

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -563,6 +563,33 @@ Slice 3 enables Postgres row-level security on every tenant-scoped data table th
 
 ## 18. Replay Nonce (Slice 3 shipped)
 
+HubSpot's signed-request freshness window protects against stale requests, but by itself it does not reject duplicate requests inside that window. Slice 3 closes that gap with a tenant-scoped nonce store.
+
+### 18.1 Design
+
+- Table: `signed_request_nonce`
+- Primary key: `(tenant_id, timestamp, body_hash)`
+- `body_hash` is raw SHA-256 over the exact raw request body captured by `hubspot-signature.ts`
+- `nonceMiddleware()` runs after auth, tenant resolution, and request-scoped DB injection
+- On duplicate insert, the request is rejected with `401 { error: "replay_detected" }`
+
+### 18.2 Why it is tenant-scoped
+
+- Two tenants can receive identical HubSpot payloads at the same timestamp without colliding.
+- The nonce is bound to the resolved internal tenant ID, not just to the body hash.
+- RLS additionally protects nonce rows from cross-tenant reads/writes.
+
+### 18.3 Lifecycle
+
+- `recordNonce()` uses `INSERT ... ON CONFLICT DO NOTHING`, so duplicate detection is atomic.
+- `sweepExpiredNonces()` removes rows older than the replay window buffer.
+- `scripts/sweep-nonces.ts` provides the operational sweep hook.
+
+### 18.4 Verification notes
+
+- Unit tests cover duplicate detection, cross-tenant independence, and TTL sweeping.
+- Middleware tests prove the same signed request succeeds once and then fails with `replay_detected` on the second call within the freshness window.
+
 ## 20. Slice 6 Install Lifecycle And Tenant Offboarding
 
 Slice 6 makes uninstall, revocation, deactivation, and reinstall explicit
@@ -634,30 +661,3 @@ problem rather than an opaque failure.
 - `docs/slice-6-preflight-notes.md`
 - `docs/runbooks/tenant-offboarding.md`
 - `docs/security/slice-6-audit.md`
-
-HubSpot's signed-request freshness window protects against stale requests, but by itself it does not reject duplicate requests inside that window. Slice 3 closes that gap with a tenant-scoped nonce store.
-
-### 18.1 Design
-
-- Table: `signed_request_nonce`
-- Primary key: `(tenant_id, timestamp, body_hash)`
-- `body_hash` is raw SHA-256 over the exact raw request body captured by `hubspot-signature.ts`
-- `nonceMiddleware()` runs after auth, tenant resolution, and request-scoped DB injection
-- On duplicate insert, the request is rejected with `401 { error: "replay_detected" }`
-
-### 18.2 Why it is tenant-scoped
-
-- Two tenants can receive identical HubSpot payloads at the same timestamp without colliding.
-- The nonce is bound to the resolved internal tenant ID, not just to the body hash.
-- RLS additionally protects nonce rows from cross-tenant reads/writes.
-
-### 18.3 Lifecycle
-
-- `recordNonce()` uses `INSERT ... ON CONFLICT DO NOTHING`, so duplicate detection is atomic.
-- `sweepExpiredNonces()` removes rows older than the replay window buffer.
-- `scripts/sweep-nonces.ts` provides the operational sweep hook.
-
-### 18.4 Verification notes
-
-- Unit tests cover duplicate detection, cross-tenant independence, and TTL sweeping.
-- Middleware tests prove the same signed request succeeds once and then fails with `replay_detected` on the second call within the freshness window.

--- a/docs/security/slice-6-audit.md
+++ b/docs/security/slice-6-audit.md
@@ -1,0 +1,91 @@
+# Slice 6 Security Audit
+
+Date: 2026-04-17
+
+Scope:
+
+- tenant lifecycle state
+- uninstall/offboarding behavior
+- runtime revocation handling
+- reinstall identity safety
+
+## Results
+
+### 1. Stale credential retention
+
+PASS
+
+Why:
+
+- offboarding deletes `tenant_hubspot_oauth`
+- refresh-token revocation path also deactivates the tenant and removes the
+  OAuth row
+- reinstall restores credentials through the normal OAuth callback flow
+
+Residual risk:
+
+- the primary lifecycle source is journal-based, so operational freshness
+  still depends on the lifecycle ingestion mechanism being run correctly
+
+### 2. Continued tenant access after uninstall
+
+PASS
+
+Why:
+
+- `tenantMiddleware` rejects inactive tenants with `401 tenant_inactive`
+- snapshot route converts mid-request credential revocation into
+  `401 tenant_access_revoked`
+- settings route is protected by the same tenant middleware
+
+### 3. Reinstall identity drift
+
+PASS
+
+Why:
+
+- reinstall upserts on `tenants.hubspot_portal_id`
+- successful reinstall explicitly reactivates the same tenant row
+- tests prove the same tenant id is reused after deactivation
+
+### 4. Lifecycle signal verification gaps
+
+PASS with documented limitation
+
+Why:
+
+- Slice 6 does not invent an inbound webhook contract that HubSpot does not
+  actually provide for this flow
+- the slice locks the authoritative model as hybrid:
+  - lifecycle event processing is primary
+  - unrecoverable OAuth refresh failure is fallback
+
+Limitation:
+
+- primary lifecycle ingestion is documented but not yet implemented as a live
+  journal consumer in this slice checkpoint, so fallback coverage is stronger
+  than primary-event automation
+
+### 5. Cross-tenant leakage during transitions
+
+PASS
+
+Why:
+
+- tenant identity remains keyed by `hubspot_portal_id`
+- tenant-owned rows remain RLS-protected
+- reactivation and deactivation operate on the resolved tenant row, not on
+  caller-supplied tenant ids
+- reinstall tests verify no duplicate tenant identity is created
+
+## Conclusion
+
+Slice 6 closes the main lifecycle security gaps left after Slice 5:
+
+- revoked credentials no longer linger ambiguously
+- uninstalled tenants no longer behave like healthy tenants
+- reinstall is repeatable and identity-safe
+
+The remaining gap is operational completeness of the primary HubSpot lifecycle
+event ingestion path, not a known isolation or credential-retention flaw in
+the implemented runtime behavior.

--- a/docs/slice-6-preflight-notes.md
+++ b/docs/slice-6-preflight-notes.md
@@ -1,0 +1,223 @@
+# Slice 6 Preflight Notes
+
+Date: 2026-04-17
+
+Purpose: lock the install-lifecycle and tenant-offboarding contract before any
+Slice 6 implementation begins.
+
+## 1. Verified external inputs
+
+### 1.1 HubSpot app lifecycle events exist
+
+Official HubSpot docs now expose app lifecycle events through the Webhooks
+Journal API:
+
+- `subscriptionType: "APP_LIFECYCLE_EVENT"`
+- install event type id: `4-1909196`
+- uninstall event type id: `4-1916193`
+
+The docs say to create these subscriptions with a **client credentials token**
+via `POST /webhooks/v4/subscriptions`, then read lifecycle events from the
+journal.
+
+Verified source:
+
+- HubSpot docs: `Webhooks journal and management APIs (BETA)`
+  - lines 203-215 in the current public docs snapshot
+
+### 1.2 HubSpot explicitly supports app uninstall by API
+
+HubSpot now documents a public uninstall endpoint:
+
+- `DELETE /appinstalls/v3/external-install`
+
+This endpoint:
+
+- requires an active OAuth access token for the installed account
+- uninstalls the app from that customer account
+- removes app features from the account
+- unsubscribes configured webhooks for that account
+
+Verified sources:
+
+- HubSpot docs: `App Uninstalls / Uninstall app`
+- HubSpot changelog: `Public Beta: New API for uninstalling a public app from a HubSpot account`
+
+### 1.3 HubSpot certification guidance implies a token-failure fallback rule
+
+HubSpot marketplace/certification guidance explicitly says:
+
+- apps should refresh OAuth tokens before expiry
+- if the app starts receiving `401` errors for 100% of requests and is unable
+  to refresh the access token, the app should treat the account as uninstalled
+  and stop making requests until the user re-authenticates
+
+This is important because it means lifecycle handling cannot rely only on a
+future webhook arriving. Runtime token failure is an officially recommended
+signal for lifecycle handling too.
+
+Verified source:
+
+- HubSpot docs: `HubSpot Marketplace certification requirements`
+
+### 1.4 Current HubSpot auth/platform guidance still matches the shipped app
+
+Current authentication docs still confirm:
+
+- OAuth is required for multi-account installs
+- `distribution` must be `marketplace` or `private` for OAuth apps
+- client credentials tokens are used for app-global management features, and
+  the Webhooks Journal API is the current documented example
+
+Verified source:
+
+- HubSpot docs: `Authentication overview`
+
+## 2. Verified repo-local starting point
+
+### 2.1 Current tenant lifecycle model is partial, not explicit
+
+The current `tenants` schema already has:
+
+- `id`
+- `hubspot_portal_id`
+- `name`
+- `is_active`
+
+This means Slice 6 does **not** need to invent lifecycle from nothing.
+However:
+
+- `isActive` is not yet enforced in tenant middleware
+- there is no explicit offboarding reason/timestamp model
+- there is no explicit reinstall/reactivation contract
+
+### 2.2 Current OAuth storage model is still correct
+
+The current token storage model remains:
+
+- `tenant_hubspot_oauth`
+- keyed 1:1 by `tenant_id`
+- no duplicated `hub_id`
+- protected by RLS
+
+This should remain the core credential store in Slice 6.
+
+### 2.3 Current runtime behavior is not yet lifecycle-aware
+
+Current runtime shape:
+
+- `tenantMiddleware()` resolves tenants by `hubspot_portal_id`
+- it does not yet reject inactive/deactivated tenants
+- `HubSpotClient` resolves tokens from `tenant_hubspot_oauth`
+- missing or broken token state currently fails as generic runtime errors
+
+So Slice 6 should add explicit lifecycle handling rather than treating token
+loss as an incidental backend failure.
+
+## 3. Locked Slice 6 lifecycle-event-source decision
+
+### Decision: hybrid model
+
+Slice 6 should use a **hybrid lifecycle signal model**:
+
+1. **Primary source:** HubSpot app lifecycle events through the Webhooks
+   Journal API (`APP_LIFECYCLE_EVENT`, including `app_uninstall`)
+2. **Fallback source:** token-failure-driven revocation/uninstall inference
+   when:
+   - HubSpot API calls start failing with unrecoverable auth errors
+   - token refresh fails or becomes impossible
+   - continued app activity should stop immediately
+
+### Why this is the right choice
+
+- HubSpot now provides a real lifecycle signal path, so we should use it
+- HubSpot certification guidance also explicitly treats unrecoverable auth
+  failure as an uninstall/disconnect indicator
+- relying on only one of these would be too brittle:
+  - webhook-only risks lag or subscription misconfiguration
+  - token-failure-only loses the explicit install/uninstall lifecycle signal
+
+## 4. Locked offboarding data policy
+
+### Decision: soft-deactivate tenant, disable OAuth access, preserve app data
+
+Default Slice 6 offboarding policy:
+
+- tenant is **soft-deactivated**
+- stored HubSpot OAuth credentials are **cleared or made unusable**
+- provider/LLM config and historical app data are **preserved**
+- reinstall for the same portal **reactivates the same tenant identity**
+- hard-delete is **out of scope** unless a later legal/compliance requirement
+  forces it
+
+### Why this is the right choice
+
+- it matches the existing tenant-centric data model better than destructive
+  cleanup
+- it supports reinstall without identity duplication
+- it avoids turning uninstall into irreversible data loss
+- it keeps future explicit delete flows available without conflating them with
+  normal uninstall
+
+## 5. Implementation implications
+
+### 5.1 Schema/model
+
+Slice 6 should start by evaluating whether the current `tenants.is_active`
+column can become the lifecycle backbone, possibly extended with fields like:
+
+- `deactivated_at`
+- `deactivation_reason`
+- optional OAuth invalidation metadata
+
+The slice should avoid over-modeling until tests prove extra fields are needed.
+
+### 5.2 Runtime guards
+
+After offboarding:
+
+- snapshot route must not behave as if the tenant is still healthy/installed
+- settings route must not allow normal mutation under a deactivated tenant
+- HubSpot client must stop retrying as if credentials are still valid forever
+
+### 5.3 Reinstall
+
+Reinstall for the same portal should:
+
+- reuse the same tenant row
+- restore OAuth access cleanly
+- avoid duplicate tenant identity or split lifecycle state
+
+## 6. What Slice 6 will not do
+
+Still out of scope:
+
+- billing
+- marketplace listing copy/assets submission
+- analytics/admin dashboards
+- hard-delete customer data as the default uninstall path
+
+## 7. Recommended task order
+
+Implementation should begin with:
+
+1. `lifecycle-preflight` — complete with this note
+2. `slice6-scope-contract` — lock hybrid lifecycle source + soft-deactivate policy
+3. `tenant-lifecycle-model`
+4. `lifecycle-service`
+
+No route/client implementation should start before the lifecycle source and
+offboarding policy are treated as hard decisions.
+
+## 8. Source summary
+
+Verified from official HubSpot docs:
+
+- Webhooks Journal API supports `APP_LIFECYCLE_EVENT` subscriptions and
+  `app_install` / `app_uninstall` events
+- HubSpot supports `DELETE /appinstalls/v3/external-install` for uninstalling
+  an app from a customer account
+- marketplace/certification guidance treats unrecoverable OAuth failure as a
+  signal to stop treating the account as installed
+- client credentials tokens are the documented auth model for Webhooks Journal
+  management

--- a/docs/slice-6-preflight-notes.md
+++ b/docs/slice-6-preflight-notes.md
@@ -87,9 +87,9 @@ The current `tenants` schema already has:
 This means Slice 6 does **not** need to invent lifecycle from nothing.
 However:
 
-- `isActive` is not yet enforced in tenant middleware
-- there is no explicit offboarding reason/timestamp model
-- there is no explicit reinstall/reactivation contract
+- `isActive` is now enforced in tenant middleware
+- the tenant schema now includes explicit offboarding reason/timestamp metadata
+- reinstall/reactivation is now explicit and keyed to the same tenant identity
 
 ### 2.2 Current OAuth storage model is still correct
 
@@ -107,9 +107,9 @@ This should remain the core credential store in Slice 6.
 Current runtime shape:
 
 - `tenantMiddleware()` resolves tenants by `hubspot_portal_id`
-- it does not yet reject inactive/deactivated tenants
+- it now rejects inactive/deactivated tenants with a lifecycle-specific `401`
 - `HubSpotClient` resolves tokens from `tenant_hubspot_oauth`
-- missing or broken token state currently fails as generic runtime errors
+- missing tenant OAuth becomes `TenantAccessRevokedError`
 
 So Slice 6 should add explicit lifecycle handling rather than treating token
 loss as an incidental backend failure.

--- a/packages/db/drizzle/0008_tenant_lifecycle_columns.sql
+++ b/packages/db/drizzle/0008_tenant_lifecycle_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "tenants"
+  ADD COLUMN IF NOT EXISTS "deactivated_at" timestamptz,
+  ADD COLUMN IF NOT EXISTS "deactivation_reason" text;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776400002000,
       "tag": "0007_rls_policies",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776453600000,
+      "tag": "0008_tenant_lifecycle_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/schema.test.ts
+++ b/packages/db/src/__tests__/schema.test.ts
@@ -56,6 +56,26 @@ describe("schema: tenants", () => {
     expect(inserted?.id).toMatch(/^[0-9a-f-]{36}$/);
     expect(inserted?.settings).toEqual({ region: "us" });
     expect(inserted?.isActive).toBe(true);
+    expect(inserted?.deactivatedAt).toBeNull();
+    expect(inserted?.deactivationReason).toBeNull();
+  });
+
+  it("persists explicit offboarding metadata without deleting the tenant row", async () => {
+    const deactivatedAt = new Date("2026-04-17T10:30:00.000Z");
+    const [inserted] = await db
+      .insert(tenants)
+      .values({
+        hubspotPortalId: portalId(),
+        name: "Offboarded Acme",
+        isActive: false,
+        deactivatedAt,
+        deactivationReason: "hubspot_app_uninstalled",
+      })
+      .returning();
+
+    expect(inserted?.isActive).toBe(false);
+    expect(inserted?.deactivatedAt).toEqual(deactivatedAt);
+    expect(inserted?.deactivationReason).toBe("hubspot_app_uninstalled");
   });
 });
 

--- a/packages/db/src/schema/__tests__/slice6-tenant-lifecycle.test.ts
+++ b/packages/db/src/schema/__tests__/slice6-tenant-lifecycle.test.ts
@@ -1,0 +1,50 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as schema from "../../schema";
+
+type TenantColumnRow = {
+  column_name: string;
+  is_nullable: "YES" | "NO";
+  data_type: string;
+};
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
+
+const sql = postgres(DATABASE_URL, { max: 2 });
+drizzle(sql, { schema });
+
+beforeAll(async () => {
+  await sql`SELECT 1`;
+});
+
+afterAll(async () => {
+  await sql.end({ timeout: 5 });
+});
+
+describe("slice6: tenant lifecycle schema", () => {
+  it("adds nullable deactivated_at and deactivation_reason columns to tenants", async () => {
+    const rows = await sql<TenantColumnRow[]>`
+      SELECT column_name, is_nullable, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'tenants'
+        AND column_name IN ('deactivated_at', 'deactivation_reason')
+      ORDER BY column_name
+    `;
+
+    expect(rows).toEqual([
+      {
+        column_name: "deactivated_at",
+        is_nullable: "YES",
+        data_type: "timestamp with time zone",
+      },
+      {
+        column_name: "deactivation_reason",
+        is_nullable: "YES",
+        data_type: "text",
+      },
+    ]);
+  });
+});

--- a/packages/db/src/schema/tenants.ts
+++ b/packages/db/src/schema/tenants.ts
@@ -5,6 +5,8 @@ export const tenants = pgTable("tenants", {
   hubspotPortalId: text("hubspot_portal_id").notNull().unique(),
   name: text("name").notNull(),
   isActive: boolean("is_active").notNull().default(true),
+  deactivatedAt: timestamp("deactivated_at", { withTimezone: true }),
+  deactivationReason: text("deactivation_reason"),
   settings: jsonb("settings").default({}),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),


### PR DESCRIPTION
## Summary
- add explicit tenant lifecycle state and service support for uninstall/offboarding
- handle revoked HubSpot OAuth access as lifecycle loss, including reinstall reactivation
- add lifecycle runtime/UI states plus runbook and security audit docs

## Validation
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm db:migrate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements an explicit tenant install lifecycle for HubSpot: soft-deactivate on uninstall or unrecoverable OAuth revocation, block access with clear 401s, and reactivate on reinstall. Adds lifecycle docs and hardens refresh handling to avoid false deactivations.

- **New Features**
  - Lifecycle fields on `tenants` (`deactivated_at`, `deactivation_reason`) and a service: `deactivateTenant`, `reactivateTenant`, `applyHubSpotLifecycleEvent`.
  - `HubSpotClient`: unrecoverable refresh deactivates the tenant, removes `tenant_hubspot_oauth`, and throws `TenantAccessRevokedError`; missing tokens now throw `TenantAccessRevokedError` (no auto-deactivate); guards stale refresh-token races to prevent false deactivation.
  - Middleware rejects inactive tenants with `401 tenant_inactive`; snapshot route maps mid-request revocation to `401 tenant_access_revoked` (assembler rethrows instead of degrading).
  - OAuth callback upsert reactivates existing tenants by `hubspot_portal_id` and clears deactivation metadata.
  - HubSpot extension shows “Reconnect HubSpot” guidance on lifecycle-related 401s.
  - Docs updated: lifecycle in `README`, offboarding runbook, security audit, and preflight notes.

- **Migration**
  - Run: `pnpm db:migrate` to add lifecycle columns to `tenants`.

<sup>Written for commit 329bf9dfcdfdd8590dc37ebbb62c1f2ba0264757. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Slice 6: Install Lifecycle and Tenant Offboarding — Release Notes

## One-line summary
Adds explicit tenant lifecycle state, automatic offboarding on HubSpot uninstall/unrecoverable OAuth revocation, reactivation on reinstall, middleware enforcement, error types, tests, migrations, and docs to ensure secure, traceable tenant lifecycle handling.

## Key changes (traceable to files)
- Tenant lifecycle columns (DB migration)
  - packages/db/drizzle/0008_tenant_lifecycle_columns.sql
  - packages/db/src/schema/tenants.ts

- Lifecycle service and types
  - apps/api/src/lib/tenant-lifecycle.ts
  - Exports: deactivateTenant, reactivateTenant, applyHubSpotLifecycleEvent, TenantDeactivationReason

- HubSpot client lifecycle integration
  - apps/api/src/lib/hubspot-client.ts
  - Adds TenantAccessRevokedError; unrecoverable refresh -> deactivateTenant + throw TenantAccessRevokedError

- Middleware / route enforcement
  - apps/api/src/middleware/tenant.ts — rejects inactive tenants: 401 { error: "tenant_inactive", detail: "tenant is deactivated" }
  - apps/api/src/routes/oauth.ts — OAuth callback upsert reactivates tenant by hubspot_portal_id (clears deactivation fields)
  - apps/api/src/routes/snapshot.ts — catches TenantAccessRevokedError -> 401 { error: "tenant_access_revoked", detail: "hubspot access revoked or app uninstalled for tenant" }
  - apps/api/src/services/snapshot-assembler.ts — rethrows TenantAccessRevokedError (no degraded fallback)

- Tests added / updated (traceability)
  - Lifecycle integration/tests: apps/api/src/lib/__tests__/tenant-lifecycle.test.ts
  - HubSpot client tests: apps/api/src/lib/__tests__/hubspot-client.test.ts
  - Snapshot route tests: apps/api/src/__tests__/snapshot-route.test.ts
  - Middleware tests: apps/api/src/__tests__/tenant.test.ts
  - OAuth callback tests: apps/api/src/routes/__tests__/oauth.test.ts
  - Settings route test: apps/api/src/routes/__tests__/settings.test.ts
  - Snapshot assembler test: apps/api/src/services/__tests__/snapshot-assembler.test.ts
  - DB schema tests: packages/db/src/__tests__/schema.test.ts, packages/db/src/schema/__tests__/slice6-tenant-lifecycle.test.ts
  - UI test: apps/hubspot-extension/src/index.test.tsx
  - UI behavior: apps/hubspot-extension/src/shared/extension-root.tsx

- Documentation & runbooks (traceability)
  - README.md (Install Lifecycle section)
  - docs/phase-6-doc-alignment.md
  - docs/slice-6-preflight-notes.md
  - docs/runbooks/tenant-offboarding.md
  - docs/security/SECURITY.md
  - docs/security/slice-6-audit.md
  - .claude/tasks/2026-04-17-slice-6-install-lifecycle-offboarding.md
  - PLANNING_INDEX.md

## Migration
- Run: pnpm db:migrate
- Adds nullable columns:
  - tenants.deactivated_at TIMESTAMPTZ
  - tenants.deactivation_reason TEXT
- Idempotent (ADD COLUMN IF NOT EXISTS). No destructive changes.

## Data-flow diagrams (Mermaid)

Lifecycle signal & effect:
```mermaid
graph TD
  HS["HubSpot Platform"] -->|app_uninstall webhook| LS["Lifecycle Service"]
  HS -->|app_install webhook| LS
  HC["HubSpot Client<br/>(token refresh)"] -->|invalid_grant / unrecoverable 400| LF["Unrecoverable Failure"]
  LF -->|deactivateTenant(reason: oauth_refresh_failed)| LS
  LS -->|app_uninstall| D["Deactivate Tenant<br/>isActive=false<br/>remove OAuth row"]
  LS -->|app_install| R["Reactivate Tenant<br/>isActive=true<br/>clear deactivated fields"]
  D -->|invalidate config cache| BLOCK["Tenant blocked by middleware"]
  R -->|recreate OAuth row via callback| ACTIVE["Tenant active"]
```

Request handling & error propagation:
```mermaid
graph TD
  Req["Incoming Request"] --> TM{tenantMiddleware}
  TM -->|no tenant| NF["401 tenant_not_found"]
  TM -->|tenant found & isActive = true| OK["proceed"]
  TM -->|tenant found & isActive = false| INACTIVE["401 tenant_inactive"]
  OK -->|calls HubSpot API| HSCall["HubSpotClient.authenticatedFetch"]
  HSCall -->|refresh success| CONT["continue"]
  HSCall -->|unrecoverable refresh| REV["TenantAccessRevokedError"]
  REV -->|deactivateTenant| INACTIVE
  REV -->|snapshot route catches| REV_RESP["401 tenant_access_revoked"]
```

Reinstall/Reactivate flow:
```mermaid
graph LR
  User["User reinstalls app (OAuth callback)"] -->|same hubspot_portal_id| Upsert["OAuth callback upsert on tenants.hubspot_portal_id"]
  Upsert -->|onConflict: set isActive=true, deactivated_at=null, deactivation_reason=null| Reactivated["Tenant reactivated; OAuth row recreated"]
  Reactivated -->|preserve| Data["Config & history preserved"]
```

## Error codes introduced / mapping
- 401 tenant_inactive — returned early by tenantMiddleware for deactivated tenants
- 401 tenant_access_revoked — returned by snapshot route when TenantAccessRevokedError occurs mid-request
- TenantAccessRevokedError — exported class from apps/api/src/lib/hubspot-client.ts used to signal unrecoverable OAuth revocation

## Testing & traceability guarantees (why and how)
- All lifecycle transitions have explicit unit/integration tests exercising DB effects and encryption:
  - deactivateTenant/reactivateTenant/applyHubSpotLifecycleEvent validated with a real test DB (apps/api/src/lib/__tests__/tenant-lifecycle.test.ts)
  - HubSpot client token-refresh failure paths unit-tested to verify DB transactional side-effects and error classification (apps/api/src/lib/__tests__/hubspot-client.test.ts)
- Snapshot assembler and route tests assert lifecycle errors are not masked and map to lifecycle-specific 401 responses.
- Middleware tests ensure inactive tenants are blocked before route handlers run.
- DB schema tests verify migration adds expected columns (nullable) and persisted values match expectations.
- Tests explicitly control encryption keys and reset encryption caches to ensure deterministic token handling in CI.
- Each behavioral change is linked to a specific file (see “Key changes (traceable to files)” above) for auditing and review.

## Operational runbook summary (quick)
- Offboard steps: mark tenants.is_active=false, set deactivated_at & deactivation_reason, delete tenant_hubspot_oauth rows, invalidate caches — implemented in deactivateTenant and documented in docs/runbooks/tenant-offboarding.md
- Reinstall steps: OAuth callback upsert clears deactivation metadata and recreates oauth row — verified by oauth callback test
- Monitoring: log snapshot_route.tenant_access_revoked with tenantId/companyId on TenantAccessRevokedError (snapshot route test asserts console.warn usage)

## Validation steps (developer checklist)
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm db:migrate

## Backward compatibility & non-goals
- Non-breaking: new columns nullable; tenants remain active until lifecycle events occur
- Preserves tenant identity by hubspot_portal_id; offboarding is soft-deactivate (no hard deletes)
- Hard-delete of tenant data is explicitly out-of-scope and not implemented

## Reasoning for design decisions (concise)
- Hybrid lifecycle signals (HubSpot lifecycle webhooks primary + unrecoverable OAuth refresh fallback) ensure timely offboarding even if webhooks are missed or delayed — traceable in docs/slice-6-preflight-notes.md and implemented in hubspot-client.ts + tenant-lifecycle.ts.
- Soft-deactivate + removal of OAuth rows preserves continuity (config/history) while preventing access — balances liability and recoverability; documented in docs/security/SECURITY.md and runbook.
- Explicit TenantAccessRevokedError provides a clear control-flow signal to surface lifecycle loss at runtime and in logs, enabling deterministic authorization behavior and test assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->