### PR TITLE
Slice 9: profile-aware extension build wrapper

### DIFF
--- a/apps/hubspot-extension/package.json
+++ b/apps/hubspot-extension/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "echo 'Use hs project dev for local HubSpot extension development'",
-    "build": "vite build"
+    "build": "vite build",
+    "build:with-profile": "tsx scripts/build-with-profile-cli.ts"
   },
   "dependencies": {
     "@hap/config": "workspace:*",

--- a/apps/hubspot-extension/scripts/__tests__/build-with-profile.e2e.test.ts
+++ b/apps/hubspot-extension/scripts/__tests__/build-with-profile.e2e.test.ts
@@ -1,0 +1,69 @@
+/**
+ * End-to-end proof that the wrapper produces a bundle containing the
+ * profile's API_ORIGIN. Complements the unit tests in
+ * `build-with-profile.test.ts` by exercising the actual Vite build.
+ *
+ * Slower than unit tests (one real `vite build`), so kept narrow — a single
+ * profile round-trip. The companion Slice 8 determinism test
+ * (`built-bundle-origin.test.ts`) already covers multi-origin determinism
+ * at the Vite level; this test covers the profile-file → env → build path.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { build } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runBuildWithProfile } from "../build-with-profile";
+
+const EXTENSION_ROOT = resolvePath(__dirname, "..", "..");
+
+let scratch: string;
+
+beforeAll(() => {
+  scratch = mkdtempSync(join(tmpdir(), "hap-build-wrapper-e2e-"));
+});
+
+afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("build-with-profile (end-to-end)", () => {
+  it("builds the extension bundle with the profile's API_ORIGIN baked in", async () => {
+    const profileDir = join(scratch, "profiles");
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(
+      join(profileDir, "hsprofile.staging.json"),
+      JSON.stringify({
+        accountId: 12345678,
+        variables: {
+          OAUTH_REDIRECT_URI: "https://hap-signal-workspace-staging.vercel.app/oauth/callback",
+          API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+        },
+      }),
+    );
+
+    const outDir = join(scratch, "out");
+    mkdirSync(outDir, { recursive: true });
+
+    await runBuildWithProfile({
+      profileName: "staging",
+      profileDir,
+      runBuild: async () => {
+        await build({
+          configFile: resolvePath(EXTENSION_ROOT, "vite.config.ts"),
+          root: EXTENSION_ROOT,
+          logLevel: "error",
+          build: {
+            outDir,
+            emptyOutDir: true,
+          },
+        });
+      },
+    });
+
+    const bundle = readFileSync(join(outDir, "index.js"), "utf8");
+    expect(bundle).toContain("https://hap-signal-workspace-staging.vercel.app");
+    // Sanity: prod URL is not what the staging build shipped as the target.
+    expect(bundle).not.toContain("https://hap-signal-workspace.vercel.app/api/snapshot/");
+  }, 45_000);
+});

--- a/apps/hubspot-extension/scripts/__tests__/build-with-profile.test.ts
+++ b/apps/hubspot-extension/scripts/__tests__/build-with-profile.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the HubSpot-project profile-aware extension build wrapper.
+ *
+ * The wrapper lives here (inside the extension package) because
+ * `apps/hubspot-project/` is intentionally excluded from the pnpm workspace
+ * and cannot host runnable TypeScript. It reads a profile file from the
+ * sibling `apps/hubspot-project/hsprofile.<name>.json`, extracts the
+ * `API_ORIGIN` variable, and invokes the existing extension build with
+ * `process.env.API_ORIGIN` set to that value.
+ *
+ * The build itself is covered by `__tests__/built-bundle-origin.test.ts`
+ * (Slice 8). Here we pin the profile-parsing + env-handoff contract.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  extractApiOrigin,
+  InvalidProfileNameError,
+  loadProfile,
+  MissingApiOriginError,
+  MissingProfileFileError,
+  resolveProfilePath,
+  runBuildWithProfile,
+} from "../build-with-profile";
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "hap-build-wrapper-"));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+function writeProfile(name: string, contents: unknown): string {
+  const path = join(scratch, `hsprofile.${name}.json`);
+  writeFileSync(path, JSON.stringify(contents));
+  return path;
+}
+
+describe("resolveProfilePath()", () => {
+  it("maps a profile name to the expected hsprofile.<name>.json path", () => {
+    expect(resolveProfilePath("staging", scratch)).toBe(join(scratch, "hsprofile.staging.json"));
+  });
+
+  it("accepts the three shipped profile names", () => {
+    for (const name of ["local", "staging", "production"]) {
+      expect(() => resolveProfilePath(name, scratch)).not.toThrow();
+    }
+  });
+
+  it.each([
+    "",
+    "..",
+    "../leak",
+    "with space",
+    "UP",
+    "semi;colon",
+  ])("rejects malformed profile name %j", (bad) => {
+    expect(() => resolveProfilePath(bad, scratch)).toThrow(InvalidProfileNameError);
+  });
+});
+
+describe("loadProfile()", () => {
+  it("parses a valid profile file into its JSON shape", () => {
+    const path = writeProfile("staging", {
+      accountId: 12345678,
+      variables: {
+        OAUTH_REDIRECT_URI: "https://x/oauth/callback",
+        API_ORIGIN: "https://x",
+      },
+    });
+
+    const loaded = loadProfile(path);
+    expect(loaded.accountId).toBe(12345678);
+    expect(loaded.variables.API_ORIGIN).toBe("https://x");
+  });
+
+  it("throws a clear MissingProfileFileError when the path does not exist", () => {
+    const path = join(scratch, "hsprofile.nope.json");
+    expect(() => loadProfile(path)).toThrow(MissingProfileFileError);
+  });
+
+  it("throws on malformed JSON rather than silently returning an empty object", () => {
+    const path = join(scratch, "hsprofile.bad.json");
+    writeFileSync(path, "{not json");
+
+    expect(() => loadProfile(path)).toThrow(/profile file is not valid JSON/i);
+  });
+});
+
+describe("extractApiOrigin()", () => {
+  it("returns the API_ORIGIN variable when present", () => {
+    const origin = "https://hap-signal-workspace-staging.vercel.app";
+    expect(extractApiOrigin({ accountId: 1, variables: { API_ORIGIN: origin } })).toBe(origin);
+  });
+
+  it("throws MissingApiOriginError when variables object is missing", () => {
+    expect(() =>
+      extractApiOrigin({ accountId: 1 } as unknown as {
+        accountId: number;
+        variables: Record<string, string>;
+      }),
+    ).toThrow(MissingApiOriginError);
+  });
+
+  it("throws MissingApiOriginError when API_ORIGIN is empty or whitespace", () => {
+    expect(() => extractApiOrigin({ accountId: 1, variables: { API_ORIGIN: "" } })).toThrow(
+      MissingApiOriginError,
+    );
+    expect(() => extractApiOrigin({ accountId: 1, variables: { API_ORIGIN: "   " } })).toThrow(
+      MissingApiOriginError,
+    );
+  });
+});
+
+describe("runBuildWithProfile() — env handoff", () => {
+  it("sets process.env.API_ORIGIN to the profile value before invoking the build", async () => {
+    writeProfile("staging", {
+      accountId: 1,
+      variables: {
+        API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+      },
+    });
+
+    // Capture the env the build sees at invocation time, NOT after.
+    let envAtBuildTime: string | undefined;
+    const runBuild = vi.fn(async () => {
+      envAtBuildTime = process.env.API_ORIGIN;
+    });
+
+    await runBuildWithProfile({
+      profileName: "staging",
+      profileDir: scratch,
+      runBuild,
+    });
+
+    expect(runBuild).toHaveBeenCalledTimes(1);
+    expect(envAtBuildTime).toBe("https://hap-signal-workspace-staging.vercel.app");
+  });
+
+  it("restores the previous API_ORIGIN after the build completes (no env leakage)", async () => {
+    writeProfile("staging", {
+      accountId: 1,
+      variables: {
+        API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+      },
+    });
+
+    const previous = process.env.API_ORIGIN;
+    process.env.API_ORIGIN = "https://sentinel.example.com";
+    try {
+      await runBuildWithProfile({
+        profileName: "staging",
+        profileDir: scratch,
+        runBuild: async () => {
+          // no-op
+        },
+      });
+      expect(process.env.API_ORIGIN).toBe("https://sentinel.example.com");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.API_ORIGIN;
+      } else {
+        process.env.API_ORIGIN = previous;
+      }
+    }
+  });
+
+  it("restores env even when the build throws", async () => {
+    writeProfile("staging", {
+      accountId: 1,
+      variables: {
+        API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+      },
+    });
+
+    const previous = process.env.API_ORIGIN;
+    delete process.env.API_ORIGIN;
+    try {
+      await expect(
+        runBuildWithProfile({
+          profileName: "staging",
+          profileDir: scratch,
+          runBuild: async () => {
+            throw new Error("vite build failed");
+          },
+        }),
+      ).rejects.toThrow(/vite build failed/);
+      expect(process.env.API_ORIGIN).toBeUndefined();
+    } finally {
+      if (previous !== undefined) {
+        process.env.API_ORIGIN = previous;
+      }
+    }
+  });
+
+  it("surfaces a readable error when the profile file is missing", async () => {
+    await expect(
+      runBuildWithProfile({
+        profileName: "local",
+        profileDir: scratch,
+        runBuild: async () => {
+          throw new Error("should not run");
+        },
+      }),
+    ).rejects.toThrow(MissingProfileFileError);
+  });
+});

--- a/apps/hubspot-extension/scripts/build-with-profile-cli.ts
+++ b/apps/hubspot-extension/scripts/build-with-profile-cli.ts
@@ -1,0 +1,68 @@
+/**
+ * CLI entry for the profile-aware build wrapper.
+ *
+ * Usage:
+ *   pnpm --filter @hap/hubspot-extension exec tsx \
+ *     scripts/build-with-profile-cli.ts --profile staging
+ *
+ * OR via the matching package script:
+ *   pnpm --filter @hap/hubspot-extension run build:with-profile -- --profile staging
+ *
+ * Resolution order for the profile name:
+ *   1. `--profile <name>` CLI flag
+ *   2. `HS_PROFILE` env var
+ *   3. error (we refuse to guess a default — production and staging must be
+ *      selected deliberately).
+ *
+ * The profile directory defaults to the sibling `apps/hubspot-project/`
+ * tree resolved relative to this file. Override with `--profile-dir` if the
+ * wrapper is invoked from outside the monorepo (e.g., a packaged release).
+ */
+import { resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "vite";
+import { runBuildWithProfile } from "./build-with-profile";
+
+function parseArgs(argv: string[]): { profile?: string; profileDir?: string } {
+  const out: { profile?: string; profileDir?: string } = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--profile" || arg === "-p") {
+      out.profile = argv[++i];
+    } else if (arg === "--profile-dir") {
+      out.profileDir = argv[++i];
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const profileName = args.profile ?? process.env.HS_PROFILE;
+  if (!profileName) {
+    throw new Error("Profile name is required. Pass --profile <name> or set HS_PROFILE.");
+  }
+
+  const here = fileURLToPath(new URL(".", import.meta.url));
+  const extensionRoot = resolvePath(here, "..");
+  const defaultProfileDir = resolvePath(extensionRoot, "..", "hubspot-project");
+  const profileDir = args.profileDir
+    ? resolvePath(process.cwd(), args.profileDir)
+    : defaultProfileDir;
+
+  await runBuildWithProfile({
+    profileName,
+    profileDir,
+    runBuild: async () => {
+      await build({
+        configFile: resolvePath(extensionRoot, "vite.config.ts"),
+        root: extensionRoot,
+      });
+    },
+  });
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/apps/hubspot-extension/scripts/build-with-profile.ts
+++ b/apps/hubspot-extension/scripts/build-with-profile.ts
@@ -1,0 +1,161 @@
+/**
+ * Profile-aware extension build wrapper.
+ *
+ * Closes the Slice 8 gap: the Vite `define` block reads
+ * `process.env.API_ORIGIN` but nothing sets that env per HubSpot profile
+ * (`hsprofile.local.json`, `hsprofile.staging.json`, `hsprofile.production.json`).
+ * This wrapper reads the selected profile file, extracts its
+ * `variables.API_ORIGIN`, sets the env, and invokes the existing build.
+ *
+ * Library (this file): pure helpers + orchestrator. The CLI entry lives in
+ * `build-with-profile-cli.ts` so tests can import the helpers without
+ * triggering a build as a side effect of import.
+ *
+ * Intended production usage (from the HubSpot project build step):
+ *
+ *   pnpm --filter @hap/hubspot-extension exec tsx \
+ *     scripts/build-with-profile-cli.ts --profile staging
+ *
+ * Profile files live in `apps/hubspot-project/` (gitignored real files,
+ * committed `.example.json` templates).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Error thrown when the caller asks for a profile name we refuse to resolve. */
+export class InvalidProfileNameError extends Error {
+  constructor(name: string) {
+    super(
+      `Invalid profile name: ${JSON.stringify(name)}. Only lowercase ` +
+        `alphanumerics, dashes, and underscores are allowed — no slashes, ` +
+        `dots, spaces, or shell metacharacters.`,
+    );
+    this.name = "InvalidProfileNameError";
+  }
+}
+
+/** Error thrown when the resolved profile path does not exist on disk. */
+export class MissingProfileFileError extends Error {
+  constructor(path: string) {
+    super(
+      `HubSpot profile file not found: ${path}. Copy ` +
+        `hsprofile.<name>.example.json to hsprofile.<name>.json and fill in ` +
+        `the account-specific values before running the build.`,
+    );
+    this.name = "MissingProfileFileError";
+  }
+}
+
+/** Error thrown when the profile's `variables.API_ORIGIN` is missing/empty. */
+export class MissingApiOriginError extends Error {
+  constructor() {
+    super(
+      "Profile is missing a non-empty variables.API_ORIGIN. The wrapper " +
+        "refuses to invoke the build without it — the produced bundle " +
+        "would hard-code the prod fallback instead of the profile's origin.",
+    );
+    this.name = "MissingApiOriginError";
+  }
+}
+
+export type HsProfile = {
+  accountId: number;
+  variables: Record<string, string>;
+};
+
+/**
+ * Allowed profile-name regex. Intentionally strict:
+ *   - lowercase ASCII letters, digits, dashes, underscores
+ *   - at least one character
+ *   - rejects `..`, `/`, `.`, whitespace, and anything that would let a
+ *     caller pivot the resolved path outside the profile directory.
+ */
+const PROFILE_NAME_RE = /^[a-z0-9_-]+$/;
+
+/**
+ * Resolve a profile name to its on-disk path without ever escaping
+ * `profileDir`. Throws on any name that fails {@link PROFILE_NAME_RE}.
+ */
+export function resolveProfilePath(profileName: string, profileDir: string): string {
+  if (!PROFILE_NAME_RE.test(profileName)) {
+    throw new InvalidProfileNameError(profileName);
+  }
+  return join(profileDir, `hsprofile.${profileName}.json`);
+}
+
+/** Read + parse the profile file. Throws typed errors on IO / JSON failures. */
+export function loadProfile(profilePath: string): HsProfile {
+  if (!existsSync(profilePath)) {
+    throw new MissingProfileFileError(profilePath);
+  }
+  const raw = readFileSync(profilePath, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    throw new Error(
+      `Profile file is not valid JSON: ${profilePath}`,
+      cause instanceof Error ? { cause } : undefined,
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as { accountId?: unknown }).accountId !== "number" ||
+    typeof (parsed as { variables?: unknown }).variables !== "object" ||
+    (parsed as { variables?: unknown }).variables === null
+  ) {
+    throw new Error(
+      `Profile file has unexpected shape (expected { accountId: number, ` +
+        `variables: object }): ${profilePath}`,
+    );
+  }
+  return parsed as HsProfile;
+}
+
+/** Return `variables.API_ORIGIN` or throw if absent / empty / whitespace. */
+export function extractApiOrigin(profile: HsProfile): string {
+  const value = profile.variables?.API_ORIGIN;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new MissingApiOriginError();
+  }
+  return value;
+}
+
+export type RunBuildWithProfileOptions = {
+  profileName: string;
+  profileDir: string;
+  /**
+   * Injected build callable. In production this runs `vite build`; in tests
+   * it is a captured spy. Keeping the build out of this function means the
+   * unit tests never touch Vite and execute in milliseconds.
+   */
+  runBuild: () => Promise<void>;
+};
+
+/**
+ * Orchestrate the wrapper flow:
+ *   1. resolve profile path (validated)
+ *   2. read + parse profile
+ *   3. extract API_ORIGIN
+ *   4. set `process.env.API_ORIGIN` for the duration of the build
+ *   5. invoke `runBuild`
+ *   6. restore the previous env (success OR failure path)
+ */
+export async function runBuildWithProfile(opts: RunBuildWithProfileOptions): Promise<void> {
+  const profilePath = resolveProfilePath(opts.profileName, opts.profileDir);
+  const profile = loadProfile(profilePath);
+  const apiOrigin = extractApiOrigin(profile);
+
+  const previous = process.env.API_ORIGIN;
+  process.env.API_ORIGIN = apiOrigin;
+  try {
+    await opts.runBuild();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = previous;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a small build wrapper that closes the profile → extension-bundle handoff. The wrapper reads the selected HubSpot profile file (`apps/hubspot-project/hsprofile.<name>.json`), extracts `variables.API_ORIGIN`, exports it into `process.env.API_ORIGIN`, and invokes the existing `vite build`. The Vite `define` block (Slice 8) then literalizes that origin into the bundled JavaScript as `__HAP_API_ORIGIN__`, and `resolveApiBaseUrl()` reads it at runtime.

**Depends on the slice-8 branch/PR** (`feature/slice-8-extension-api-origin-profile`). This PR targets that branch deliberately so the diff view shows only the 5 slice-9 files. When slice-8 merges to `main`, GitHub will auto-retarget this PR.

## Root cause

Slice 8 wired a profile-aware API origin resolver through Vite's `define`:
- Extension code reads `__HAP_API_ORIGIN__` (build-time constant) via `resolveApiBaseUrl()`.
- Vite injects the constant from `process.env.API_ORIGIN` at `vite build` time.

But nothing in the repo actually set `process.env.API_ORIGIN` per active HubSpot profile. `hs project upload` expands `${API_ORIGIN}` inside `hsmeta.json` from the active profile variables, but it does not propagate the variable into the TypeScript build. Running the raw `pnpm --filter @hap/hubspot-extension run build` therefore always produced a bundle that fell through to `DEFAULT_API_BASE_URL` (prod), regardless of which profile was active.

This slice supplies the missing wrapper that bridges profile → env → build.

## What changed

**New files**
- `apps/hubspot-extension/scripts/build-with-profile.ts` — pure helpers and orchestrator:
  - `resolveProfilePath(name, dir)` — strict `^[a-z0-9_-]+$` regex blocks path traversal (`..`, `../leak`, etc.).
  - `loadProfile(path)` — reads and JSON-parses with typed error on missing file and on invalid JSON / shape.
  - `extractApiOrigin(profile)` — returns `variables.API_ORIGIN` or throws on missing / empty / whitespace.
  - `runBuildWithProfile({ profileName, profileDir, runBuild })` — sets `process.env.API_ORIGIN`, awaits the injected `runBuild`, and restores the previous env in `finally` (including when the build throws).
  - Typed errors: `InvalidProfileNameError`, `MissingProfileFileError`, `MissingApiOriginError`.
- `apps/hubspot-extension/scripts/build-with-profile-cli.ts` — CLI shim that parses `--profile <name>` (or `HS_PROFILE` env) and `--profile-dir`, defaults the profile directory to the sibling `apps/hubspot-project/`, and wires a real `vite.build()` as `runBuild`.
- `apps/hubspot-extension/scripts/__tests__/build-with-profile.test.ts` — 18 unit tests (path resolution / malformed name rejection / file loading / JSON error / API_ORIGIN extraction / env set-and-restore on success, throw, and missing-file paths).
- `apps/hubspot-extension/scripts/__tests__/build-with-profile.e2e.test.ts` — end-to-end: writes a temp profile, runs the real `vite build` via the wrapper, reads `index.js`, asserts the profile's origin appears verbatim and that the prod URL does not leak in.

**Modified**
- `apps/hubspot-extension/package.json` — additive: `"build:with-profile": "tsx scripts/build-with-profile-cli.ts"`. `tsx` is already a root devDependency so no install impact.

Zero changes to `apps/hubspot-project/` (profile templates untouched), zero changes to existing extension or API source outside the new `scripts/` tree and the single package.json line.

## Verification

```
pnpm typecheck                  # tsc --build, exit 0
pnpm test                       # 75 files / 655 passed (was 73/636 on slice-8 baseline; +2 files / +19 tests)
```

Fresh run immediately before the commit:

| Check | Result |
|---|---|
| Typecheck | ✅ exit 0 |
| Full test suite | ✅ 75/75 files, 655/655 tests |
| Slice-9 unit tests (`build-with-profile.test.ts`) | ✅ 18/18 |
| Slice-9 end-to-end test (`build-with-profile.e2e.test.ts`) | ✅ 1/1, ≈800ms for a real `vite build` |

RED→GREEN was verified cleanly before implementation: both test files initially failed with `Cannot find module '../build-with-profile'` against a bare branch, then went green with the wrapper in place.

## Scope / non-goals

**In scope (this PR):**
- Profile parsing (name validation, file read, JSON shape check).
- `API_ORIGIN` extraction with strict validation.
- Env set-and-restore around an injected build call.
- CLI shim for operational use.
- TDD coverage at unit and end-to-end levels.

**Explicitly out of scope (queued for separate PRs):**
- Lifecycle webhook subscription bootstrap (HubSpot-side `POST /webhooks/v4/subscriptions`).
- Root `/` → `/oauth/install` redirect.
- Committing the Slice 7 lifecycle webhook receiver branch.
- Any `hsmeta.json` or `hsprofile.*.json` modifications — the template placeholder contract is already right; this slice only fills the missing transport between it and Vite.
- `use-snapshot.ts` dead-code cleanup (`SLICE2_TRANSPORT_NOT_WIRED`, stale `@todo Slice 3` comment).
- Any runtime behaviour change inside the extension — no API, route, or component touched.

## Remaining risks or follow-ups

- **Operator wiring.** The wrapper exists and is tested; the HubSpot project upload flow still needs to be updated to call `pnpm --filter @hap/hubspot-extension run build:with-profile -- --profile $PROFILE` instead of the raw `build`. Without that wiring the wrapper sits unused — the rest of the chain is already correct. Recommend following this PR with a small ops PR that updates whatever orchestrates `hs project upload` per environment.
- **Stacked-PR rebase risk.** If the slice-8 PR receives change requests that rename or delete any of the paths this PR touches (unlikely — slice-9 only adds new files and adds a single line to `package.json`), a rebase will be required. Current overlap is zero-file modifications; a clean rebase is the expected outcome.
- **Profile file hygiene.** `apps/hubspot-project/hsprofile.<name>.json` files are gitignored (contain account-specific ids). The `.example.json` templates are committed. Operators must copy + fill before running the wrapper; `MissingProfileFileError` gives a readable message pointing at that step.
- **Scaffold anti-regression coverage.** `apps/hubspot-project/__validate__/scaffold.test.ts` does not currently assert the presence of the new `build:with-profile` package script. Worth adding as a follow-up so a future refactor can not silently drop the entry point.

## After slice-8 merges

1. GitHub auto-retargets this PR to `main` and offers an auto-rebase.
2. If clean (expected, no file overlap): accept.
3. Otherwise: `git fetch origin && git rebase origin/main && git push --force-with-lease`.
4. Merge this PR. Worktree at `.worktrees/slice-9-build-wrapper-profile` can then be removed via `git worktree remove`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a profile-aware build wrapper for the HubSpot extension that reads the selected profile and bakes its API origin into the bundle. It sets `process.env.API_ORIGIN` from `apps/hubspot-project/hsprofile.<name>.json` and runs `vite` so each build targets the right environment.

- **New Features**
  - Wrapper library + CLI to read `API_ORIGIN` from a profile, validate it, set the env, and invoke the build (strict name validation and clear errors).
  - Adds `build:with-profile` script using `tsx` in `@hap/hubspot-extension`; CLI accepts `--profile <name>` or `HS_PROFILE` and optional `--profile-dir`.
  - Unit and end-to-end tests cover env handoff and bundle output.

- **Migration**
  - Use: pnpm --filter `@hap/hubspot-extension` run build:with-profile -- --profile <name>
  - Ensure `apps/hubspot-project/hsprofile.<name>.json` exists and includes a non-empty `variables.API_ORIGIN`.

<sup>Written for commit 142c4e389940b93e25314a6054a57b75c95698bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

