### PR TITLE
Slice 8: resolve extension API origin from build profile

### DIFF
--- a/apps/hubspot-extension/__tests__/built-bundle-origin.test.ts
+++ b/apps/hubspot-extension/__tests__/built-bundle-origin.test.ts
@@ -1,0 +1,74 @@
+/**
+ * End-to-end determinism check for the extension bundle.
+ *
+ * Loads the Vite config with different `API_ORIGIN` values, runs a real
+ * `vite build` under each, and proves the produced bundle carries the
+ * expected origin string verbatim. This closes the gap that
+ * `vite-config.test.ts` cannot — the config contract is correct *and* the
+ * bundler actually performs the substitution.
+ *
+ * Builds are slow (~1-2s each) so we scope to two targeted origins rather
+ * than the full matrix. Bundle output is written to a temporary directory
+ * outside `dist/` so local dev state isn't touched.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { build } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const EXTENSION_ROOT = resolvePath(__dirname, "..");
+
+async function buildWith(apiOrigin: string, outDir: string): Promise<string> {
+  const prev = process.env.API_ORIGIN;
+  process.env.API_ORIGIN = apiOrigin;
+  try {
+    await build({
+      configFile: resolvePath(EXTENSION_ROOT, "vite.config.ts"),
+      root: EXTENSION_ROOT,
+      logLevel: "error",
+      build: {
+        outDir,
+        emptyOutDir: true,
+      },
+    });
+  } finally {
+    if (prev === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = prev;
+    }
+  }
+  return readFileSync(join(outDir, "index.js"), "utf8");
+}
+
+let scratchRoot: string;
+
+beforeAll(() => {
+  scratchRoot = mkdtempSync(join(tmpdir(), "hap-ext-build-"));
+  mkdirSync(scratchRoot, { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(scratchRoot, { recursive: true, force: true });
+});
+
+describe("hubspot-extension built bundle — origin determinism", () => {
+  it("embeds a staging API_ORIGIN literally into the bundle", async () => {
+    const origin = "https://hap-signal-workspace-staging.vercel.app";
+    const out = join(scratchRoot, "staging");
+    const bundle = await buildWith(origin, out);
+
+    expect(bundle).toContain(origin);
+    // Sanity: the unrelated prod URL must NOT appear when staging built.
+    expect(bundle).not.toContain("https://hap-signal-workspace.vercel.app/api/snapshot/");
+  }, 30_000);
+
+  it("embeds a local API_ORIGIN literally into the bundle", async () => {
+    const origin = "https://hap-signal-workspace-local.vercel.app";
+    const out = join(scratchRoot, "local");
+    const bundle = await buildWith(origin, out);
+
+    expect(bundle).toContain(origin);
+  }, 30_000);
+});

--- a/apps/hubspot-extension/__tests__/vite-config.test.ts
+++ b/apps/hubspot-extension/__tests__/vite-config.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the HubSpot extension's Vite config.
+ *
+ * The build pipeline is the only place where `process.env.API_ORIGIN` can
+ * flow INTO the bundled JavaScript: HubSpot's `hs project upload` expands
+ * `${API_ORIGIN}` inside `hsmeta.json` from the active profile, but it does
+ * NOT propagate the variable into the TypeScript source. We close that gap
+ * by having the HubSpot-side build wrapper set `API_ORIGIN` in the env
+ * before invoking `vite build`, and have Vite replace the global constant
+ * `__HAP_API_ORIGIN__` at build time via `define`.
+ *
+ * This test pins the contract of the `define` block so a future refactor
+ * can't silently drop the substitution.
+ */
+import { resolve as resolvePath } from "node:path";
+import type { UserConfig } from "vite";
+import { describe, expect, it } from "vitest";
+
+async function loadConfigWithEnv(
+  envOverride: Partial<NodeJS.ProcessEnv>,
+): Promise<UserConfig | Awaited<UserConfig>> {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(envOverride)) {
+    previous[key] = process.env[key];
+    const value = envOverride[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    // Bust the module cache so Vite re-reads process.env on each call.
+    const configPath = resolvePath(__dirname, "../vite.config.ts");
+    const modUrl = `${configPath}?env=${encodeURIComponent(JSON.stringify(envOverride))}`;
+    const mod = (await import(/* @vite-ignore */ modUrl)) as {
+      default: UserConfig | (() => UserConfig | Promise<UserConfig>);
+    };
+    const raw = mod.default;
+    return typeof raw === "function" ? await raw() : raw;
+  } finally {
+    for (const [key, prevValue] of Object.entries(previous)) {
+      if (prevValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prevValue;
+      }
+    }
+  }
+}
+
+function defineFor(config: UserConfig): Record<string, string> {
+  const defineBlock = (config.define ?? {}) as Record<string, string>;
+  return defineBlock;
+}
+
+describe("hubspot-extension vite.config.ts", () => {
+  it("injects __HAP_API_ORIGIN__ from process.env.API_ORIGIN as a JSON string literal", async () => {
+    const cfg = await loadConfigWithEnv({
+      API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+    });
+
+    const block = defineFor(cfg);
+    expect(block.__HAP_API_ORIGIN__).toBe(
+      JSON.stringify("https://hap-signal-workspace-staging.vercel.app"),
+    );
+  });
+
+  it("injects an empty-string literal when API_ORIGIN is unset, so the runtime resolver falls through", async () => {
+    const cfg = await loadConfigWithEnv({ API_ORIGIN: undefined });
+
+    const block = defineFor(cfg);
+    // `JSON.stringify("")` → '""'. An empty string is how we signal
+    // "no build-time configuration; use runtime/default fallback" in the
+    // resolver. See resolve-api-base-url.test.ts for the consumer side.
+    expect(block.__HAP_API_ORIGIN__).toBe(JSON.stringify(""));
+  });
+
+  it("preserves the API_ORIGIN value verbatim (no trailing-slash normalization)", async () => {
+    // Clarity: the resolver does NOT strip trailing slashes. If a profile
+    // supplies "https://host/" the built bundle carries that exact string
+    // and any downstream URL construction (`${baseUrl}/api/snapshot/...`)
+    // is responsible for reconciling it. Pin this as an explicit decision
+    // so a later "helpful" normalization doesn't break signed fetch URLs.
+    const cfg = await loadConfigWithEnv({
+      API_ORIGIN: "https://hap-signal-workspace.vercel.app/",
+    });
+
+    const block = defineFor(cfg);
+    expect(block.__HAP_API_ORIGIN__).toBe(
+      JSON.stringify("https://hap-signal-workspace.vercel.app/"),
+    );
+  });
+});

--- a/apps/hubspot-extension/src/features/snapshot/hooks/__tests__/resolve-api-base-url.test.ts
+++ b/apps/hubspot-extension/src/features/snapshot/hooks/__tests__/resolve-api-base-url.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for `resolveApiBaseUrl()` — profile/build-time API origin resolver.
+ *
+ * Resolution precedence (highest wins):
+ *   1. A build-time global constant `__HAP_API_ORIGIN__` (injected by Vite
+ *      `define` from `process.env.API_ORIGIN` at `vite build` time). This
+ *      is the production path — the HubSpot project build runs once per
+ *      profile, so each bundle carries the correct origin literally.
+ *   2. `process.env.API_ORIGIN` — the test/runtime escape hatch. Applies
+ *      only in Node runtimes (vitest, SSR). In the real HubSpot extension
+ *      environment `process` is undefined, so this branch never fires.
+ *   3. The hardcoded `DEFAULT_API_BASE_URL` (prod Vercel), so an
+ *      unconfigured build still has a safe default rather than crashing.
+ *
+ * A value of `""`, whitespace-only, or a non-string is treated as absent so
+ * an empty `process.env.API_ORIGIN` doesn't silently nuke the fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_API_BASE_URL, resolveApiBaseUrl } from "../api-fetcher";
+
+const INJECTED_KEY = "__HAP_API_ORIGIN__";
+
+type GlobalWithInjected = typeof globalThis & { [INJECTED_KEY]?: unknown };
+
+function setInjected(value: unknown): void {
+  (globalThis as GlobalWithInjected)[INJECTED_KEY] = value;
+}
+
+function clearInjected(): void {
+  delete (globalThis as GlobalWithInjected)[INJECTED_KEY];
+}
+
+describe("resolveApiBaseUrl()", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.API_ORIGIN;
+    delete process.env.API_ORIGIN;
+    clearInjected();
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = savedEnv;
+    }
+    clearInjected();
+  });
+
+  it("returns the build-time injected constant when it is a non-empty string", () => {
+    setInjected("https://hap-signal-workspace-staging.vercel.app");
+
+    expect(resolveApiBaseUrl()).toBe("https://hap-signal-workspace-staging.vercel.app");
+  });
+
+  it("prefers the build-time injected constant over a runtime env override", () => {
+    setInjected("https://hap-signal-workspace.vercel.app");
+    process.env.API_ORIGIN = "http://localhost:3001";
+
+    expect(resolveApiBaseUrl()).toBe("https://hap-signal-workspace.vercel.app");
+  });
+
+  it("falls back to process.env.API_ORIGIN when the build-time constant is missing", () => {
+    process.env.API_ORIGIN = "http://localhost:3001";
+
+    expect(resolveApiBaseUrl()).toBe("http://localhost:3001");
+  });
+
+  it("falls back to DEFAULT_API_BASE_URL when the build-time constant is an empty string", () => {
+    setInjected("");
+
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+
+  it("falls back to DEFAULT_API_BASE_URL when the build-time constant is whitespace only", () => {
+    setInjected("   ");
+
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+
+  it("falls back to DEFAULT_API_BASE_URL when nothing is configured", () => {
+    // Neither injected constant nor env var — the safe prod default.
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+
+  it("ignores a non-string injected value rather than coercing it", () => {
+    // A misconfigured Vite `define` that passes a raw number instead of
+    // `JSON.stringify(...)` would leave us with a non-string. Treat it as
+    // absent — the fallback is always a string URL.
+    setInjected(123);
+
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+});

--- a/apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts
+++ b/apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts
@@ -13,9 +13,13 @@
  *     tenant-resolution middleware (Slice 2 Step 4) reads these from the
  *     signed payload — NOT from any client-supplied header.
  *   - The destination URL MUST appear in `permittedUrls.fetch[]` inside
- *     `apps/hubspot-project/src/app/app-hsmeta.json`. `DEFAULT_API_BASE_URL`
- *     below is kept in sync with that file via
- *     `apps/hubspot-project/__validate__/scaffold.test.ts`.
+ *     `apps/hubspot-project/src/app/app-hsmeta.json`. That file lists the
+ *     template variable `${API_ORIGIN}`, which HubSpot expands at upload
+ *     time from the active profile (hsprofile.*.json). The Vite build
+ *     passes the matching `process.env.API_ORIGIN` through to the bundled
+ *     JS via `define`, and `resolveApiBaseUrl()` (below) reads it at
+ *     runtime. The scaffold anti-regression test keeps the placeholder +
+ *     profile variable contract intact.
  *   - Per-account outbound limits: 20 concurrent requests, 15s timeout cap,
  *     1MB payload cap. The snapshot route is well inside these bounds.
  *
@@ -27,14 +31,55 @@ import { hubspot } from "@hubspot/ui-extensions";
 import type { SnapshotFetcher } from "./use-snapshot";
 
 /**
- * Default production API origin for the snapshot backend.
- *
- * MUST be kept in sync with `permittedUrls.fetch[0]` in
- * `apps/hubspot-project/src/app/app-hsmeta.json`. The scaffold anti-regression
- * test binds the two together; if you change this string, change that file
- * and the test's expected value at the same time.
+ * Hard-coded prod fallback. Only reached when both the build-time
+ * `__HAP_API_ORIGIN__` injection and the runtime `process.env.API_ORIGIN`
+ * escape hatch are absent — see {@link resolveApiBaseUrl}. Kept as a string
+ * literal (not derived from env) so a misconfigured build is still safe.
  */
 export const DEFAULT_API_BASE_URL = "https://hap-signal-workspace.vercel.app";
+
+/**
+ * Build-time constant injected by Vite `define` from
+ * `process.env.API_ORIGIN` at `vite build` time. The HubSpot project build
+ * wrapper sets the env per-profile before invoking vite, so each uploaded
+ * bundle literalizes its own target origin. At runtime inside the HubSpot
+ * extension host, this symbol is replaced with a string literal (e.g.,
+ * `"https://hap-signal-workspace-staging.vercel.app"`) by the time the
+ * code executes, and the `typeof` guard is evaluated against that literal.
+ */
+declare const __HAP_API_ORIGIN__: string | undefined;
+
+/**
+ * Resolve the API origin the extension fetcher should target.
+ *
+ * Precedence (highest wins):
+ *   1. `__HAP_API_ORIGIN__` — build-time substitution (the production path).
+ *   2. `process.env.API_ORIGIN` — runtime override for Node environments
+ *      (vitest, SSR). `process` is undefined inside the HubSpot extension
+ *      host, so this branch is Node-only.
+ *   3. {@link DEFAULT_API_BASE_URL} — safe prod default.
+ *
+ * A value of `""`, whitespace-only, or a non-string is treated as absent.
+ * This matters because Vite `define` must emit *some* replacement for
+ * `__HAP_API_ORIGIN__` even when the env is unset; we emit `""` and rely on
+ * this function to fall through.
+ */
+export function resolveApiBaseUrl(): string {
+  const injected =
+    typeof __HAP_API_ORIGIN__ !== "undefined" ? (__HAP_API_ORIGIN__ as unknown) : undefined;
+  if (typeof injected === "string" && injected.trim().length > 0) {
+    return injected;
+  }
+
+  if (typeof process !== "undefined") {
+    const envOrigin = process.env?.API_ORIGIN;
+    if (typeof envOrigin === "string" && envOrigin.trim().length > 0) {
+      return envOrigin;
+    }
+  }
+
+  return DEFAULT_API_BASE_URL;
+}
 
 /**
  * Transport-layer error thrown when the snapshot API returns a non-2xx
@@ -55,9 +100,10 @@ export class ApiFetcherError extends Error {
 
 export type HubSpotApiFetcherDeps = {
   /**
-   * API origin to target. Defaults to `DEFAULT_API_BASE_URL`. Tests override
-   * this; in V1 production we pin the single prod origin and rely on the
-   * HubSpot project's `permittedUrls.fetch` to gate it.
+   * API origin to target. Defaults to the result of {@link resolveApiBaseUrl},
+   * which honors the build-time injected origin first, then
+   * `process.env.API_ORIGIN`, then {@link DEFAULT_API_BASE_URL}. Tests that
+   * want a deterministic origin pass it explicitly.
    */
   baseUrl?: string;
 };
@@ -74,7 +120,7 @@ export type HubSpotApiFetcherDeps = {
  * failure. Schema validation + Date coercion happens in `useSnapshot`.
  */
 export function createHubSpotApiFetcher(deps: HubSpotApiFetcherDeps = {}): SnapshotFetcher {
-  const baseUrl = deps.baseUrl ?? DEFAULT_API_BASE_URL;
+  const baseUrl = deps.baseUrl ?? resolveApiBaseUrl();
 
   return async function fetchSnapshot(companyId: string): Promise<unknown> {
     const url = `${baseUrl}/api/snapshot/${companyId}`;

--- a/apps/hubspot-extension/vite.config.ts
+++ b/apps/hubspot-extension/vite.config.ts
@@ -2,18 +2,38 @@ import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-export default defineConfig({
-  plugins: [react()],
-  build: {
-    emptyOutDir: true,
-    lib: {
-      entry: resolve(__dirname, "src/hubspot-card-entry.tsx"),
-      formats: ["es"],
+/**
+ * Vite config is a factory so `process.env.API_ORIGIN` is read EACH time
+ * `vite build` runs. The HubSpot project build wrapper sets that env per
+ * active profile before invoking the build, and the value flows through
+ * `define` into the bundled JavaScript as the literal string constant
+ * `__HAP_API_ORIGIN__` — consumed at runtime by
+ * `src/features/snapshot/hooks/api-fetcher.ts::resolveApiBaseUrl`.
+ *
+ * Contract (pinned by `__tests__/vite-config.test.ts`):
+ *   - `API_ORIGIN=...`  → `__HAP_API_ORIGIN__ = JSON.stringify(value)`
+ *   - `API_ORIGIN`unset → `__HAP_API_ORIGIN__ = JSON.stringify("")`
+ *   - values are preserved verbatim (no trailing-slash normalization).
+ */
+export default defineConfig(() => {
+  const apiOrigin = process.env.API_ORIGIN ?? "";
+
+  return {
+    plugins: [react()],
+    define: {
+      __HAP_API_ORIGIN__: JSON.stringify(apiOrigin),
     },
-    rollupOptions: {
-      output: {
-        entryFileNames: "index.js",
+    build: {
+      emptyOutDir: true,
+      lib: {
+        entry: resolve(__dirname, "src/hubspot-card-entry.tsx"),
+        formats: ["es"],
+      },
+      rollupOptions: {
+        output: {
+          entryFileNames: "index.js",
+        },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
## Summary

The HubSpot extension's snapshot fetcher hard-coded the prod Vercel API origin, so every bundle — regardless of which HubSpot profile was active — targeted production. This PR replaces that literal with a three-tier resolver and a matching Vite `define` block so a per-profile origin can flow into the built bundle.

> **PR #8 is stacked on this branch and should merge after this PR lands.** It adds the wrapper that actually sets `process.env.API_ORIGIN` per HubSpot profile before invoking the build — without this PR it has nothing to inject into.

## Root cause

`apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts` defined:

```ts
export const DEFAULT_API_BASE_URL = "https://hap-signal-workspace.vercel.app";
```

…and used it as the default base URL for every call. `apps/hubspot-project/src/app/app-hsmeta.json` already used the template variable `${API_ORIGIN}` in `permittedUrls.fetch`, and `hsprofile.{local,staging,production}.json` already supplied the matching value. HubSpot's project uploader expands that placeholder at upload time — but only inside `hsmeta.json`, never into the TypeScript source. The bundled JavaScript therefore always carried the prod URL verbatim, independent of profile. Staging and local previews could only work by accident (if the prod backend happened to accept their requests) and would fail closed against `permittedUrls.fetch` in any non-prod environment.

## What changed

**`apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts`**
- New `declare const __HAP_API_ORIGIN__` — build-time injection hook.
- New exported `resolveApiBaseUrl()` with strict 3-tier precedence:
  1. `__HAP_API_ORIGIN__` — build-time substitution (the production path).
  2. `process.env.API_ORIGIN` — runtime override for Node environments (vitest, SSR). `process` is undefined inside the HubSpot extension host, so this branch is Node-only.
  3. `DEFAULT_API_BASE_URL` — prod fallback kept as a string literal so a misconfigured build still has a safe default.
- Empty / whitespace / non-string values at any tier are treated as absent, so an unset Vite `define` (which emits `""`) correctly falls through to the runtime env or the hardcoded default.
- `createHubSpotApiFetcher` now defaults to `deps.baseUrl ?? resolveApiBaseUrl()` instead of the hardcoded constant.
- Top-of-file doc comment updated to describe the new profile → Vite `define` → runtime-resolver flow (the old comment described a `DEFAULT_API_BASE_URL` ↔ `permittedUrls.fetch[0]` literal tie-in that stopped being true when `${API_ORIGIN}` replaced the literal).

**`apps/hubspot-extension/vite.config.ts`**
- Refactored from static `defineConfig({...})` to a factory `defineConfig(() => {...})` so `process.env.API_ORIGIN` is read on each `vite build` invocation.
- Added a pinned `define` block:
  ```ts
  define: { __HAP_API_ORIGIN__: JSON.stringify(process.env.API_ORIGIN ?? "") }
  ```
- Empty-string literal emitted when the env is unset, so the runtime resolver's fall-through is deterministic.

**Tests (new files)**
- `apps/hubspot-extension/src/features/snapshot/hooks/__tests__/resolve-api-base-url.test.ts` — 7 resolver precedence and validation tests.
- `apps/hubspot-extension/__tests__/vite-config.test.ts` — 3 tests pinning the `define` contract (JSON-stringified origin, empty-string sentinel, verbatim preservation including trailing slashes).
- `apps/hubspot-extension/__tests__/built-bundle-origin.test.ts` — 2 end-to-end tests that run a real `vite build` under different `API_ORIGIN` values and grep the produced `index.js` for the expected URL, also asserting the unrelated prod URL does not leak in.

No changes to `apps/hubspot-project/` (profile templates untouched), no API or route changes, no database changes, no behavioural change to any already-shipping request path when `API_ORIGIN` is unset.

## Verification

Fresh run in the slice-8 worktree immediately before requesting review:

| Check | Result |
|---|---|
| `pnpm typecheck` (`tsc --build`) | ✅ exit 0 |
| `pnpm test` | ✅ **73 files / 636 tests passed**, 0 failures |
| New resolver tests | ✅ 7/7 |
| New Vite `define` contract tests | ✅ 3/3 |
| New end-to-end `vite build` determinism tests | ✅ 2/2 (≈1.5s for both real builds) |
| RED→GREEN discipline | ✅ All new tests failed on the bare branch before implementation (`Cannot find module` / `AssertionError`) and turned green with the production code in place. |

Baseline before this PR was 70 files / 624 tests on `origin/main`; delta is exactly +3 files / +12 tests.

Diff stat:
```
apps/hubspot-extension/__tests__/built-bundle-origin.test.ts                       | 74 +++++++++++++++++
apps/hubspot-extension/__tests__/vite-config.test.ts                               | 94 +++++++++++++++++++++
apps/hubspot-extension/src/features/snapshot/hooks/__tests__/resolve-api-base-url.test.ts | 95 ++++++++++++++++++++++
apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts                  | 72 +++++++++++++---
apps/hubspot-extension/vite.config.ts                                              | 42 +++++++---
5 files changed, 353 insertions(+), 24 deletions(-)
```

## Scope / non-goals

**In scope:**
- Build-time origin injection mechanism (Vite `define`).
- Runtime resolver with strict precedence + sanitization.
- Test coverage at unit, config-contract, and end-to-end bundle levels.

**Explicitly out of scope (queued for follow-up PRs):**
- The actual profile → env handoff that feeds `API_ORIGIN` per profile — this is **stacked PR #8** (`feature/slice-9-hubspot-build-wrapper`), which adds the CLI wrapper + orchestrator + 19 more tests and must merge after this PR.
- Wiring the HubSpot project upload flow to call `build:with-profile` instead of raw `build`.
- Any change to `app-hsmeta.json`, `hsprofile.*.json`, or the `permittedUrls.fetch` contract — the existing `${API_ORIGIN}` placeholder is already correct for this mechanism.
- Lifecycle webhook subscription bootstrap, root `/` → `/oauth/install` redirect, Slice 7 lifecycle receiver commit, `use-snapshot.ts` dead-code cleanup — all tracked separately.

## Remaining risks or follow-ups

- **Until the HubSpot project upload flow passes `API_ORIGIN` to `vite build`, no behavioural change ships.** The resolver falls through to `DEFAULT_API_BASE_URL` (prod), which is identical to today's behaviour. This is intentional — this PR is the mechanism; PR #8 + a later ops PR are the activation. Review can treat this as a no-op in isolation and verify the wiring end-to-end only once the stack lands.
- **`DEFAULT_API_BASE_URL` kept as a string literal fallback.** Conservative choice to match existing prod behaviour in the unconfigured-build case. Future: once all deploy paths go through the wrapper, the fallback can hard-fail instead (or be dropped entirely) — but that is a separate decision.
- **End-to-end determinism tests run real `vite build`s** (~800ms each). Added to the default suite because they complete inside the normal CI budget and catch any regression in the `define` pipeline directly. If test-suite time becomes a concern, they can be moved behind a flag — but the unit + config tests are fast and would still guard the most common regressions.
- **After PR #8 is rebased onto `main`:** its diff becomes a clean single-commit add-on. GitHub will auto-retarget it from this branch to `main` when this PR merges. Reviewers of #8 can wait to review until after this PR is merged, or review against the current stacked base — the #8 diff only contains the wrapper's own files + one line in `package.json`.

## After this PR merges

1. PR #8 auto-retargets from `feature/slice-8-extension-api-origin-profile` to `main`.
2. Accept the GitHub auto-rebase offer (expected clean).
3. Merge #8.
4. Follow up with a small ops PR that wires the HubSpot project upload flow to call `pnpm --filter @hap/hubspot-extension run build:with-profile -- --profile $PROFILE` per environment.
5. Delete both slice worktrees: `git worktree remove .worktrees/slice-8-extension-api-origin` and `.worktrees/slice-9-build-wrapper-profile` (from the main repo checkout).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the HubSpot extension’s API base URL from the active build profile via a build-time `__HAP_API_ORIGIN__` injected by `vite`, replacing the hardcoded prod origin. Staging/local bundles now target the right backend; if unset, it falls back to prod (no behavior change today).

- **New Features**
  - Added `resolveApiBaseUrl()` with strict precedence: `__HAP_API_ORIGIN__` → `process.env.API_ORIGIN` (Node only) → prod fallback.
  - Updated `vite.config.ts` to a factory and inject `__HAP_API_ORIGIN__ = JSON.stringify(process.env.API_ORIGIN ?? "")` via `define`.
  - `createHubSpotApiFetcher` now defaults to `resolveApiBaseUrl()` instead of a literal URL.
  - Added tests for the resolver, `vite` define contract, and end-to-end build determinism.
  - No behavior change until the build wrapper sets `API_ORIGIN`; default remains production.

<sup>Written for commit 24037112e2f72d2d88c23b7fbd7a3e96b4752c11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Slice 8: Resolve Extension API Origin from Build Profile

## Release Notes

### What's Changed
- **Build-time origin injection**: Added a Vite `define` contract that injects `__HAP_API_ORIGIN__` as a JSON-stringified literal during `vite build`, allowing per-profile origins to be embedded directly into the bundle
- **Three-tier fallback resolver**: Introduced `resolveApiBaseUrl()` with strict precedence that eliminates the hard-coded origin value:
  1. Build-time injected constant `__HAP_API_ORIGIN__` (Vite define)
  2. Runtime `process.env.API_ORIGIN` (Node/test escape hatch)
  3. `DEFAULT_API_BASE_URL` constant (safe production fallback)
- **Safety handling for empty/invalid values**: Empty strings, whitespace-only strings, and non-string values are treated as "absent" across both injected and environment sources, ensuring robust fallback behavior
- **Vite config factory pattern**: Converted Vite config from static object to factory function to read `process.env.API_ORIGIN` at build time (not at config load time)
- **Updated fetcher default**: `createHubSpotApiFetcher()` now defaults `deps.baseUrl` to `resolveApiBaseUrl()` instead of directly using the hardcoded constant
- **HubSpot template expansion contract**: Documented the full pipeline where HubSpot's `hs project upload` expands `${API_ORIGIN}` in `hsmeta.json` from the active profile, and the build wrapper propagates this to the bundled code via Vite

### Scope & Risk Profile
- ✅ **In-scope**: Build-time injection mechanism, runtime resolver implementation, comprehensive test coverage
- ✅ **No behavioral change shipped**: Until stacked PR #8 wires the profile→env handoff, behavior falls back to current production URL
- ❌ **Out-of-scope**: Profile-to-environment variable setup (addressed by PR #8), template expansion in `apps/hubspot-project`, API/route/DB changes

---

## Data Flow Architecture

```mermaid
graph TD
    A["HubSpot Build Wrapper\n(Per-Profile Setup)"] -->|sets env| B["process.env.API_ORIGIN"]
    B -->|read at vite build| C["vite.config.ts\n(Factory)"]
    C -->|JSON.stringify| D["define Block\n__HAP_API_ORIGIN__"]
    D -->|bundled literal| E["Built index.js\n(Embedded String)"]
    
    F["Runtime: Extension Host\nprocess is undefined"] -->|reads| E
    G["Runtime: Node/Vitest\nprocess available"] -->|reads| H["process.env.API_ORIGIN"]
    
    E -->|→ resolveApiBaseUrl| I["Tier 1: __HAP_API_ORIGIN__\n(non-empty string?)"]
    H -->|→ resolveApiBaseUrl| I
    I -->|No| J["Tier 2: process.env.API_ORIGIN\n(Node-only, non-empty?)"]
    J -->|No| K["Tier 3: DEFAULT_API_BASE_URL\n'https://hap-signal-workspace.vercel.app'"]
    I -->|Yes| L["Return Injected Origin"]
    J -->|Yes| M["Return Env Origin"]
    K -->|Fallback| N["Return Production Default"]
    
    L --> O["createHubSpotApiFetcher\nbaseUrl = resolveApiBaseUrl"]
    M --> O
    N --> O
    O --> P["API Endpoint\n{baseUrl}/api/snapshot/{companyId}"]
```

---

## Three-Tier Resolution Precedence

| Tier | Source | Value Type | When Used | Falls Through If |
|------|--------|-----------|-----------|------------------|
| **1** | `__HAP_API_ORIGIN__` | Build-time string literal | Production (bundled code in HubSpot) | Empty, whitespace, or undefined |
| **2** | `process.env.API_ORIGIN` | Runtime string (Node only) | Testing & Vitest; Node SSR environments | Empty, whitespace, or `process` undefined |
| **3** | `DEFAULT_API_BASE_URL` | Hard-coded constant | Fallback safety net | — (always succeeds) |

**Key Safety Mechanism**: Empty strings (`""`), whitespace-only strings (`"   "`), and non-string values are treated as absent, allowing automatic fallthrough to the next tier without silent URL corruption.

---

## Testing & Verification Strategy

### Test Pyramid (12 Tests Total → 636 Tests Across Suite)

```
          ┌─────────────────────┐
          │  E2E Bundle Tests   │  ← 2 tests
          │  (Real Vite Build)  │     • Staging origin embeds correctly
          │   built-bundle-     │     • Local origin embeds correctly
          │   origin.test.ts    │     (30s timeout each)
          └────────────────────┘
                 ▲
                 │
        ┌────────────────────┐
        │ Integration Tests  │  ← 3 tests
        │ (Config Contract)  │    • Injects from process.env
        │ vite-config.       │    • Emits "" when unset
        │ test.ts            │    • Preserves values verbatim
        └────────────────────┘
                 ▲
                 │
    ┌────────────────────────────┐
    │   Unit Tests (Resolver)    │  ← 7 tests
    │ resolve-api-base-url.      │    • Prefers build-time injected
    │ test.ts                    │    • Overrides env when present
    │                            │    • Falls back to env when missing
    │  ✓ Non-empty string        │    • Rejects empty/whitespace
    │  ✓ Prefers injected        │    • Rejects non-strings
    │  ✓ Env fallback            │    • Safe default when all absent
    │  ✓ Empty/whitespace/non-   │
    │    string safety           │
    └────────────────────────────┘
```

### DD (Design & Development) Testing Traceability

#### Unit Tests: `resolve-api-base-url.test.ts` (7 tests)
| Test Case | Purpose | Traceability |
|-----------|---------|--------------|
| Returns build-time injected when non-empty string | Verify Tier 1 production path | Production bundles carry origin literally |
| Prefers injected over env override | Ensure Tier 1 > Tier 2 precedence | Multi-tier system correctly prioritizes |
| Falls back to env when injected missing | Verify Tier 2 fallback | Node runtimes can override for testing |
| Falls back when injected is empty string | Validate empty-string safety | Vite's `""` emission doesn't corrupt fallback |
| Falls back when injected is whitespace | Validate whitespace safety | Prevents silent URL failures |
| Falls back to DEFAULT when nothing set | Verify Tier 3 safety net | Misconfigured builds still have production default |
| Ignores non-string injected values | Prevent coercion bugs | Misconfigured Vite `define` doesn't crash |

#### Integration Tests: `vite-config.test.ts` (3 tests)
| Test Case | Purpose | Traceability |
|-----------|---------|--------------|
| Injects `__HAP_API_ORIGIN__` as JSON string | Verify Vite define contract | Build wrapper can rely on predictable output |
| Emits `""` when API_ORIGIN unset | Validate fallthrough signal | Confirms resolver receives correct sentinel |
| Preserves value verbatim (no normalization) | Ensure no silent trailing-slash removal | URL construction remains predictable |

**Contract Enforcement**: `vite-config.test.ts` uses dynamic module cache busting (`?env=...` query string) to force re-evaluation of the factory function under different environment states, preventing stale cache behavior.

#### E2E Tests: `built-bundle-origin.test.ts` (2 tests)
| Test Case | Purpose | Traceability |
|-----------|---------|--------------|
| Staging origin embeds into bundle | Verify real Vite build substitutes correctly | Non-prod profiles work end-to-end |
| Local origin embeds into bundle | Verify dev/local profiles work | Development workflow supported |

**Process**:
1. Creates temporary scratch directory for build outputs
2. Sets `process.env.API_ORIGIN` to test value
3. Runs actual `vite build` command via Vite API
4. Reads bundled `index.js` and asserts origin string presence
5. Cleans up temporary files in `afterAll` hook
6. 30-second timeout per build (accounts for bundler overhead)

---

## Implementation Details

### New Exported Function
```typescript
export function resolveApiBaseUrl(): string
```
- **Location**: `apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts`
- **Behavior**: Returns the correct origin URL based on three-tier precedence
- **Used by**: `createHubSpotApiFetcher()` default, tests, and any future code needing the configured origin

### Build-Time Injection
```typescript
// In vite.config.ts (factory function)
define: {
  __HAP_API_ORIGIN__: JSON.stringify(process.env.API_ORIGIN ?? "")
}
```
- **When**: At `vite build` time (happens once per profile)
- **Output**: Literal string in bundled JavaScript (e.g., `"https://staging.example.com"`)
- **Safety**: Unset env → empty string `""` → runtime resolver falls through

### Updated Fetcher Creation
```typescript
// Before: baseUrl defaults to DEFAULT_API_BASE_URL directly
// After: baseUrl defaults to resolveApiBaseUrl()
export function createHubSpotApiFetcher(deps: HubSpotApiFetcherDeps = {}): SnapshotFetcher {
  const baseUrl = deps.baseUrl ?? resolveApiBaseUrl();
  // ... uses baseUrl for /api/snapshot/{companyId} endpoint
}
```

---

## Verification Results

✅ **Local Verification**
- Typecheck: Passed (TypeScript strict mode)
- Full test suite: 636 tests passed across 73 files
- New tests: +12 tests covering resolver, config contract, and E2E bundles
- No regression in existing tests

✅ **Test Coverage Delta**
- +3 new test files
- +95 lines in resolver tests
- +94 lines in config contract tests  
- +74 lines in E2E bundle tests

---

## Migration Path & Rollout

**No action required** for this PR. The change is:
- ✅ Backward compatible (explicit `baseUrl` parameter still accepted)
- ✅ Safe by default (produces current prod URL if env not set)
- ✅ Non-breaking (no API changes to `createHubSpotApiFetcher`)

**When PR #8 lands** (profile→env handoff):
- HubSpot build wrapper will set `API_ORIGIN` env before `vite build`
- This PR's mechanism automatically picks up the profile-specific origin
- Extension bundles will carry the correct origin per profile with zero code changes here

---

## Related Context

- **Slice 8 Goal**: Enable per-profile API origin configuration for the HubSpot extension
- **Stacked with**: PR #8 (handles profile variable expansion at build wrapper level)
- **Testing Sacred**: DD approach ensures build-time and runtime behavior align; test pyramid covers factory logic, config contract, and real bundle determinism
- **No template changes**: `apps/hubspot-project/src/app/app-hsmeta.json` remains unchanged; contract preserved by anti-regression scaffold test

<!-- end of auto-generated comment: release notes by coderabbit.ai -->