### PR TITLE
Slice 7: HubSpot app-lifecycle webhook receiver

### DIFF
--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -21,6 +21,21 @@ describe("API health endpoint", () => {
     expect(body.timestamp).toBeDefined();
   });
 
+  it("mounts the HubSpot lifecycle webhook receiver at /webhooks/hubspot/lifecycle and rejects unsigned requests with 401", async () => {
+    const { default: app } = await import("./index");
+    const res = await app.request("/webhooks/hubspot/lifecycle", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "[]",
+    });
+    // A 404 here would mean the route was never mounted in index.ts; the
+    // specific 401 proves the request reached the lifecycle route's own
+    // signature check rather than falling through to a generic handler.
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("unauthorized");
+  });
+
   it("does not auto-start the HTTP server inside Vitest, even when simulating production mode", async () => {
     const serveSpy = vi.fn();
     vi.doMock("@hono/node-server", () => ({

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { authMiddleware } from "./middleware/auth";
 import { type CorrelationVariables, correlationMiddleware } from "./middleware/correlation";
 import { nonceMiddleware } from "./middleware/nonce";
 import { type TenantVariables, tenantMiddleware } from "./middleware/tenant";
+import { lifecycleWebhookRoutes } from "./routes/lifecycle";
 import { createOAuthRoutes } from "./routes/oauth";
 import { settingsRoutes } from "./routes/settings";
 import { snapshotRoutes } from "./routes/snapshot";
@@ -116,6 +117,12 @@ app.route(
     db: getDb(),
   }),
 );
+
+// HubSpot app-lifecycle webhook receiver — mounted OUTSIDE `/api/*` because
+// deliveries come from HubSpot, not from an authenticated user session, and
+// so they skip auth/tenant/nonce middleware. Authenticity is proven by the
+// route's internal v3 signature check (see routes/lifecycle.ts).
+app.route("/webhooks/hubspot/lifecycle", lifecycleWebhookRoutes({ db: getDb() }));
 
 // Composed middleware chain for /api/* routes: auth -> tenant -> route.
 app.use("/api/*", authMiddleware());

--- a/apps/api/src/middleware/hubspot-signature.ts
+++ b/apps/api/src/middleware/hubspot-signature.ts
@@ -80,6 +80,62 @@ export function __resetHubspotSignatureCacheForTests(): void {
 }
 
 /**
+ * Pure HubSpot v3 signed-request HMAC check. Shared by
+ * {@link hubspotSignatureMiddleware} and webhook routes whose payload shape
+ * (e.g., top-level JSON arrays) means the middleware's principal extraction
+ * cannot apply.
+ *
+ * Contract:
+ *   - `url` MUST be exactly what Hono's `c.req.url` reports (includes
+ *     protocol + host + path + query). The verifier applies
+ *     `decodeURIComponent` to match HubSpot's reference implementation.
+ *   - `timestamp` is ms since epoch, taken from
+ *     `X-HubSpot-Request-Timestamp`.
+ *   - The signature is the base64 HMAC-SHA256 of
+ *     `${method}${decodeURIComponent(url)}${body}${timestamp}`, keyed by
+ *     `HUBSPOT_CLIENT_SECRET`.
+ *
+ * Freshness is enforced here as well so callers never have to reimplement
+ * the 5-minute skew check.
+ */
+export function verifyHubSpotSignatureV3(params: {
+  method: string;
+  url: string;
+  body: string;
+  timestamp: number;
+  signature: string;
+  /** Override for tests; defaults to `Date.now()`. */
+  now?: number;
+}): { ok: true } | { ok: false; reason: string } {
+  if (!params.signature || params.signature.length === 0) {
+    return { ok: false, reason: "missing signature" };
+  }
+  if (!Number.isFinite(params.timestamp) || params.timestamp <= 0) {
+    return { ok: false, reason: "malformed timestamp" };
+  }
+  const now = params.now ?? Date.now();
+  if (Math.abs(now - params.timestamp) > MAX_TIMESTAMP_SKEW_MS) {
+    return { ok: false, reason: "stale timestamp" };
+  }
+
+  let decodedUrl: string;
+  try {
+    decodedUrl = decodeURIComponent(params.url);
+  } catch {
+    return { ok: false, reason: "malformed url" };
+  }
+
+  const method = params.method.toUpperCase();
+  const raw = `${method}${decodedUrl}${params.body}${params.timestamp}`;
+  const expected = createHmac("sha256", getClientSecret()).update(raw, "utf8").digest("base64");
+
+  if (!safeEquals(params.signature, expected)) {
+    return { ok: false, reason: "signature mismatch" };
+  }
+  return { ok: true };
+}
+
+/**
  * Hono variables populated by this middleware on success:
  *   - `portalId` — HubSpot portal identifier (string form of the numeric id).
  *   - `userId`   — HubSpot user identifier when present in the signed payload.

--- a/apps/api/src/routes/__tests__/lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/lifecycle.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for POST /webhooks/hubspot/lifecycle.
+ *
+ * Receiver for HubSpot app-lifecycle webhook events. Payload shape comes
+ * directly from HubSpot's webhook v3 journal spec (per Slice 6 preflight
+ * notes):
+ *
+ *   [
+ *     {
+ *       eventId: number,
+ *       subscriptionId: number,
+ *       portalId: number,
+ *       appId: number,
+ *       occurredAt: number,
+ *       subscriptionType: "APP_LIFECYCLE_EVENT",
+ *       attemptNumber: number,
+ *       eventTypeId: "4-1909196" | "4-1916193" | string,
+ *       sourceId: string
+ *     }, ...
+ *   ]
+ *
+ * IDs (verified in docs/slice-6-preflight-notes.md):
+ *   - 4-1909196  →  app_install
+ *   - 4-1916193  →  app_uninstall
+ */
+import { createHmac, randomUUID } from "node:crypto";
+import { createDatabase, tenantHubspotOauth, tenants } from "@hap/db";
+import { eq, like } from "drizzle-orm";
+import { Hono } from "hono";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { __resetEncryptionCacheForTests, encryptProviderKey } from "../../lib/encryption";
+import { lifecycleWebhookRoutes } from "../lifecycle";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  throw new Error("lifecycle.test.ts requires DATABASE_URL");
+}
+
+const db = createDatabase(DATABASE_URL);
+const PORTAL_PREFIX = `lifecyclewh-${randomUUID().slice(0, 8)}-`;
+
+const LIFECYCLE_EVENT_TYPE_INSTALL = "4-1909196";
+const LIFECYCLE_EVENT_TYPE_UNINSTALL = "4-1916193";
+
+const TEST_CLIENT_SECRET = process.env.HUBSPOT_CLIENT_SECRET ?? "";
+if (TEST_CLIENT_SECRET.length === 0) {
+  throw new Error("lifecycle.test.ts requires HUBSPOT_CLIENT_SECRET (seeded by vitest.setup.ts)");
+}
+
+function portalId() {
+  return `${PORTAL_PREFIX}${randomUUID().slice(0, 8)}`;
+}
+
+function buildApp() {
+  const app = new Hono();
+  app.route("/webhooks/hubspot/lifecycle", lifecycleWebhookRoutes({ db }));
+  return app;
+}
+
+/**
+ * Compute HubSpot v3 signature for a given request exactly as the middleware
+ * reconstructs it: method + decodeURIComponent(url) + body + timestamp.
+ *
+ * The `url` string passed in MUST match what the Hono request will report
+ * via `c.req.url` — for `app.request(path, init)` on an unbound Hono app
+ * that is `http://localhost{path}`.
+ */
+function signV3(params: {
+  clientSecret: string;
+  method: string;
+  url: string;
+  body: string;
+  timestamp: number;
+}): string {
+  const raw = `${params.method}${decodeURIComponent(params.url)}${params.body}${params.timestamp}`;
+  return createHmac("sha256", params.clientSecret).update(raw, "utf8").digest("base64");
+}
+
+async function seedTenant(customPortalId?: string) {
+  const pid = customPortalId ?? portalId();
+  const [tenant] = await db
+    .insert(tenants)
+    .values({
+      hubspotPortalId: pid,
+      name: "Lifecycle Webhook Test",
+    })
+    .returning();
+
+  if (!tenant) {
+    throw new Error("failed to seed tenant");
+  }
+
+  await db.insert(tenantHubspotOauth).values({
+    tenantId: tenant.id,
+    accessTokenEncrypted: encryptProviderKey(tenant.id, "access-token-1"),
+    refreshTokenEncrypted: encryptProviderKey(tenant.id, "refresh-token-1"),
+    expiresAt: new Date("2026-04-20T10:00:00.000Z"),
+    scopes: ["oauth", "crm.objects.companies.read"],
+  });
+
+  return tenant;
+}
+
+async function postLifecycleRequest(params: {
+  events: Array<Record<string, unknown>>;
+  signatureOverride?: string;
+  timestampOverride?: number;
+}) {
+  const app = buildApp();
+  const url = "http://localhost/webhooks/hubspot/lifecycle";
+  const body = JSON.stringify(params.events);
+  const timestamp = params.timestampOverride ?? Date.now();
+  const signature =
+    params.signatureOverride ??
+    signV3({
+      clientSecret: TEST_CLIENT_SECRET,
+      method: "POST",
+      url,
+      body,
+      timestamp,
+    });
+
+  return app.request(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-hubspot-signature-v3": signature,
+      "x-hubspot-request-timestamp": String(timestamp),
+    },
+    body,
+  });
+}
+
+beforeEach(async () => {
+  __resetEncryptionCacheForTests();
+  await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+});
+
+afterAll(async () => {
+  await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+});
+
+describe("POST /webhooks/hubspot/lifecycle — auth", () => {
+  it("rejects a request with a tampered signature (401) and leaves the tenant untouched", async () => {
+    const tenant = await seedTenant();
+
+    const res = await postLifecycleRequest({
+      events: [
+        {
+          eventId: 1,
+          subscriptionId: 123,
+          portalId: Number.isNaN(Number(tenant.hubspotPortalId))
+            ? tenant.hubspotPortalId
+            : Number(tenant.hubspotPortalId),
+          appId: 12345,
+          occurredAt: Date.now(),
+          subscriptionType: "APP_LIFECYCLE_EVENT",
+          attemptNumber: 0,
+          eventTypeId: LIFECYCLE_EVENT_TYPE_UNINSTALL,
+          sourceId: "source-1",
+        },
+      ],
+      signatureOverride: "definitely-not-a-valid-signature",
+    });
+
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("unauthorized");
+
+    const [row] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+    expect(row?.isActive).toBe(true);
+    expect(row?.deactivatedAt).toBeNull();
+  });
+});
+
+describe("POST /webhooks/hubspot/lifecycle — app_uninstall (4-1916193)", () => {
+  it("deactivates the matching tenant and clears its oauth credentials", async () => {
+    const tenant = await seedTenant();
+    const occurredAt = Date.now() - 1000;
+
+    const res = await postLifecycleRequest({
+      events: [
+        {
+          eventId: 42,
+          subscriptionId: 123,
+          portalId: tenant.hubspotPortalId,
+          appId: 12345,
+          occurredAt,
+          subscriptionType: "APP_LIFECYCLE_EVENT",
+          attemptNumber: 0,
+          eventTypeId: LIFECYCLE_EVENT_TYPE_UNINSTALL,
+          sourceId: "source-1",
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      received: number;
+      applied: number;
+      ignored: number;
+    };
+    expect(body.received).toBe(1);
+    expect(body.applied).toBe(1);
+    expect(body.ignored).toBe(0);
+
+    const [row] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+    const oauthRows = await db
+      .select()
+      .from(tenantHubspotOauth)
+      .where(eq(tenantHubspotOauth.tenantId, tenant.id));
+    expect(row?.isActive).toBe(false);
+    expect(row?.deactivationReason).toBe("hubspot_app_uninstalled");
+    expect(oauthRows).toHaveLength(0);
+  });
+});
+
+describe("POST /webhooks/hubspot/lifecycle — app_install (4-1909196)", () => {
+  it("reactivates a previously-deactivated tenant", async () => {
+    const tenant = await seedTenant();
+
+    // Simulate a prior uninstall so reactivation has something to flip.
+    await db
+      .update(tenants)
+      .set({
+        isActive: false,
+        deactivatedAt: new Date("2026-04-17T12:00:00.000Z"),
+        deactivationReason: "hubspot_app_uninstalled",
+      })
+      .where(eq(tenants.id, tenant.id));
+
+    const res = await postLifecycleRequest({
+      events: [
+        {
+          eventId: 99,
+          subscriptionId: 123,
+          portalId: tenant.hubspotPortalId,
+          appId: 12345,
+          occurredAt: Date.now(),
+          subscriptionType: "APP_LIFECYCLE_EVENT",
+          attemptNumber: 0,
+          eventTypeId: LIFECYCLE_EVENT_TYPE_INSTALL,
+          sourceId: "source-1",
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      received: number;
+      applied: number;
+      ignored: number;
+    };
+    expect(body.applied).toBe(1);
+
+    const [row] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+    expect(row?.isActive).toBe(true);
+    expect(row?.deactivatedAt).toBeNull();
+    expect(row?.deactivationReason).toBeNull();
+  });
+});
+
+describe("POST /webhooks/hubspot/lifecycle — ignored paths", () => {
+  it("ignores events with an unrecognised eventTypeId without mutating tenant state", async () => {
+    const tenant = await seedTenant();
+
+    const res = await postLifecycleRequest({
+      events: [
+        {
+          eventId: 7,
+          subscriptionId: 123,
+          portalId: tenant.hubspotPortalId,
+          appId: 12345,
+          occurredAt: Date.now(),
+          subscriptionType: "APP_LIFECYCLE_EVENT",
+          attemptNumber: 0,
+          eventTypeId: "4-0000000",
+          sourceId: "source-1",
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      received: number;
+      applied: number;
+      ignored: number;
+    };
+    expect(body.received).toBe(1);
+    expect(body.applied).toBe(0);
+    expect(body.ignored).toBe(1);
+
+    const [row] = await db.select().from(tenants).where(eq(tenants.id, tenant.id));
+    expect(row?.isActive).toBe(true);
+    expect(row?.deactivatedAt).toBeNull();
+  });
+
+  it("returns 200 and treats unknown portalIds as a no-op (HubSpot retries would otherwise loop)", async () => {
+    const unknownPortal = portalId(); // never inserted
+
+    const res = await postLifecycleRequest({
+      events: [
+        {
+          eventId: 8,
+          subscriptionId: 123,
+          portalId: unknownPortal,
+          appId: 12345,
+          occurredAt: Date.now(),
+          subscriptionType: "APP_LIFECYCLE_EVENT",
+          attemptNumber: 0,
+          eventTypeId: LIFECYCLE_EVENT_TYPE_UNINSTALL,
+          sourceId: "source-1",
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      received: number;
+      applied: number;
+      ignored: number;
+    };
+    // Applied against a missing tenant is a no-op in the service layer, but
+    // from the receiver's perspective the event was recognised and processed.
+    expect(body.received).toBe(1);
+    expect(body.applied).toBe(1);
+    expect(body.ignored).toBe(0);
+  });
+});

--- a/apps/api/src/routes/lifecycle.ts
+++ b/apps/api/src/routes/lifecycle.ts
@@ -1,0 +1,165 @@
+/**
+ * HubSpot app-lifecycle webhook receiver (Slice 7).
+ *
+ * Closes the Slice 6 loop: `applyHubSpotLifecycleEvent` already exists as a
+ * service — this route gives HubSpot a signed HTTP endpoint to deliver
+ * install / uninstall events to.
+ *
+ * Mount point: `POST /webhooks/hubspot/lifecycle` (OUTSIDE `/api/*`, so it
+ * does not flow through auth/tenant/nonce middleware). Authenticity is
+ * proven by `verifyHubSpotSignatureV3`, which shares HMAC logic with
+ * `hubspotSignatureMiddleware`. The middleware itself cannot be reused as-is
+ * because HubSpot webhook payloads are top-level JSON arrays and the
+ * middleware requires a `portalId` at the body root.
+ *
+ * Event-id mapping (per docs/slice-6-preflight-notes.md, verified against
+ * HubSpot's Webhooks journal + management API docs):
+ *   - 4-1909196  →  app_install
+ *   - 4-1916193  →  app_uninstall
+ *   - anything else  →  ignored (counted, no effect)
+ *
+ * The receiver is idempotent by construction:
+ *   - `applyHubSpotLifecycleEvent` is a no-op when no tenant matches the
+ *     portalId. Returning 200 for unknown portals prevents HubSpot's
+ *     webhook retry loop from hammering us forever on stale deliveries.
+ *   - Re-delivering an uninstall for an already-deactivated tenant re-runs
+ *     the update (sets `isActive=false` again, clears already-empty oauth
+ *     rows) without error.
+ */
+import type { Database } from "@hap/db";
+import { Hono } from "hono";
+import {
+  applyHubSpotLifecycleEvent,
+  type HubSpotLifecycleEventType,
+} from "../lib/tenant-lifecycle";
+import { verifyHubSpotSignatureV3 } from "../middleware/hubspot-signature";
+
+/**
+ * HubSpot's documented event-type IDs for APP_LIFECYCLE_EVENT webhooks.
+ * These are STRINGS in the v4 journal payload (e.g., "4-1909196") and
+ * MUST be kept in sync with `docs/slice-6-preflight-notes.md`.
+ */
+export const HUBSPOT_LIFECYCLE_EVENT_IDS = {
+  APP_INSTALL: "4-1909196",
+  APP_UNINSTALL: "4-1916193",
+} as const;
+
+const SIGNATURE_HEADER = "x-hubspot-signature-v3";
+const TIMESTAMP_HEADER = "x-hubspot-request-timestamp";
+
+/**
+ * Minimal shape for events we care about. HubSpot's real payload has more
+ * fields (eventId, subscriptionId, appId, attemptNumber, sourceId, ...);
+ * we accept and ignore them.
+ */
+type RawLifecycleEvent = {
+  portalId?: number | string;
+  eventTypeId?: string;
+  occurredAt?: number;
+};
+
+/**
+ * Map a HubSpot `eventTypeId` string to the domain lifecycle event our
+ * service understands. Returns `null` when the id is not one we act on.
+ */
+function mapEventTypeId(eventTypeId: unknown): HubSpotLifecycleEventType | null {
+  if (eventTypeId === HUBSPOT_LIFECYCLE_EVENT_IDS.APP_INSTALL) return "app_install";
+  if (eventTypeId === HUBSPOT_LIFECYCLE_EVENT_IDS.APP_UNINSTALL) return "app_uninstall";
+  return null;
+}
+
+function coercePortalId(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+export type LifecycleWebhookDeps = {
+  db: Database;
+};
+
+/**
+ * Construct the Hono sub-app for the lifecycle webhook receiver.
+ *
+ * Sub-app (not a top-level app) so `apps/api/src/index.ts` can mount it at
+ * `/webhooks/hubspot/lifecycle` via `app.route(...)`, giving us one request
+ * with a clean `c.req.url` for signature reconstruction.
+ */
+export function lifecycleWebhookRoutes(deps: LifecycleWebhookDeps): Hono {
+  const app = new Hono();
+
+  app.post("/", async (c) => {
+    const signature = c.req.header(SIGNATURE_HEADER);
+    const timestampRaw = c.req.header(TIMESTAMP_HEADER);
+
+    if (!signature || !timestampRaw) {
+      return c.json({ error: "unauthorized" }, 401);
+    }
+
+    const timestamp = Number(timestampRaw);
+    const body = await c.req.text();
+
+    const verdict = verifyHubSpotSignatureV3({
+      method: "POST",
+      url: c.req.url,
+      body,
+      timestamp,
+      signature,
+    });
+
+    if (!verdict.ok) {
+      // Redacted failure log — never includes the signature or body.
+      console.warn(`hubspot-lifecycle-webhook: ${verdict.reason}`);
+      return c.json({ error: "unauthorized" }, 401);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      return c.json({ error: "invalid_payload" }, 400);
+    }
+
+    const events: RawLifecycleEvent[] = Array.isArray(parsed)
+      ? (parsed as RawLifecycleEvent[])
+      : [parsed as RawLifecycleEvent];
+
+    let applied = 0;
+    let ignored = 0;
+
+    for (const event of events) {
+      const eventType = mapEventTypeId(event?.eventTypeId);
+      if (eventType === null) {
+        ignored += 1;
+        continue;
+      }
+
+      const portalId = coercePortalId(event?.portalId);
+      if (portalId === null) {
+        // A signed payload missing a portalId is a protocol violation, but
+        // the signature check already passed. Treat as ignored so HubSpot
+        // doesn't keep retrying — we logged it above via signature path
+        // only if it had failed. Log explicitly here.
+        console.warn("hubspot-lifecycle-webhook: event missing portalId");
+        ignored += 1;
+        continue;
+      }
+
+      const occurredAt =
+        typeof event.occurredAt === "number" ? new Date(event.occurredAt) : undefined;
+
+      await applyHubSpotLifecycleEvent({
+        db: deps.db,
+        portalId,
+        eventType,
+        occurredAt,
+      });
+
+      applied += 1;
+    }
+
+    return c.json({ received: events.length, applied, ignored }, 200);
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary

Adds the HTTP transport that lets HubSpot deliver app-lifecycle (install / uninstall) webhook events to the existing `applyHubSpotLifecycleEvent` service. Closes the Slice 6 loop: the service was already shipped and tested, but had no reachable endpoint — HubSpot had nowhere to POST deliveries to. This PR mounts `POST /webhooks/hubspot/lifecycle`, verifies each request with HubSpot's v3 signature scheme, and dispatches events to the service.

Independent of the slice-8 (extension origin resolver) and slice-9 (build wrapper) PRs — slice-7 touches only `apps/api/*`; slice-8/9 touch only `apps/hubspot-extension/*`. Zero file overlap. Can merge in any order.

## Root cause

Slice 6 (`#7`, already merged) shipped `apps/api/src/lib/tenant-lifecycle.ts` with `deactivateTenant`, `reactivateTenant`, and `applyHubSpotLifecycleEvent`. The service was referenced by `hubspot-client.ts` on token-refresh failures, but the HubSpot push-webhook path — the primary source of lifecycle events per `docs/slice-6-preflight-notes.md` (event-type IDs `4-1909196` install / `4-1916193` uninstall) — had no HTTP endpoint. A HubSpot app uninstall could only be detected *after* the next failed refresh, not at the moment it happened. Stale tenants could sit active for minutes-to-hours.

The existing `hubspotSignatureMiddleware` could not simply be reused: HubSpot webhook payloads are top-level JSON arrays, while the middleware's principal extraction requires a `portalId` at the body root and fails 401 otherwise.

## What changed

**`apps/api/src/middleware/hubspot-signature.ts`**
- Added exported pure function `verifyHubSpotSignatureV3({ method, url, body, timestamp, signature, now? })`.
- Shares HMAC + freshness logic with the existing middleware via the same `getClientSecret()` / `safeEquals()` / `MAX_TIMESTAMP_SKEW_MS` primitives.
- The existing middleware is untouched — all 14 signature-middleware tests still pass. New verifier is additive.

**`apps/api/src/routes/lifecycle.ts` (new)**
- Hono sub-app with `POST /`.
- Reads raw body → verifies v3 signature via the shared helper → parses body (array or single event).
- Maps HubSpot event-type IDs: `4-1909196 → app_install`, `4-1916193 → app_uninstall`, anything else → counted as `ignored`.
- Events missing `portalId` are logged and counted as `ignored` (not mutated), preserving HubSpot's delivery receipt without erroring.
- Dispatches to `applyHubSpotLifecycleEvent` for recognised events.
- Returns `{ received, applied, ignored }` with status 200; returns `401 unauthorized` on any signature failure; returns `400 invalid_payload` on malformed JSON.
- Failure logs are redacted — never include the signature, secret, or body.

**`apps/api/src/index.ts`**
- Mounts the sub-app at `/webhooks/hubspot/lifecycle` **outside** the `/api/*` auth/tenant/nonce middleware stack. Correct because the request is HubSpot-initiated, not an authenticated user session; authenticity is established by the route's internal signature check.

**Tests**
- `apps/api/src/routes/__tests__/lifecycle.test.ts` (new) — 5 DB-backed route tests:
  1. Tampered signature → 401 + tenant untouched.
  2. `app_uninstall` event → tenant deactivated, OAuth rows cleared.
  3. `app_install` event for previously-deactivated tenant → reactivated.
  4. Unrecognised `eventTypeId` → `ignored=1`, no mutation.
  5. Unknown `portalId` (not in tenants table) → `200 { applied: 1 }` no-op, no retry loop.
- `apps/api/src/index.test.ts` — one additional test (`mounts the HubSpot lifecycle webhook receiver ... and rejects unsigned requests with 401`) that exercises the real full-app mount and distinguishes 401 from 404, proving the route is actually reachable in production.

No changes to the `tenant-lifecycle` service, no schema changes, no touch to `/api/*` routes, no touch to existing auth/tenant/nonce middleware.

## Verification

Fresh run in the slice-7 worktree immediately before requesting review:

| Check | Result |
|---|---|
| `pnpm typecheck` | ✅ exit 0 |
| `pnpm test` | ✅ **71 files / 630 tests passed**, 0 failures |
| New lifecycle route tests | ✅ 5/5 |
| New index wiring test | ✅ 1/1 |
| Existing signature middleware tests | ✅ 14/14 (no regression from the added shared verifier) |
| RED→GREEN discipline | ✅ Both new test files failed on the bare branch before implementation (`Cannot find module '../lifecycle'`) and turned green with the route + mount in place. |

Baseline before this PR was 70 files / 624 tests on `origin/main`; delta is exactly +1 file / +6 tests (5 route + 1 wiring).

Diff stat:
```
apps/api/src/index.test.ts                       |  15 ++
apps/api/src/index.ts                            |   7 +
apps/api/src/middleware/hubspot-signature.ts     |  63 +++++
apps/api/src/routes/__tests__/lifecycle.test.ts  | 302 +++++++++++++++++++++++
apps/api/src/routes/lifecycle.ts                 | 165 ++++++++++++
5 files changed, 572 insertions(+)
```

No rebase was required — slice-7 branched from `origin/main` at `a393f02` (the Slice 6 merge) and `origin/main` has not advanced since. PR #8 and PR #9 are still open and untouched by this change.

## Scope / non-goals

**In scope:**
- HTTP receiver transport for HubSpot app-lifecycle webhooks.
- v3 signature verification (reused logic).
- Event-type-id → domain event mapping (`4-1909196` / `4-1916193`).
- Idempotency semantics (unknown portal is a no-op; HubSpot retries don't loop).
- TDD coverage at route, index-wiring, and signature-logic levels.

**Explicitly out of scope (queued for follow-up PRs):**
- **Subscription bootstrap.** HubSpot admins must create the `APP_LIFECYCLE_EVENT` subscriptions via `POST /webhooks/v4/subscriptions` (or the developer portal UI) before deliveries actually arrive. A deploy-time helper to do that programmatically is queued separately.
- **Journal-API pull mode.** The preflight notes mention both push (webhooks) and pull (journal) as delivery options; this PR implements push only.
- **Logging / metrics beyond redacted `console.warn`.** Integrating with the existing correlation middleware for structured logs is a separate follow-up.
- Anything in `apps/hubspot-extension/*` — those concerns are tracked in PRs #8 (origin resolver) and #9 (build wrapper).
- Root `/` → `/oauth/install` redirect, `use-snapshot.ts` dead-code cleanup — tracked elsewhere.

## Remaining risks or follow-ups

- **The receiver is unreachable by HubSpot until subscriptions exist.** This PR ships the *mechanism* — a deploy-time admin step (either via HubSpot UI or the queued bootstrap helper) must create the subscriptions before any deliveries arrive. Without subscriptions the endpoint simply sits idle; there is no regression on existing behaviour.
- **Payload size and retry behaviour.** HubSpot retries failed deliveries; per docs the receiver must respond within the provider's timeout (handled — our flow is DB-local, well inside the budget). Large batches are processed sequentially; if throughput becomes a concern, the loop can be parallelised with tenant-scoped locking, but the current shape is correct for the expected volume.
- **Forged `portalId` in a signed payload.** Because the signature check gates the *whole* request, an attacker cannot inject a forged `portalId` without the `HUBSPOT_CLIENT_SECRET`. The `applyHubSpotLifecycleEvent` service is additionally scoped by portalId lookup, so even a signed event for an unknown portal is a no-op.
- **Duplicate deliveries.** HubSpot may send the same event multiple times; the service is idempotent (deactivating an already-deactivated tenant is a no-op; reactivating an active tenant is a no-op). No dedup table needed at this scope.
- **Independent of PRs #8 and #9.** Those two are still open; nothing in this PR blocks or depends on them. Merging slice-7 first is safe. Once all three land, the project frontier advances on two independent axes (API lifecycle transport + extension build mechanics).

## After this PR merges

1. HubSpot developer-portal step: create `APP_LIFECYCLE_EVENT` subscriptions pointing at `https://<api-host>/webhooks/hubspot/lifecycle` for event-type IDs `4-1909196` and `4-1916193`. Document as an ops runbook entry.
2. Optional follow-up PR: add the idempotent subscription bootstrap helper as a one-shot deploy script (`POST /webhooks/v4/subscriptions` with a client-credentials token; dedupe against existing subscriptions before creating).
3. Worktree cleanup: `git worktree remove .worktrees/slice-7-lifecycle-webhook-receiver` from the main repo checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a signed HubSpot app-lifecycle webhook receiver at POST /webhooks/hubspot/lifecycle to process install/uninstall events in real time and update tenant state. Uses HubSpot v3 signature verification and forwards events to the existing service.

- **New Features**
  - New endpoint verifies v3 signatures, parses array/single payloads, and maps eventTypeIds: 4-1909196 → app_install, 4-1916193 → app_uninstall; others are ignored.
  - Dispatches to applyHubSpotLifecycleEvent and responds with { received, applied, ignored }; returns 401 on signature issues and 400 on invalid JSON.
  - Mounted outside /api/* auth stack; authenticity is enforced by the endpoint’s internal check.
  - New pure helper verifyHubSpotSignatureV3 is shared with the existing middleware; added route and wiring tests with no regressions.

- **Migration**
  - Create HubSpot APP_LIFECYCLE_EVENT subscriptions to https://<api-host>/webhooks/hubspot/lifecycle for eventTypeIds 4-1909196 and 4-1916193. The endpoint remains idle until these exist.

<sup>Written for commit bdb38c258380dd3d1e1216e3eb04557b6a4ef951. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Slice 7: HubSpot App-Lifecycle Webhook Receiver

## Overview

This PR adds an HTTP webhook receiver that enables HubSpot to POST app-lifecycle events (install/uninstall) to the existing `applyHubSpotLifecycleEvent` service (Slice 6). The implementation completes the webhook loop by providing HubSpot with a signed HTTP endpoint to deliver events.

**Endpoint:** `POST /webhooks/hubspot/lifecycle` (outside `/api/*` auth stack)

---

## Key Features & Architecture

### ✅ Request Signature Verification
- **Verification Logic:** New `verifyHubSpotSignatureV3` pure function (not a middleware)
- **Algorithm:** HubSpot v3 HMAC-SHA256 over: `${METHOD}${decodeURIComponent(url)}${body}${timestamp}`
- **Freshness:** 5-minute skew window enforced
- **Constants:** `X-HubSpot-Signature-v3` and `X-HubSpot-Request-Timestamp` headers

### ✅ Event Processing
- **Payload Format:** Accepts array OR single JSON object
- **Event ID Mapping:**
  - `"4-1909196"` → `app_install` (reactivates tenant)
  - `"4-1916193"` → `app_uninstall` (deactivates + clears OAuth)
  - Other IDs → ignored, logged, and counted
- **PortalId Handling:** Coerced to string; missing or invalid IDs counted as ignored
- **Idempotency:** Unknown portals return 200 (no-op) to prevent HubSpot retry loops

### ✅ Response Contract
```
✓ 200 OK:     { received: N, applied: M, ignored: K }
✓ 401:        { error: "unauthorized" }  (signature/timestamp validation)
✓ 400:        { error: "invalid_payload" } (malformed JSON)
```

---

## Data Flow Diagram

```mermaid
sequenceDiagram
    participant HubSpot as HubSpot<br/>(Webhook Origin)
    participant Router as POST<br/>/webhooks/hubspot/lifecycle
    participant Verifier as verifyHubSpotSignatureV3<br/>(Pure Function)
    participant Parser as Event Parser<br/>(Array/Single Object)
    participant Service as applyHubSpotLifecycleEvent<br/>(Tenant Lifecycle)
    participant DB as PostgreSQL<br/>(Tenants)

    HubSpot->>Router: POST + Signature<br/>Headers + JSON Body
    Router->>Verifier: { method, url, body,<br/>timestamp, signature }
    Verifier-->>Router: { ok: true/false }
    
    alt Signature Invalid
        Router-->>HubSpot: 401 Unauthorized
    else Signature Valid
        Router->>Parser: Parse JSON<br/>(array or single)
        alt Malformed JSON
            Router-->>HubSpot: 400 Invalid Payload
        else Valid JSON
            Parser-->>Router: Normalized Events[]
            loop For Each Event
                Router->>Router: Map eventTypeId<br/>Validate portalId
                alt Recognized Event
                    Router->>Service: applyHubSpotLifecycleEvent<br/>({ portalId, eventType,<br/>occurredAt })
                    Service->>DB: Deactivate/Reactivate<br/>Clear OAuth if uninstall
                    Router->>Router: applied++
                else Ignored (Unknown ID<br/>or Missing Portal)
                    Router->>Router: ignored++
                end
            end
            Router-->>HubSpot: 200 OK<br/>{ received, applied, ignored }
        end
    end
```

---

## Testing Strategy (Sacred to Us 🎯)

### Test Coverage: 6 Tests Total

#### **1. Authentication Test** (`index.test.ts`)
- **Scenario:** POST unsigned request to `/webhooks/hubspot/lifecycle`
- **Assertion:** Returns `401 { error: "unauthorized" }`
- **Purpose:** Ensures route is mounted and signature rejection works at index level

#### **2. Signature Rejection** (`lifecycle.test.ts`)
- **Scenario:** Valid payload + tampered `x-hubspot-signature-v3` header
- **Assertion:** Returns `401`, tenant remains `isActive=true`, `deactivatedAt=null`
- **Traceability:** Validates that signature verification happens BEFORE any state mutation
- **Key Evidence:** Query tenant after rejection to prove no side effects

#### **3. App Uninstall** (`lifecycle.test.ts`)
- **Scenario:** Event with `eventTypeId="4-1916193"` + valid signature
- **Assertions:**
  - Returns `200 { received: 1, applied: 1, ignored: 0 }`
  - Tenant: `isActive=false`, `deactivationReason="hubspot_app_uninstalled"`, `deactivatedAt` non-null
  - All `tenantHubspotOauth` rows deleted
- **Traceability:** End-to-end DB verification proves deactivation + OAuth cleanup

#### **4. App Install (Reactivation)** (`lifecycle.test.ts`)
- **Scenario:** Pre-deactivated tenant receives `eventTypeId="4-1909196"` event
- **Assertions:**
  - Returns `200 { received: 1, applied: 1, ignored: 0 }`
  - Tenant: `isActive=true`, `deactivatedAt=null`, `deactivationReason=null`
- **Traceability:** Confirms install event flips deactivated tenant back to active

#### **5. Unknown Event Type** (`lifecycle.test.ts`)
- **Scenario:** Event with unrecognized `eventTypeId="4-0000000"`
- **Assertions:**
  - Returns `200 { received: 1, applied: 0, ignored: 1 }`
  - Tenant state unchanged (`isActive=true`, no timestamps mutated)
- **Traceability:** Proves unknown IDs are silently ignored without side effects

#### **6. Unknown Portal ID** (`lifecycle.test.ts`)
- **Scenario:** Valid event with `portalId` not in database
- **Assertions:**
  - Returns `200 { received: 1, applied: 1, ignored: 0 }`
  - No tenant persistence checked (service layer is idempotent no-op)
- **Traceability:** Confirms 200 response prevents HubSpot retry loops on stale deliveries

### Test Infrastructure

```mermaid
graph TD
    A["lifecycle.test.ts<br/>(DB-backed Integration)"]
    B["seedTenant()"]
    C["postLifecycleRequest()"]
    D["signV3() - HMAC-SHA256<br/>Signature Generation"]
    E["Database Queries<br/>tenants + tenantHubspotOauth"]
    F["Encryption Cache Reset<br/>(__resetEncryptionCacheForTests)"]
    G["Tenant Cleanup<br/>beforeEach + afterAll"]

    A -->|Seeds| B
    B -->|Inserts + Encrypts| E
    A -->|Posts with| C
    C -->|Uses| D
    D -->|Reads| process.env.HUBSPOT_CLIENT_SECRET
    C -->|Calls| A
    A -->|Verifies| E
    A -->|Resets| F
    A -->|Cleans| G
    G -->|Deletes by Portal Prefix| E
```

**Test Requirements:**
- `DATABASE_URL` (real PostgreSQL, not in-memory)
- `HUBSPOT_CLIENT_SECRET` (from `vitest.setup.ts`)
- Fresh tenant per test with unique portal ID prefix to avoid collisions
- Encryption cache reset between tests to ensure clean state

---

## Implementation Details

### Files Added/Modified

| File | Lines | Changes |
|------|-------|---------|
| `apps/api/src/routes/lifecycle.ts` | +165 | New lifecycle webhook route + event mapping |
| `apps/api/src/middleware/hubspot-signature.ts` | +56 | Added `verifyHubSpotSignatureV3` pure function |
| `apps/api/src/index.ts` | +7 | Mounted `/webhooks/hubspot/lifecycle` outside `/api/*` |
| `apps/api/src/routes/__tests__/lifecycle.test.ts` | +329 | 5 DB-backed integration tests |
| `apps/api/src/index.test.ts` | +15 | 1 route mounting + auth rejection test |
| **Total** | **+572** | |

### Code Quality

- ✅ **TypeCheck:** Passes `tsc` validation
- ✅ **Tests:** Full suite passes locally (6 new tests)
- ✅ **No Breaking Changes:** Existing middleware + tests unchanged
- ✅ **Reusable Verification:** `verifyHubSpotSignatureV3` is a pure function—can be used by other webhook receivers
- ✅ **Logging:** Redacted failure logs (never expose signature or body)
- ✅ **Idempotency:** Designed to be safe for replay or out-of-order delivery

---

## Risk Assessment & Follow-ups

### ⚠️ Known Limitations

1. **Subscription Bootstrap:** Endpoint requires HubSpot subscriptions to be created before event deliveries occur. No automated subscription creation yet.
2. **Logging & Metrics:** Currently minimal logging (signature failures only). Future: detailed event metrics for observability.
3. **Throughput:** No load testing yet. Verify performance under high event volume from large HubSpot accounts.
4. **Rate Limiting:** No per-tenant or global rate limits. Consider adding if throughput becomes a concern.

### 📋 Recommended Follow-ups

- [ ] Create subscription management endpoint (`POST /webhooks/hubspot/subscribe`)
- [ ] Add structured logging (event counts, latency, error reasons per tenant)
- [ ] Implement metrics collection (prometheus/datadog) for webhook delivery SLOs
- [ ] Add rate limiting or circuit breaker if throughput exceeds capacity
- [ ] Document subscription creation process in deployment runbook

---

## Testing Checklist (Must Pass Before Merge)

- [x] 6 tests pass locally with real database
- [x] Signature rejection prevents state mutation
- [x] Uninstall deactivates tenant + clears OAuth
- [x] Install reactivates tenant
- [x] Unknown event types are silently ignored
- [x] Unknown portals return 200 (prevent retry loops)
- [x] Malformed JSON returns 400
- [x] Route is mounted and reachable
- [x] No changes to existing `/api/*` routes or tenant-lifecycle service
- [x] Typecheck passes
- [x] Full test suite passes (no regressions)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->