### PR TITLE
Slice 10: wire profile API_ORIGIN into HubSpot upload pipeline

### DIFF
--- a/apps/hubspot-extension/__tests__/built-bundle-origin.test.ts
+++ b/apps/hubspot-extension/__tests__/built-bundle-origin.test.ts
@@ -1,0 +1,74 @@
+/**
+ * End-to-end determinism check for the extension bundle.
+ *
+ * Loads the Vite config with different `API_ORIGIN` values, runs a real
+ * `vite build` under each, and proves the produced bundle carries the
+ * expected origin string verbatim. This closes the gap that
+ * `vite-config.test.ts` cannot — the config contract is correct *and* the
+ * bundler actually performs the substitution.
+ *
+ * Builds are slow (~1-2s each) so we scope to two targeted origins rather
+ * than the full matrix. Bundle output is written to a temporary directory
+ * outside `dist/` so local dev state isn't touched.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { build } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const EXTENSION_ROOT = resolvePath(__dirname, "..");
+
+async function buildWith(apiOrigin: string, outDir: string): Promise<string> {
+  const prev = process.env.API_ORIGIN;
+  process.env.API_ORIGIN = apiOrigin;
+  try {
+    await build({
+      configFile: resolvePath(EXTENSION_ROOT, "vite.config.ts"),
+      root: EXTENSION_ROOT,
+      logLevel: "error",
+      build: {
+        outDir,
+        emptyOutDir: true,
+      },
+    });
+  } finally {
+    if (prev === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = prev;
+    }
+  }
+  return readFileSync(join(outDir, "index.js"), "utf8");
+}
+
+let scratchRoot: string;
+
+beforeAll(() => {
+  scratchRoot = mkdtempSync(join(tmpdir(), "hap-ext-build-"));
+  mkdirSync(scratchRoot, { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(scratchRoot, { recursive: true, force: true });
+});
+
+describe("hubspot-extension built bundle — origin determinism", () => {
+  it("embeds a staging API_ORIGIN literally into the bundle", async () => {
+    const origin = "https://hap-signal-workspace-staging.vercel.app";
+    const out = join(scratchRoot, "staging");
+    const bundle = await buildWith(origin, out);
+
+    expect(bundle).toContain(origin);
+    // Sanity: the unrelated prod URL must NOT appear when staging built.
+    expect(bundle).not.toContain("https://hap-signal-workspace.vercel.app/api/snapshot/");
+  }, 30_000);
+
+  it("embeds a local API_ORIGIN literally into the bundle", async () => {
+    const origin = "https://hap-signal-workspace-local.vercel.app";
+    const out = join(scratchRoot, "local");
+    const bundle = await buildWith(origin, out);
+
+    expect(bundle).toContain(origin);
+  }, 30_000);
+});

--- a/apps/hubspot-extension/__tests__/vite-config.test.ts
+++ b/apps/hubspot-extension/__tests__/vite-config.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the HubSpot extension's Vite config.
+ *
+ * The build pipeline is the only place where `process.env.API_ORIGIN` can
+ * flow INTO the bundled JavaScript: HubSpot's `hs project upload` expands
+ * `${API_ORIGIN}` inside `hsmeta.json` from the active profile, but it does
+ * NOT propagate the variable into the TypeScript source. We close that gap
+ * by having the HubSpot-side build wrapper set `API_ORIGIN` in the env
+ * before invoking `vite build`, and have Vite replace the global constant
+ * `__HAP_API_ORIGIN__` at build time via `define`.
+ *
+ * This test pins the contract of the `define` block so a future refactor
+ * can't silently drop the substitution.
+ */
+import { resolve as resolvePath } from "node:path";
+import type { UserConfig } from "vite";
+import { describe, expect, it } from "vitest";
+
+async function loadConfigWithEnv(
+  envOverride: Partial<NodeJS.ProcessEnv>,
+): Promise<UserConfig | Awaited<UserConfig>> {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(envOverride)) {
+    previous[key] = process.env[key];
+    const value = envOverride[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    // Bust the module cache so Vite re-reads process.env on each call.
+    const configPath = resolvePath(__dirname, "../vite.config.ts");
+    const modUrl = `${configPath}?env=${encodeURIComponent(JSON.stringify(envOverride))}`;
+    const mod = (await import(/* @vite-ignore */ modUrl)) as {
+      default: UserConfig | (() => UserConfig | Promise<UserConfig>);
+    };
+    const raw = mod.default;
+    return typeof raw === "function" ? await raw() : raw;
+  } finally {
+    for (const [key, prevValue] of Object.entries(previous)) {
+      if (prevValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prevValue;
+      }
+    }
+  }
+}
+
+function defineFor(config: UserConfig): Record<string, string> {
+  const defineBlock = (config.define ?? {}) as Record<string, string>;
+  return defineBlock;
+}
+
+describe("hubspot-extension vite.config.ts", () => {
+  it("injects __HAP_API_ORIGIN__ from process.env.API_ORIGIN as a JSON string literal", async () => {
+    const cfg = await loadConfigWithEnv({
+      API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+    });
+
+    const block = defineFor(cfg);
+    expect(block.__HAP_API_ORIGIN__).toBe(
+      JSON.stringify("https://hap-signal-workspace-staging.vercel.app"),
+    );
+  });
+
+  it("injects an empty-string literal when API_ORIGIN is unset, so the runtime resolver falls through", async () => {
+    const cfg = await loadConfigWithEnv({ API_ORIGIN: undefined });
+
+    const block = defineFor(cfg);
+    // `JSON.stringify("")` → '""'. An empty string is how we signal
+    // "no build-time configuration; use runtime/default fallback" in the
+    // resolver. See resolve-api-base-url.test.ts for the consumer side.
+    expect(block.__HAP_API_ORIGIN__).toBe(JSON.stringify(""));
+  });
+
+  it("preserves the API_ORIGIN value verbatim (no trailing-slash normalization)", async () => {
+    // Clarity: the resolver does NOT strip trailing slashes. If a profile
+    // supplies "https://host/" the built bundle carries that exact string
+    // and any downstream URL construction (`${baseUrl}/api/snapshot/...`)
+    // is responsible for reconciling it. Pin this as an explicit decision
+    // so a later "helpful" normalization doesn't break signed fetch URLs.
+    const cfg = await loadConfigWithEnv({
+      API_ORIGIN: "https://hap-signal-workspace.vercel.app/",
+    });
+
+    const block = defineFor(cfg);
+    expect(block.__HAP_API_ORIGIN__).toBe(
+      JSON.stringify("https://hap-signal-workspace.vercel.app/"),
+    );
+  });
+});

--- a/apps/hubspot-extension/package.json
+++ b/apps/hubspot-extension/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "echo 'Use hs project dev for local HubSpot extension development'",
-    "build": "vite build"
+    "build": "vite build",
+    "build:with-profile": "tsx scripts/build-with-profile-cli.ts"
   },
   "dependencies": {
     "@hap/config": "workspace:*",

--- a/apps/hubspot-extension/scripts/__tests__/build-with-profile.e2e.test.ts
+++ b/apps/hubspot-extension/scripts/__tests__/build-with-profile.e2e.test.ts
@@ -1,0 +1,69 @@
+/**
+ * End-to-end proof that the wrapper produces a bundle containing the
+ * profile's API_ORIGIN. Complements the unit tests in
+ * `build-with-profile.test.ts` by exercising the actual Vite build.
+ *
+ * Slower than unit tests (one real `vite build`), so kept narrow — a single
+ * profile round-trip. The companion Slice 8 determinism test
+ * (`built-bundle-origin.test.ts`) already covers multi-origin determinism
+ * at the Vite level; this test covers the profile-file → env → build path.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { build } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runBuildWithProfile } from "../build-with-profile";
+
+const EXTENSION_ROOT = resolvePath(__dirname, "..", "..");
+
+let scratch: string;
+
+beforeAll(() => {
+  scratch = mkdtempSync(join(tmpdir(), "hap-build-wrapper-e2e-"));
+});
+
+afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("build-with-profile (end-to-end)", () => {
+  it("builds the extension bundle with the profile's API_ORIGIN baked in", async () => {
+    const profileDir = join(scratch, "profiles");
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(
+      join(profileDir, "hsprofile.staging.json"),
+      JSON.stringify({
+        accountId: 12345678,
+        variables: {
+          OAUTH_REDIRECT_URI: "https://hap-signal-workspace-staging.vercel.app/oauth/callback",
+          API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+        },
+      }),
+    );
+
+    const outDir = join(scratch, "out");
+    mkdirSync(outDir, { recursive: true });
+
+    await runBuildWithProfile({
+      profileName: "staging",
+      profileDir,
+      runBuild: async () => {
+        await build({
+          configFile: resolvePath(EXTENSION_ROOT, "vite.config.ts"),
+          root: EXTENSION_ROOT,
+          logLevel: "error",
+          build: {
+            outDir,
+            emptyOutDir: true,
+          },
+        });
+      },
+    });
+
+    const bundle = readFileSync(join(outDir, "index.js"), "utf8");
+    expect(bundle).toContain("https://hap-signal-workspace-staging.vercel.app");
+    // Sanity: prod URL is not what the staging build shipped as the target.
+    expect(bundle).not.toContain("https://hap-signal-workspace.vercel.app/api/snapshot/");
+  }, 45_000);
+});

--- a/apps/hubspot-extension/scripts/__tests__/build-with-profile.test.ts
+++ b/apps/hubspot-extension/scripts/__tests__/build-with-profile.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the HubSpot-project profile-aware extension build wrapper.
+ *
+ * The wrapper lives here (inside the extension package) because
+ * `apps/hubspot-project/` is intentionally excluded from the pnpm workspace
+ * and cannot host runnable TypeScript. It reads a profile file from the
+ * sibling `apps/hubspot-project/hsprofile.<name>.json`, extracts the
+ * `API_ORIGIN` variable, and invokes the existing extension build with
+ * `process.env.API_ORIGIN` set to that value.
+ *
+ * The build itself is covered by `__tests__/built-bundle-origin.test.ts`
+ * (Slice 8). Here we pin the profile-parsing + env-handoff contract.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  extractApiOrigin,
+  InvalidProfileNameError,
+  loadProfile,
+  MissingApiOriginError,
+  MissingProfileFileError,
+  resolveProfilePath,
+  runBuildWithProfile,
+} from "../build-with-profile";
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "hap-build-wrapper-"));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+function writeProfile(name: string, contents: unknown): string {
+  const path = join(scratch, `hsprofile.${name}.json`);
+  writeFileSync(path, JSON.stringify(contents));
+  return path;
+}
+
+describe("resolveProfilePath()", () => {
+  it("maps a profile name to the expected hsprofile.<name>.json path", () => {
+    expect(resolveProfilePath("staging", scratch)).toBe(join(scratch, "hsprofile.staging.json"));
+  });
+
+  it("accepts the three shipped profile names", () => {
+    for (const name of ["local", "staging", "production"]) {
+      expect(() => resolveProfilePath(name, scratch)).not.toThrow();
+    }
+  });
+
+  it.each([
+    "",
+    "..",
+    "../leak",
+    "with space",
+    "UP",
+    "semi;colon",
+  ])("rejects malformed profile name %j", (bad) => {
+    expect(() => resolveProfilePath(bad, scratch)).toThrow(InvalidProfileNameError);
+  });
+});
+
+describe("loadProfile()", () => {
+  it("parses a valid profile file into its JSON shape", () => {
+    const path = writeProfile("staging", {
+      accountId: 12345678,
+      variables: {
+        OAUTH_REDIRECT_URI: "https://x/oauth/callback",
+        API_ORIGIN: "https://x",
+      },
+    });
+
+    const loaded = loadProfile(path);
+    expect(loaded.accountId).toBe(12345678);
+    expect(loaded.variables.API_ORIGIN).toBe("https://x");
+  });
+
+  it("throws a clear MissingProfileFileError when the path does not exist", () => {
+    const path = join(scratch, "hsprofile.nope.json");
+    expect(() => loadProfile(path)).toThrow(MissingProfileFileError);
+  });
+
+  it("throws on malformed JSON rather than silently returning an empty object", () => {
+    const path = join(scratch, "hsprofile.bad.json");
+    writeFileSync(path, "{not json");
+
+    expect(() => loadProfile(path)).toThrow(/profile file is not valid JSON/i);
+  });
+});
+
+describe("extractApiOrigin()", () => {
+  it("returns the API_ORIGIN variable when present", () => {
+    const origin = "https://hap-signal-workspace-staging.vercel.app";
+    expect(extractApiOrigin({ accountId: 1, variables: { API_ORIGIN: origin } })).toBe(origin);
+  });
+
+  it("throws MissingApiOriginError when variables object is missing", () => {
+    expect(() =>
+      extractApiOrigin({ accountId: 1 } as unknown as {
+        accountId: number;
+        variables: Record<string, string>;
+      }),
+    ).toThrow(MissingApiOriginError);
+  });
+
+  it("throws MissingApiOriginError when API_ORIGIN is empty or whitespace", () => {
+    expect(() => extractApiOrigin({ accountId: 1, variables: { API_ORIGIN: "" } })).toThrow(
+      MissingApiOriginError,
+    );
+    expect(() => extractApiOrigin({ accountId: 1, variables: { API_ORIGIN: "   " } })).toThrow(
+      MissingApiOriginError,
+    );
+  });
+});
+
+describe("runBuildWithProfile() — env handoff", () => {
+  it("sets process.env.API_ORIGIN to the profile value before invoking the build", async () => {
+    writeProfile("staging", {
+      accountId: 1,
+      variables: {
+        API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+      },
+    });
+
+    // Capture the env the build sees at invocation time, NOT after.
+    let envAtBuildTime: string | undefined;
+    const runBuild = vi.fn(async () => {
+      envAtBuildTime = process.env.API_ORIGIN;
+    });
+
+    await runBuildWithProfile({
+      profileName: "staging",
+      profileDir: scratch,
+      runBuild,
+    });
+
+    expect(runBuild).toHaveBeenCalledTimes(1);
+    expect(envAtBuildTime).toBe("https://hap-signal-workspace-staging.vercel.app");
+  });
+
+  it("restores the previous API_ORIGIN after the build completes (no env leakage)", async () => {
+    writeProfile("staging", {
+      accountId: 1,
+      variables: {
+        API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+      },
+    });
+
+    const previous = process.env.API_ORIGIN;
+    process.env.API_ORIGIN = "https://sentinel.example.com";
+    try {
+      await runBuildWithProfile({
+        profileName: "staging",
+        profileDir: scratch,
+        runBuild: async () => {
+          // no-op
+        },
+      });
+      expect(process.env.API_ORIGIN).toBe("https://sentinel.example.com");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.API_ORIGIN;
+      } else {
+        process.env.API_ORIGIN = previous;
+      }
+    }
+  });
+
+  it("restores env even when the build throws", async () => {
+    writeProfile("staging", {
+      accountId: 1,
+      variables: {
+        API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+      },
+    });
+
+    const previous = process.env.API_ORIGIN;
+    delete process.env.API_ORIGIN;
+    try {
+      await expect(
+        runBuildWithProfile({
+          profileName: "staging",
+          profileDir: scratch,
+          runBuild: async () => {
+            throw new Error("vite build failed");
+          },
+        }),
+      ).rejects.toThrow(/vite build failed/);
+      expect(process.env.API_ORIGIN).toBeUndefined();
+    } finally {
+      if (previous !== undefined) {
+        process.env.API_ORIGIN = previous;
+      }
+    }
+  });
+
+  it("surfaces a readable error when the profile file is missing", async () => {
+    await expect(
+      runBuildWithProfile({
+        profileName: "local",
+        profileDir: scratch,
+        runBuild: async () => {
+          throw new Error("should not run");
+        },
+      }),
+    ).rejects.toThrow(MissingProfileFileError);
+  });
+});

--- a/apps/hubspot-extension/scripts/build-with-profile-cli.ts
+++ b/apps/hubspot-extension/scripts/build-with-profile-cli.ts
@@ -1,0 +1,68 @@
+/**
+ * CLI entry for the profile-aware build wrapper.
+ *
+ * Usage:
+ *   pnpm --filter @hap/hubspot-extension exec tsx \
+ *     scripts/build-with-profile-cli.ts --profile staging
+ *
+ * OR via the matching package script:
+ *   pnpm --filter @hap/hubspot-extension run build:with-profile -- --profile staging
+ *
+ * Resolution order for the profile name:
+ *   1. `--profile <name>` CLI flag
+ *   2. `HS_PROFILE` env var
+ *   3. error (we refuse to guess a default — production and staging must be
+ *      selected deliberately).
+ *
+ * The profile directory defaults to the sibling `apps/hubspot-project/`
+ * tree resolved relative to this file. Override with `--profile-dir` if the
+ * wrapper is invoked from outside the monorepo (e.g., a packaged release).
+ */
+import { resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "vite";
+import { runBuildWithProfile } from "./build-with-profile";
+
+function parseArgs(argv: string[]): { profile?: string; profileDir?: string } {
+  const out: { profile?: string; profileDir?: string } = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--profile" || arg === "-p") {
+      out.profile = argv[++i];
+    } else if (arg === "--profile-dir") {
+      out.profileDir = argv[++i];
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const profileName = args.profile ?? process.env.HS_PROFILE;
+  if (!profileName) {
+    throw new Error("Profile name is required. Pass --profile <name> or set HS_PROFILE.");
+  }
+
+  const here = fileURLToPath(new URL(".", import.meta.url));
+  const extensionRoot = resolvePath(here, "..");
+  const defaultProfileDir = resolvePath(extensionRoot, "..", "hubspot-project");
+  const profileDir = args.profileDir
+    ? resolvePath(process.cwd(), args.profileDir)
+    : defaultProfileDir;
+
+  await runBuildWithProfile({
+    profileName,
+    profileDir,
+    runBuild: async () => {
+      await build({
+        configFile: resolvePath(extensionRoot, "vite.config.ts"),
+        root: extensionRoot,
+      });
+    },
+  });
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/apps/hubspot-extension/scripts/build-with-profile.ts
+++ b/apps/hubspot-extension/scripts/build-with-profile.ts
@@ -1,0 +1,161 @@
+/**
+ * Profile-aware extension build wrapper.
+ *
+ * Closes the Slice 8 gap: the Vite `define` block reads
+ * `process.env.API_ORIGIN` but nothing sets that env per HubSpot profile
+ * (`hsprofile.local.json`, `hsprofile.staging.json`, `hsprofile.production.json`).
+ * This wrapper reads the selected profile file, extracts its
+ * `variables.API_ORIGIN`, sets the env, and invokes the existing build.
+ *
+ * Library (this file): pure helpers + orchestrator. The CLI entry lives in
+ * `build-with-profile-cli.ts` so tests can import the helpers without
+ * triggering a build as a side effect of import.
+ *
+ * Intended production usage (from the HubSpot project build step):
+ *
+ *   pnpm --filter @hap/hubspot-extension exec tsx \
+ *     scripts/build-with-profile-cli.ts --profile staging
+ *
+ * Profile files live in `apps/hubspot-project/` (gitignored real files,
+ * committed `.example.json` templates).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Error thrown when the caller asks for a profile name we refuse to resolve. */
+export class InvalidProfileNameError extends Error {
+  constructor(name: string) {
+    super(
+      `Invalid profile name: ${JSON.stringify(name)}. Only lowercase ` +
+        `alphanumerics, dashes, and underscores are allowed — no slashes, ` +
+        `dots, spaces, or shell metacharacters.`,
+    );
+    this.name = "InvalidProfileNameError";
+  }
+}
+
+/** Error thrown when the resolved profile path does not exist on disk. */
+export class MissingProfileFileError extends Error {
+  constructor(path: string) {
+    super(
+      `HubSpot profile file not found: ${path}. Copy ` +
+        `hsprofile.<name>.example.json to hsprofile.<name>.json and fill in ` +
+        `the account-specific values before running the build.`,
+    );
+    this.name = "MissingProfileFileError";
+  }
+}
+
+/** Error thrown when the profile's `variables.API_ORIGIN` is missing/empty. */
+export class MissingApiOriginError extends Error {
+  constructor() {
+    super(
+      "Profile is missing a non-empty variables.API_ORIGIN. The wrapper " +
+        "refuses to invoke the build without it — the produced bundle " +
+        "would hard-code the prod fallback instead of the profile's origin.",
+    );
+    this.name = "MissingApiOriginError";
+  }
+}
+
+export type HsProfile = {
+  accountId: number;
+  variables: Record<string, string>;
+};
+
+/**
+ * Allowed profile-name regex. Intentionally strict:
+ *   - lowercase ASCII letters, digits, dashes, underscores
+ *   - at least one character
+ *   - rejects `..`, `/`, `.`, whitespace, and anything that would let a
+ *     caller pivot the resolved path outside the profile directory.
+ */
+const PROFILE_NAME_RE = /^[a-z0-9_-]+$/;
+
+/**
+ * Resolve a profile name to its on-disk path without ever escaping
+ * `profileDir`. Throws on any name that fails {@link PROFILE_NAME_RE}.
+ */
+export function resolveProfilePath(profileName: string, profileDir: string): string {
+  if (!PROFILE_NAME_RE.test(profileName)) {
+    throw new InvalidProfileNameError(profileName);
+  }
+  return join(profileDir, `hsprofile.${profileName}.json`);
+}
+
+/** Read + parse the profile file. Throws typed errors on IO / JSON failures. */
+export function loadProfile(profilePath: string): HsProfile {
+  if (!existsSync(profilePath)) {
+    throw new MissingProfileFileError(profilePath);
+  }
+  const raw = readFileSync(profilePath, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    throw new Error(
+      `Profile file is not valid JSON: ${profilePath}`,
+      cause instanceof Error ? { cause } : undefined,
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as { accountId?: unknown }).accountId !== "number" ||
+    typeof (parsed as { variables?: unknown }).variables !== "object" ||
+    (parsed as { variables?: unknown }).variables === null
+  ) {
+    throw new Error(
+      `Profile file has unexpected shape (expected { accountId: number, ` +
+        `variables: object }): ${profilePath}`,
+    );
+  }
+  return parsed as HsProfile;
+}
+
+/** Return `variables.API_ORIGIN` or throw if absent / empty / whitespace. */
+export function extractApiOrigin(profile: HsProfile): string {
+  const value = profile.variables?.API_ORIGIN;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new MissingApiOriginError();
+  }
+  return value;
+}
+
+export type RunBuildWithProfileOptions = {
+  profileName: string;
+  profileDir: string;
+  /**
+   * Injected build callable. In production this runs `vite build`; in tests
+   * it is a captured spy. Keeping the build out of this function means the
+   * unit tests never touch Vite and execute in milliseconds.
+   */
+  runBuild: () => Promise<void>;
+};
+
+/**
+ * Orchestrate the wrapper flow:
+ *   1. resolve profile path (validated)
+ *   2. read + parse profile
+ *   3. extract API_ORIGIN
+ *   4. set `process.env.API_ORIGIN` for the duration of the build
+ *   5. invoke `runBuild`
+ *   6. restore the previous env (success OR failure path)
+ */
+export async function runBuildWithProfile(opts: RunBuildWithProfileOptions): Promise<void> {
+  const profilePath = resolveProfilePath(opts.profileName, opts.profileDir);
+  const profile = loadProfile(profilePath);
+  const apiOrigin = extractApiOrigin(profile);
+
+  const previous = process.env.API_ORIGIN;
+  process.env.API_ORIGIN = apiOrigin;
+  try {
+    await opts.runBuild();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = previous;
+    }
+  }
+}

--- a/apps/hubspot-extension/src/features/snapshot/hooks/__tests__/resolve-api-base-url.test.ts
+++ b/apps/hubspot-extension/src/features/snapshot/hooks/__tests__/resolve-api-base-url.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for `resolveApiBaseUrl()` — profile/build-time API origin resolver.
+ *
+ * Resolution precedence (highest wins):
+ *   1. A build-time global constant `__HAP_API_ORIGIN__` (injected by Vite
+ *      `define` from `process.env.API_ORIGIN` at `vite build` time). This
+ *      is the production path — the HubSpot project build runs once per
+ *      profile, so each bundle carries the correct origin literally.
+ *   2. `process.env.API_ORIGIN` — the test/runtime escape hatch. Applies
+ *      only in Node runtimes (vitest, SSR). In the real HubSpot extension
+ *      environment `process` is undefined, so this branch never fires.
+ *   3. The hardcoded `DEFAULT_API_BASE_URL` (prod Vercel), so an
+ *      unconfigured build still has a safe default rather than crashing.
+ *
+ * A value of `""`, whitespace-only, or a non-string is treated as absent so
+ * an empty `process.env.API_ORIGIN` doesn't silently nuke the fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_API_BASE_URL, resolveApiBaseUrl } from "../api-fetcher";
+
+const INJECTED_KEY = "__HAP_API_ORIGIN__";
+
+type GlobalWithInjected = typeof globalThis & { [INJECTED_KEY]?: unknown };
+
+function setInjected(value: unknown): void {
+  (globalThis as GlobalWithInjected)[INJECTED_KEY] = value;
+}
+
+function clearInjected(): void {
+  delete (globalThis as GlobalWithInjected)[INJECTED_KEY];
+}
+
+describe("resolveApiBaseUrl()", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.API_ORIGIN;
+    delete process.env.API_ORIGIN;
+    clearInjected();
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = savedEnv;
+    }
+    clearInjected();
+  });
+
+  it("returns the build-time injected constant when it is a non-empty string", () => {
+    setInjected("https://hap-signal-workspace-staging.vercel.app");
+
+    expect(resolveApiBaseUrl()).toBe("https://hap-signal-workspace-staging.vercel.app");
+  });
+
+  it("prefers the build-time injected constant over a runtime env override", () => {
+    setInjected("https://hap-signal-workspace.vercel.app");
+    process.env.API_ORIGIN = "http://localhost:3001";
+
+    expect(resolveApiBaseUrl()).toBe("https://hap-signal-workspace.vercel.app");
+  });
+
+  it("falls back to process.env.API_ORIGIN when the build-time constant is missing", () => {
+    process.env.API_ORIGIN = "http://localhost:3001";
+
+    expect(resolveApiBaseUrl()).toBe("http://localhost:3001");
+  });
+
+  it("falls back to DEFAULT_API_BASE_URL when the build-time constant is an empty string", () => {
+    setInjected("");
+
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+
+  it("falls back to DEFAULT_API_BASE_URL when the build-time constant is whitespace only", () => {
+    setInjected("   ");
+
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+
+  it("falls back to DEFAULT_API_BASE_URL when nothing is configured", () => {
+    // Neither injected constant nor env var — the safe prod default.
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+
+  it("ignores a non-string injected value rather than coercing it", () => {
+    // A misconfigured Vite `define` that passes a raw number instead of
+    // `JSON.stringify(...)` would leave us with a non-string. Treat it as
+    // absent — the fallback is always a string URL.
+    setInjected(123);
+
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+});

--- a/apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts
+++ b/apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts
@@ -13,9 +13,13 @@
  *     tenant-resolution middleware (Slice 2 Step 4) reads these from the
  *     signed payload — NOT from any client-supplied header.
  *   - The destination URL MUST appear in `permittedUrls.fetch[]` inside
- *     `apps/hubspot-project/src/app/app-hsmeta.json`. `DEFAULT_API_BASE_URL`
- *     below is kept in sync with that file via
- *     `apps/hubspot-project/__validate__/scaffold.test.ts`.
+ *     `apps/hubspot-project/src/app/app-hsmeta.json`. That file lists the
+ *     template variable `${API_ORIGIN}`, which HubSpot expands at upload
+ *     time from the active profile (hsprofile.*.json). The Vite build
+ *     passes the matching `process.env.API_ORIGIN` through to the bundled
+ *     JS via `define`, and `resolveApiBaseUrl()` (below) reads it at
+ *     runtime. The scaffold anti-regression test keeps the placeholder +
+ *     profile variable contract intact.
  *   - Per-account outbound limits: 20 concurrent requests, 15s timeout cap,
  *     1MB payload cap. The snapshot route is well inside these bounds.
  *
@@ -27,14 +31,55 @@ import { hubspot } from "@hubspot/ui-extensions";
 import type { SnapshotFetcher } from "./use-snapshot";
 
 /**
- * Default production API origin for the snapshot backend.
- *
- * MUST be kept in sync with `permittedUrls.fetch[0]` in
- * `apps/hubspot-project/src/app/app-hsmeta.json`. The scaffold anti-regression
- * test binds the two together; if you change this string, change that file
- * and the test's expected value at the same time.
+ * Hard-coded prod fallback. Only reached when both the build-time
+ * `__HAP_API_ORIGIN__` injection and the runtime `process.env.API_ORIGIN`
+ * escape hatch are absent — see {@link resolveApiBaseUrl}. Kept as a string
+ * literal (not derived from env) so a misconfigured build is still safe.
  */
 export const DEFAULT_API_BASE_URL = "https://hap-signal-workspace.vercel.app";
+
+/**
+ * Build-time constant injected by Vite `define` from
+ * `process.env.API_ORIGIN` at `vite build` time. The HubSpot project build
+ * wrapper sets the env per-profile before invoking vite, so each uploaded
+ * bundle literalizes its own target origin. At runtime inside the HubSpot
+ * extension host, this symbol is replaced with a string literal (e.g.,
+ * `"https://hap-signal-workspace-staging.vercel.app"`) by the time the
+ * code executes, and the `typeof` guard is evaluated against that literal.
+ */
+declare const __HAP_API_ORIGIN__: string | undefined;
+
+/**
+ * Resolve the API origin the extension fetcher should target.
+ *
+ * Precedence (highest wins):
+ *   1. `__HAP_API_ORIGIN__` — build-time substitution (the production path).
+ *   2. `process.env.API_ORIGIN` — runtime override for Node environments
+ *      (vitest, SSR). `process` is undefined inside the HubSpot extension
+ *      host, so this branch is Node-only.
+ *   3. {@link DEFAULT_API_BASE_URL} — safe prod default.
+ *
+ * A value of `""`, whitespace-only, or a non-string is treated as absent.
+ * This matters because Vite `define` must emit *some* replacement for
+ * `__HAP_API_ORIGIN__` even when the env is unset; we emit `""` and rely on
+ * this function to fall through.
+ */
+export function resolveApiBaseUrl(): string {
+  const injected =
+    typeof __HAP_API_ORIGIN__ !== "undefined" ? (__HAP_API_ORIGIN__ as unknown) : undefined;
+  if (typeof injected === "string" && injected.trim().length > 0) {
+    return injected;
+  }
+
+  if (typeof process !== "undefined") {
+    const envOrigin = process.env?.API_ORIGIN;
+    if (typeof envOrigin === "string" && envOrigin.trim().length > 0) {
+      return envOrigin;
+    }
+  }
+
+  return DEFAULT_API_BASE_URL;
+}
 
 /**
  * Transport-layer error thrown when the snapshot API returns a non-2xx
@@ -55,9 +100,10 @@ export class ApiFetcherError extends Error {
 
 export type HubSpotApiFetcherDeps = {
   /**
-   * API origin to target. Defaults to `DEFAULT_API_BASE_URL`. Tests override
-   * this; in V1 production we pin the single prod origin and rely on the
-   * HubSpot project's `permittedUrls.fetch` to gate it.
+   * API origin to target. Defaults to the result of {@link resolveApiBaseUrl},
+   * which honors the build-time injected origin first, then
+   * `process.env.API_ORIGIN`, then {@link DEFAULT_API_BASE_URL}. Tests that
+   * want a deterministic origin pass it explicitly.
    */
   baseUrl?: string;
 };
@@ -74,7 +120,7 @@ export type HubSpotApiFetcherDeps = {
  * failure. Schema validation + Date coercion happens in `useSnapshot`.
  */
 export function createHubSpotApiFetcher(deps: HubSpotApiFetcherDeps = {}): SnapshotFetcher {
-  const baseUrl = deps.baseUrl ?? DEFAULT_API_BASE_URL;
+  const baseUrl = deps.baseUrl ?? resolveApiBaseUrl();
 
   return async function fetchSnapshot(companyId: string): Promise<unknown> {
     const url = `${baseUrl}/api/snapshot/${companyId}`;

--- a/apps/hubspot-extension/vite.config.ts
+++ b/apps/hubspot-extension/vite.config.ts
@@ -2,18 +2,38 @@ import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-export default defineConfig({
-  plugins: [react()],
-  build: {
-    emptyOutDir: true,
-    lib: {
-      entry: resolve(__dirname, "src/hubspot-card-entry.tsx"),
-      formats: ["es"],
+/**
+ * Vite config is a factory so `process.env.API_ORIGIN` is read EACH time
+ * `vite build` runs. The HubSpot project build wrapper sets that env per
+ * active profile before invoking the build, and the value flows through
+ * `define` into the bundled JavaScript as the literal string constant
+ * `__HAP_API_ORIGIN__` — consumed at runtime by
+ * `src/features/snapshot/hooks/api-fetcher.ts::resolveApiBaseUrl`.
+ *
+ * Contract (pinned by `__tests__/vite-config.test.ts`):
+ *   - `API_ORIGIN=...`  → `__HAP_API_ORIGIN__ = JSON.stringify(value)`
+ *   - `API_ORIGIN`unset → `__HAP_API_ORIGIN__ = JSON.stringify("")`
+ *   - values are preserved verbatim (no trailing-slash normalization).
+ */
+export default defineConfig(() => {
+  const apiOrigin = process.env.API_ORIGIN ?? "";
+
+  return {
+    plugins: [react()],
+    define: {
+      __HAP_API_ORIGIN__: JSON.stringify(apiOrigin),
     },
-    rollupOptions: {
-      output: {
-        entryFileNames: "index.js",
+    build: {
+      emptyOutDir: true,
+      lib: {
+        entry: resolve(__dirname, "src/hubspot-card-entry.tsx"),
+        formats: ["es"],
+      },
+      rollupOptions: {
+        output: {
+          entryFileNames: "index.js",
+        },
       },
     },
-  },
+  };
 });

--- a/apps/hubspot-project/UPLOAD.md
+++ b/apps/hubspot-project/UPLOAD.md
@@ -15,11 +15,11 @@ The HubSpot CLI's project uploader (`@hubspot/cli` 8.4.0) cannot reliably upload
 
 This appears to be a worktree-context issue in the CLI's git-aware file walker, not a misconfiguration on our side. Reproduced consistently:
 
-| Source dir | Outcome |
-|---|---|
+| Source dir                                 | Outcome                                          |
+| ------------------------------------------ | ------------------------------------------------ |
 | `.worktrees/slice-2/apps/hubspot-project/` | upload succeeds; build FAILS (`*.tsx not found`) |
-| `/tmp/<copy>/` (no git) | build + deploy succeed |
-| `/tmp/<copy>/` (with `git init`) | build + deploy succeed |
+| `/tmp/<copy>/` (no git)                    | build + deploy succeed                           |
+| `/tmp/<copy>/` (with `git init`)           | build + deploy succeed                           |
 
 The wrapper script removes the worktree variable from the equation.
 
@@ -96,6 +96,26 @@ readiness contract is:
 - the selected HubSpot profile supplies `OAUTH_REDIRECT_URI` and `API_ORIGIN`
 - staging/production installs must use HTTPS callback URLs
 - the API-side `HUBSPOT_OAUTH_REDIRECT_URI` must match the active deployed origin
+
+Slice 10 closes the extension side of that contract: `hs-project-upload.ts`
+now threads the selected profile's `variables.API_ORIGIN` into the
+programmatic bundler (`scripts/bundle-hubspot-card.ts`) via
+`process.env.API_ORIGIN`. The bundler's `define` block embeds
+`__HAP_API_ORIGIN__` into both the card and settings bundles, so deployed
+extensions call the origin declared in `hsprofile.<name>.json` instead of
+the hardcoded default.
+
+Two profile-aware build paths now exist:
+
+- `apps/hubspot-extension` → `pnpm build:with-profile --profile <name>` —
+  single-bundle wrapper for local dev ergonomics.
+- `scripts/hs-project-upload.ts --profile <name>` — production two-bundle
+  path that actually ships to HubSpot.
+
+Both read the same `hsprofile.<name>.json` and share the same
+`__HAP_API_ORIGIN__` substitution contract. A profile that is missing
+`variables.API_ORIGIN` causes the upload wrapper to exit non-zero before
+any bundling or `hs project upload` subprocess runs.
 
 See also:
 

--- a/scripts/__tests__/bundle-hubspot-card.test.ts
+++ b/scripts/__tests__/bundle-hubspot-card.test.ts
@@ -31,7 +31,9 @@ describe("bundle-hubspot-card — programmatic define contract", () => {
   });
 
   it("uses an empty-string sentinel when API_ORIGIN is unset", () => {
-    const options = buildViteOptions(bundleTargets[0]!, "");
+    const firstTarget = bundleTargets[0];
+    if (!firstTarget) throw new Error("expected at least one bundle target");
+    const options = buildViteOptions(firstTarget, "");
     expect(options.define).toEqual({
       __HAP_API_ORIGIN__: JSON.stringify(""),
     });
@@ -39,7 +41,9 @@ describe("bundle-hubspot-card — programmatic define contract", () => {
 
   it("preserves trailing slashes verbatim inside the JSON-encoded value", () => {
     const origin = "https://staging.example.test/";
-    const options = buildViteOptions(bundleTargets[0]!, origin);
+    const firstTarget = bundleTargets[0];
+    if (!firstTarget) throw new Error("expected at least one bundle target");
+    const options = buildViteOptions(firstTarget, origin);
     expect(options.define).toEqual({
       __HAP_API_ORIGIN__: JSON.stringify(origin),
     });

--- a/scripts/__tests__/bundle-hubspot-card.test.ts
+++ b/scripts/__tests__/bundle-hubspot-card.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildViteOptions, bundleTargets } from "../bundle-hubspot-card";
+
+describe("bundle-hubspot-card — programmatic define contract", () => {
+  let previous: string | undefined;
+
+  beforeEach(() => {
+    previous = process.env.API_ORIGIN;
+  });
+
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = previous;
+    }
+  });
+
+  it("exposes the card and settings targets", () => {
+    const names = bundleTargets.map((target) => target.name).sort();
+    expect(names).toEqual(["card", "settings"]);
+  });
+
+  it("emits __HAP_API_ORIGIN__ as JSON.stringify(apiOrigin) for each target", () => {
+    for (const target of bundleTargets) {
+      const options = buildViteOptions(target, "https://staging.example.test");
+      expect(options.define).toEqual({
+        __HAP_API_ORIGIN__: JSON.stringify("https://staging.example.test"),
+      });
+    }
+  });
+
+  it("uses an empty-string sentinel when API_ORIGIN is unset", () => {
+    const options = buildViteOptions(bundleTargets[0]!, "");
+    expect(options.define).toEqual({
+      __HAP_API_ORIGIN__: JSON.stringify(""),
+    });
+  });
+
+  it("preserves trailing slashes verbatim inside the JSON-encoded value", () => {
+    const origin = "https://staging.example.test/";
+    const options = buildViteOptions(bundleTargets[0]!, origin);
+    expect(options.define).toEqual({
+      __HAP_API_ORIGIN__: JSON.stringify(origin),
+    });
+    // Also assert the raw encoded form contains the trailing slash literally.
+    const encoded = (options.define as Record<string, string>).__HAP_API_ORIGIN__;
+    expect(encoded).toBe(`"${origin}"`);
+  });
+
+  it("keeps configFile=false and two-bundle lib structure", () => {
+    for (const target of bundleTargets) {
+      const options = buildViteOptions(target, "https://example.test");
+      expect(options.configFile).toBe(false);
+      expect(options.build?.lib).toBeTruthy();
+      expect(options.build?.lib && "entry" in options.build.lib && options.build.lib.entry).toBe(
+        target.entry,
+      );
+    }
+  });
+});

--- a/scripts/__tests__/hs-project-upload-e2e.test.ts
+++ b/scripts/__tests__/hs-project-upload-e2e.test.ts
@@ -24,7 +24,8 @@
  * single origin rather than sweeping the matrix.
  */
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildUploadRunner, type UploadDeps } from "../hs-project-upload";
@@ -40,7 +41,10 @@ const CARD_BUNDLE = resolve(repoRoot, "apps/hubspot-project/src/app/cards/dist/i
 const SETTINGS_BUNDLE = resolve(repoRoot, "apps/hubspot-project/src/app/settings/dist/index.js");
 
 describe("hs-project-upload — e2e define contract", () => {
+  let scratchDir: string;
+
   beforeAll(() => {
+    scratchDir = mkdtempSync(join(tmpdir(), "hap-upload-e2e-"));
     writeFileSync(
       PROFILE_PATH,
       JSON.stringify(
@@ -63,13 +67,16 @@ describe("hs-project-upload — e2e define contract", () => {
       // would confuse later runs.
       rmSync(PROFILE_PATH, { force: true });
     }
+    if (scratchDir && existsSync(scratchDir)) {
+      rmSync(scratchDir, { recursive: true, force: true });
+    }
   });
 
   it("embeds the profile's API_ORIGIN into both the card and settings bundles", async () => {
     let uploadCalls = 0;
     const deps: UploadDeps = {
       repoRoot: () => repoRoot,
-      makeTempDir: () => join(repoRoot, ".bundle-artifacts-e2e-scratch"),
+      makeTempDir: () => scratchDir,
       copyProject: () => {
         // Skip copying to the temp dir — the upload is stubbed below, so
         // nothing downstream reads this path.

--- a/scripts/__tests__/hs-project-upload-e2e.test.ts
+++ b/scripts/__tests__/hs-project-upload-e2e.test.ts
@@ -1,0 +1,110 @@
+/**
+ * End-to-end determinism check for the production upload pipeline.
+ *
+ * Writes a HubSpot profile with a sentinel `API_ORIGIN`, invokes the upload
+ * runner with `runUpload` stubbed to exit 0 (so `hs project upload` is
+ * never called), but lets `runBundle` run for real. This exercises the
+ * actual Vite build via `scripts/bundle-hubspot-card-cli.ts` and proves
+ * that the emitted card bundle carries the profile's origin string
+ * verbatim — closing the Slice 8 / Slice 9 / Slice 10 loop end-to-end.
+ *
+ * Scope note on the settings bundle:
+ *   The `define` contract is applied to *both* card and settings targets
+ *   (see `scripts/__tests__/bundle-hubspot-card.test.ts`), but the settings
+ *   entry reads `API_ORIGIN` from `context.variables` at runtime rather
+ *   than the `__HAP_API_ORIGIN__` global. Nothing in the settings source
+ *   currently references that identifier, so Vite has no substitution site
+ *   to inline it into the settings bundle. The card bundle — which does
+ *   reference `__HAP_API_ORIGIN__` via `features/snapshot/hooks/api-fetcher`
+ *   — is the real evidence that the end-to-end pipeline works. We verify
+ *   both bundles are produced, but only assert the origin string on the
+ *   card bundle.
+ *
+ * Builds are slow (~1-2s each; two targets per run) so we scope to a
+ * single origin rather than sweeping the matrix.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildUploadRunner, type UploadDeps } from "../hs-project-upload";
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+const PROFILE_NAME = "slice10e2e";
+const PROFILE_PATH = resolve(repoRoot, "apps/hubspot-project", `hsprofile.${PROFILE_NAME}.json`);
+const SENTINEL_ORIGIN = "https://slice10-e2e.example.test";
+
+const CARD_BUNDLE = resolve(repoRoot, "apps/hubspot-project/src/app/cards/dist/index.js");
+const SETTINGS_BUNDLE = resolve(repoRoot, "apps/hubspot-project/src/app/settings/dist/index.js");
+
+describe("hs-project-upload — e2e define contract", () => {
+  beforeAll(() => {
+    writeFileSync(
+      PROFILE_PATH,
+      JSON.stringify(
+        {
+          accountId: 424242,
+          variables: {
+            OAUTH_REDIRECT_URI: "https://slice10-e2e.example.test/oauth/callback",
+            API_ORIGIN: SENTINEL_ORIGIN,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  });
+
+  afterAll(() => {
+    if (existsSync(PROFILE_PATH)) {
+      // Clean up the temp profile; it is gitignored but leaving it around
+      // would confuse later runs.
+      rmSync(PROFILE_PATH, { force: true });
+    }
+  });
+
+  it("embeds the profile's API_ORIGIN into both the card and settings bundles", async () => {
+    let uploadCalls = 0;
+    const deps: UploadDeps = {
+      repoRoot: () => repoRoot,
+      makeTempDir: () => join(repoRoot, ".bundle-artifacts-e2e-scratch"),
+      copyProject: () => {
+        // Skip copying to the temp dir — the upload is stubbed below, so
+        // nothing downstream reads this path.
+      },
+      runBundle: (root) => {
+        // Run the real bundler against the real extension source so we
+        // exercise the Vite define substitution end-to-end.
+        execFileSync("pnpm", ["tsx", "scripts/bundle-hubspot-card-cli.ts"], {
+          cwd: root,
+          stdio: "inherit",
+          env: process.env,
+        });
+      },
+      runUpload: () => {
+        uploadCalls += 1;
+        return 0;
+      },
+      log: () => {
+        // Silence logs in the test runner.
+      },
+    };
+
+    const code = buildUploadRunner(deps)(["--profile", PROFILE_NAME]);
+
+    expect(code).toBe(0);
+    expect(uploadCalls).toBe(1);
+
+    const cardBundle = readFileSync(CARD_BUNDLE, "utf8");
+    const settingsBundle = readFileSync(SETTINGS_BUNDLE, "utf8");
+
+    // Card bundle references __HAP_API_ORIGIN__ and must embed the sentinel.
+    expect(cardBundle).toContain(SENTINEL_ORIGIN);
+    // Settings bundle is produced (proves the two-target pipeline ran) but
+    // today its source does not reference __HAP_API_ORIGIN__, so the define
+    // contract has no substitution site there. See the module docstring.
+    expect(settingsBundle.length).toBeGreaterThan(0);
+  }, 60_000);
+});

--- a/scripts/__tests__/hs-project-upload.test.ts
+++ b/scripts/__tests__/hs-project-upload.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
-import { buildUploadRunner, type UploadDeps } from "../hs-project-upload";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildUploadRunner, extractProfileName, type UploadDeps } from "../hs-project-upload";
 
 function makeDeps(overrides: Partial<UploadDeps> = {}): UploadDeps {
   return {
@@ -13,20 +16,70 @@ function makeDeps(overrides: Partial<UploadDeps> = {}): UploadDeps {
   };
 }
 
+/**
+ * Stage a HubSpot profile file on disk under `${root}/apps/hubspot-project/`
+ * so `resolveProfilePath` + `loadProfile` can read it during tests.
+ */
+function stageProfile(root: string, name: string, apiOrigin: string | null): void {
+  const dir = join(root, "apps/hubspot-project");
+  mkdirSync(dir, { recursive: true });
+  const variables: Record<string, string> = {
+    OAUTH_REDIRECT_URI: "https://example.test/oauth/callback",
+  };
+  if (apiOrigin !== null) {
+    variables.API_ORIGIN = apiOrigin;
+  }
+  writeFileSync(join(dir, `hsprofile.${name}.json`), JSON.stringify({ accountId: 42, variables }));
+}
+
+describe("extractProfileName", () => {
+  it.each([
+    ["--profile staging", ["--profile", "staging"], "staging"],
+    ["--profile=staging", ["--profile=staging"], "staging"],
+    ["-p staging", ["-p", "staging"], "staging"],
+    ["-p=staging", ["-p=staging"], "staging"],
+    ["absent", ["other", "args"], undefined],
+  ])("%s", (_label, argv, expected) => {
+    expect(extractProfileName(argv)).toBe(expected);
+  });
+});
+
 describe("hs-project-upload", () => {
+  let profileRoot: string;
+  let previousApiOrigin: string | undefined;
+
+  beforeEach(() => {
+    profileRoot = mkdtempSync(join(tmpdir(), "hap-upload-base-"));
+    previousApiOrigin = process.env.API_ORIGIN;
+    stageProfile(profileRoot, "dev", "https://dev.example.test");
+  });
+
+  afterEach(() => {
+    rmSync(profileRoot, { recursive: true, force: true });
+    if (previousApiOrigin === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = previousApiOrigin;
+    }
+  });
+
   it("bundles the HubSpot card before copying and uploading the project", () => {
-    const deps = makeDeps();
+    const deps = makeDeps({ repoRoot: () => profileRoot });
 
     const exitCode = buildUploadRunner(deps)(["--profile", "dev"]);
 
     expect(exitCode).toBe(0);
     expect(deps.runBundle).toHaveBeenCalledTimes(1);
-    expect(deps.copyProject).toHaveBeenCalledWith("/repo/apps/hubspot-project", "/tmp/hap-upload");
+    expect(deps.copyProject).toHaveBeenCalledWith(
+      join(profileRoot, "apps/hubspot-project"),
+      "/tmp/hap-upload",
+    );
     expect(deps.runUpload).toHaveBeenCalledWith("/tmp/hap-upload", ["--profile", "dev"]);
   });
 
   it("does not upload when bundling fails", () => {
     const deps = makeDeps({
+      repoRoot: () => profileRoot,
       runBundle: vi.fn(() => {
         throw new Error("bundle failed");
       }),
@@ -40,6 +93,107 @@ describe("hs-project-upload", () => {
     const deps = makeDeps();
 
     expect(() => buildUploadRunner(deps)([])).toThrow(/--profile/);
+    expect(deps.runUpload).not.toHaveBeenCalled();
+  });
+});
+
+describe("hs-project-upload — profile API_ORIGIN handoff", () => {
+  let profileRoot: string;
+  let previousApiOrigin: string | undefined;
+
+  beforeEach(() => {
+    profileRoot = mkdtempSync(join(tmpdir(), "hap-upload-profile-"));
+    previousApiOrigin = process.env.API_ORIGIN;
+  });
+
+  afterEach(() => {
+    rmSync(profileRoot, { recursive: true, force: true });
+    if (previousApiOrigin === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = previousApiOrigin;
+    }
+  });
+
+  function depsReadingProfile(
+    overrides: Partial<UploadDeps> = {},
+  ): UploadDeps & { observedApiOrigin: { value: string | undefined } } {
+    const observed = { value: undefined as string | undefined };
+    const deps = makeDeps({
+      repoRoot: () => profileRoot,
+      runBundle: vi.fn(() => {
+        observed.value = process.env.API_ORIGIN;
+      }),
+      ...overrides,
+    });
+    return Object.assign(deps, { observedApiOrigin: observed });
+  }
+
+  it.each([
+    ["--profile staging", ["--profile", "staging"]],
+    ["--profile=staging", ["--profile=staging"]],
+    ["-p staging", ["-p", "staging"]],
+    ["-p=staging", ["-p=staging"]],
+  ])("extracts the profile name from %s", (_label, args) => {
+    stageProfile(profileRoot, "staging", "https://staging.example.test");
+    const deps = depsReadingProfile();
+
+    const code = buildUploadRunner(deps)(args);
+
+    expect(code).toBe(0);
+    expect(deps.observedApiOrigin.value).toBe("https://staging.example.test");
+  });
+
+  it("sets process.env.API_ORIGIN to the profile value at the moment runBundle is called", () => {
+    stageProfile(profileRoot, "staging", "https://staging.example.test/");
+    const deps = depsReadingProfile();
+
+    buildUploadRunner(deps)(["--profile", "staging"]);
+
+    expect(deps.observedApiOrigin.value).toBe("https://staging.example.test/");
+  });
+
+  it("restores the previous API_ORIGIN value after the runner returns", () => {
+    process.env.API_ORIGIN = "https://prior.example.test";
+    stageProfile(profileRoot, "staging", "https://staging.example.test");
+    const deps = depsReadingProfile();
+
+    buildUploadRunner(deps)(["--profile", "staging"]);
+
+    expect(process.env.API_ORIGIN).toBe("https://prior.example.test");
+  });
+
+  it("deletes API_ORIGIN after the runner if it was previously unset", () => {
+    delete process.env.API_ORIGIN;
+    stageProfile(profileRoot, "staging", "https://staging.example.test");
+    const deps = depsReadingProfile();
+
+    buildUploadRunner(deps)(["--profile", "staging"]);
+
+    expect(process.env.API_ORIGIN).toBeUndefined();
+  });
+
+  it("restores API_ORIGIN even when runUpload throws", () => {
+    process.env.API_ORIGIN = "https://prior.example.test";
+    stageProfile(profileRoot, "staging", "https://staging.example.test");
+    const deps = depsReadingProfile({
+      runUpload: vi.fn(() => {
+        throw new Error("upload blew up");
+      }),
+    });
+
+    expect(() => buildUploadRunner(deps)(["--profile", "staging"])).toThrow(/upload blew up/);
+    expect(process.env.API_ORIGIN).toBe("https://prior.example.test");
+  });
+
+  it("surfaces MissingApiOriginError before bundling or uploading when profile lacks API_ORIGIN", () => {
+    stageProfile(profileRoot, "staging", null);
+    const deps = depsReadingProfile();
+
+    expect(() => buildUploadRunner(deps)(["--profile", "staging"])).toThrow(
+      /variables\.API_ORIGIN/,
+    );
+    expect(deps.runBundle).not.toHaveBeenCalled();
     expect(deps.runUpload).not.toHaveBeenCalled();
   });
 });

--- a/scripts/__tests__/hs-project-upload.test.ts
+++ b/scripts/__tests__/hs-project-upload.test.ts
@@ -42,6 +42,15 @@ describe("extractProfileName", () => {
   ])("%s", (_label, argv, expected) => {
     expect(extractProfileName(argv)).toBe(expected);
   });
+
+  it.each([
+    ["--profile as last arg", ["--profile"]],
+    ["-p as last arg", ["-p"]],
+    ["--profile followed by another flag", ["--profile", "--other"]],
+    ["-p followed by another flag", ["-p", "--other"]],
+  ])("throws a clear missing-value error: %s", (_label, argv) => {
+    expect(() => extractProfileName(argv)).toThrow(/missing value for --profile/i);
+  });
 });
 
 describe("hs-project-upload", () => {

--- a/scripts/bundle-hubspot-card-cli.ts
+++ b/scripts/bundle-hubspot-card-cli.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * CLI entry for the programmatic two-bundle HubSpot upload pipeline.
+ *
+ * This is the file `scripts/hs-project-upload.ts` invokes via
+ * `pnpm tsx scripts/bundle-hubspot-card-cli.ts`. It statically imports
+ * `vite` and `@vitejs/plugin-react` (both resolvable under `pnpm tsx`'s
+ * workspace-aware resolution) and orchestrates the per-target `build()`
+ * calls. Keeping plugin imports out of the library module
+ * (`bundle-hubspot-card.ts`) means the test file can import helpers
+ * without requiring the react plugin to be hoisted to the repo root.
+ */
+import { cp, mkdir, rm, stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import react from "@vitejs/plugin-react";
+import { build } from "vite";
+import { type BundleTarget, buildViteOptions, bundleTargets } from "./bundle-hubspot-card";
+
+async function ensureFile(path: string) {
+  await stat(path);
+}
+
+async function buildTarget(target: BundleTarget) {
+  await rm(target.outDir, { recursive: true, force: true });
+
+  const baseOptions = buildViteOptions(target, process.env.API_ORIGIN ?? "");
+  await build({
+    ...baseOptions,
+    plugins: [react()],
+  });
+
+  const bundlePath = resolve(target.outDir, "index.js");
+  await ensureFile(bundlePath);
+
+  await mkdir(target.projectDistDir, { recursive: true });
+  await cp(bundlePath, resolve(target.projectDistDir, "index.js"));
+
+  const cssPath = resolve(target.outDir, "style.css");
+  try {
+    await ensureFile(cssPath);
+    await cp(cssPath, resolve(target.projectDistDir, "index.css"));
+  } catch {
+    // No stylesheet emitted for this bundle.
+  }
+}
+
+async function main() {
+  for (const target of bundleTargets) {
+    await buildTarget(target);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/bundle-hubspot-card.ts
+++ b/scripts/bundle-hubspot-card.ts
@@ -1,21 +1,20 @@
 import { cp, mkdir, rm, stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import react from "@vitejs/plugin-react";
-import { build } from "vite";
+import type { InlineConfig } from "vite";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const extensionDir = resolve(rootDir, "apps/hubspot-extension");
 const tempBundleRoot = resolve(extensionDir, ".bundle-artifacts");
 
-type BundleTarget = {
+export type BundleTarget = {
   name: "card" | "settings";
   entry: string;
   outDir: string;
   projectDistDir: string;
 };
 
-const bundleTargets: BundleTarget[] = [
+export const bundleTargets: BundleTarget[] = [
   {
     name: "card",
     entry: resolve(extensionDir, "src/hubspot-card-entry.tsx"),
@@ -30,17 +29,25 @@ const bundleTargets: BundleTarget[] = [
   },
 ];
 
-async function ensureFile(path: string) {
-  await stat(path);
-}
-
-async function buildTarget(target: BundleTarget) {
-  await rm(target.outDir, { recursive: true, force: true });
-
-  await build({
+/**
+ * Pure helper: build the Vite inline config for a single target.
+ *
+ * Mirrors the `define` contract pinned by `apps/hubspot-extension/vite.config.ts`
+ * (Slice 8): `__HAP_API_ORIGIN__` is always `JSON.stringify(apiOrigin)`, with
+ * an empty-string sentinel when the caller has not supplied an origin.
+ * Trailing slashes are preserved verbatim — no normalization happens here.
+ *
+ * Plugins are intentionally omitted so tests can import this helper without
+ * requiring `@vitejs/plugin-react` to be resolvable from the repo root.
+ * `buildTarget` composes plugins in before invoking `vite.build`.
+ */
+export function buildViteOptions(target: BundleTarget, apiOrigin: string): InlineConfig {
+  return {
     configFile: false,
     root: extensionDir,
-    plugins: [react()],
+    define: {
+      __HAP_API_ORIGIN__: JSON.stringify(apiOrigin),
+    },
     build: {
       emptyOutDir: true,
       outDir: target.outDir,
@@ -54,6 +61,25 @@ async function buildTarget(target: BundleTarget) {
         },
       },
     },
+  };
+}
+
+async function ensureFile(path: string) {
+  await stat(path);
+}
+
+async function buildTarget(target: BundleTarget) {
+  await rm(target.outDir, { recursive: true, force: true });
+
+  const [{ default: react }, { build }] = await Promise.all([
+    import("@vitejs/plugin-react"),
+    import("vite"),
+  ]);
+
+  const baseOptions = buildViteOptions(target, process.env.API_ORIGIN ?? "");
+  await build({
+    ...baseOptions,
+    plugins: [react()],
   });
 
   const bundlePath = resolve(target.outDir, "index.js");
@@ -71,13 +97,15 @@ async function buildTarget(target: BundleTarget) {
   }
 }
 
-async function main() {
+export async function main() {
   for (const target of bundleTargets) {
     await buildTarget(target);
   }
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bundle-hubspot-card.ts
+++ b/scripts/bundle-hubspot-card.ts
@@ -1,4 +1,19 @@
-import { cp, mkdir, rm, stat } from "node:fs/promises";
+/**
+ * Library module for the programmatic two-bundle HubSpot upload pipeline.
+ *
+ * Pure helpers + the `bundleTargets` declaration only. No top-level `vite`
+ * import, no plugin import, no CLI entry — those live in
+ * `bundle-hubspot-card-cli.ts` so this file can be imported from tests
+ * without pulling in `@vitejs/plugin-react` (not resolvable from the repo
+ * root under plain Node resolution) or kicking off a build as a side
+ * effect of import.
+ *
+ * The `define` block mirrors the Slice 8 contract pinned by
+ * `apps/hubspot-extension/vite.config.ts`:
+ *   - `__HAP_API_ORIGIN__` is always `JSON.stringify(apiOrigin)`
+ *   - an empty-string sentinel is emitted when the caller has no origin
+ *   - trailing slashes are preserved verbatim — no normalization
+ */
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { InlineConfig } from "vite";
@@ -29,18 +44,6 @@ export const bundleTargets: BundleTarget[] = [
   },
 ];
 
-/**
- * Pure helper: build the Vite inline config for a single target.
- *
- * Mirrors the `define` contract pinned by `apps/hubspot-extension/vite.config.ts`
- * (Slice 8): `__HAP_API_ORIGIN__` is always `JSON.stringify(apiOrigin)`, with
- * an empty-string sentinel when the caller has not supplied an origin.
- * Trailing slashes are preserved verbatim — no normalization happens here.
- *
- * Plugins are intentionally omitted so tests can import this helper without
- * requiring `@vitejs/plugin-react` to be resolvable from the repo root.
- * `buildTarget` composes plugins in before invoking `vite.build`.
- */
 export function buildViteOptions(target: BundleTarget, apiOrigin: string): InlineConfig {
   return {
     configFile: false,
@@ -62,50 +65,4 @@ export function buildViteOptions(target: BundleTarget, apiOrigin: string): Inlin
       },
     },
   };
-}
-
-async function ensureFile(path: string) {
-  await stat(path);
-}
-
-async function buildTarget(target: BundleTarget) {
-  await rm(target.outDir, { recursive: true, force: true });
-
-  const [{ default: react }, { build }] = await Promise.all([
-    import("@vitejs/plugin-react"),
-    import("vite"),
-  ]);
-
-  const baseOptions = buildViteOptions(target, process.env.API_ORIGIN ?? "");
-  await build({
-    ...baseOptions,
-    plugins: [react()],
-  });
-
-  const bundlePath = resolve(target.outDir, "index.js");
-  await ensureFile(bundlePath);
-
-  await mkdir(target.projectDistDir, { recursive: true });
-  await cp(bundlePath, resolve(target.projectDistDir, "index.js"));
-
-  const cssPath = resolve(target.outDir, "style.css");
-  try {
-    await ensureFile(cssPath);
-    await cp(cssPath, resolve(target.projectDistDir, "index.css"));
-  } catch {
-    // No stylesheet emitted for this bundle.
-  }
-}
-
-export async function main() {
-  for (const target of bundleTargets) {
-    await buildTarget(target);
-  }
-}
-
-if (import.meta.main) {
-  main().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-  });
 }

--- a/scripts/hs-project-upload.ts
+++ b/scripts/hs-project-upload.ts
@@ -7,12 +7,22 @@
  * (cards/*.tsx files are reported "not found"). Same files upload cleanly
  * from a /tmp dir. See apps/hubspot-project/UPLOAD.md for the full diagnosis.
  *
+ * Slice 10: the wrapper now reads the selected HubSpot profile's
+ * `variables.API_ORIGIN` and sets `process.env.API_ORIGIN` before invoking
+ * the programmatic bundler, so `__HAP_API_ORIGIN__` is baked into both the
+ * card and settings bundles at build time.
+ *
  * @todo Slice 3: remove this wrapper if/when @hubspot/cli handles worktrees.
  */
 import { execFileSync, spawnSync } from "node:child_process";
 import { cpSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  extractApiOrigin,
+  loadProfile,
+  resolveProfilePath,
+} from "../apps/hubspot-extension/scripts/build-with-profile";
 
 const PROJECT_DIR = "apps/hubspot-project";
 // Default to PATH-resolved `hs` so the wrapper works across environments.
@@ -31,6 +41,7 @@ function runBundle(root: string): void {
   execFileSync("pnpm", ["tsx", "scripts/bundle-hubspot-card.ts"], {
     cwd: root,
     stdio: "inherit",
+    env: process.env,
   });
 }
 
@@ -43,26 +54,59 @@ export interface UploadDeps {
   log(message: string): void;
 }
 
+/**
+ * Pure helper: pull the `--profile`/`-p` value out of argv.
+ *
+ * Returns `undefined` when the flag is absent, so callers can still throw
+ * the "HubSpot profile required" error themselves.
+ */
+export function extractProfileName(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--profile" || arg === "-p") {
+      return args[i + 1];
+    }
+    if (arg?.startsWith("--profile=")) {
+      return arg.slice("--profile=".length);
+    }
+    if (arg?.startsWith("-p=")) {
+      return arg.slice("-p=".length);
+    }
+  }
+  return undefined;
+}
+
 export function buildUploadRunner(deps: UploadDeps) {
   return (args: string[]): number => {
-    const hasProfile =
-      args.includes("--profile") ||
-      args.includes("-p") ||
-      args.some((arg) => arg.startsWith("--profile=")) ||
-      args.some((arg) => arg.startsWith("-p="));
-    if (!hasProfile) {
+    const profileName = extractProfileName(args);
+    if (!profileName) {
       throw new Error("hs project upload requires --profile <name>");
     }
 
     const root = deps.repoRoot();
+    const profileDir = join(root, PROJECT_DIR);
+    const profilePath = resolveProfilePath(profileName, profileDir);
+    const profile = loadProfile(profilePath);
+    const apiOrigin = extractApiOrigin(profile);
+
     const src = join(root, PROJECT_DIR);
     const tmp = deps.makeTempDir();
 
-    deps.runBundle(root);
-    deps.log(`[hs-upload] copying ${src} → ${tmp}`);
-    deps.copyProject(src, tmp);
-    deps.log(`[hs-upload] running '${HS_CLI} project upload' from ${tmp}`);
-    return deps.runUpload(tmp, args);
+    const previousApiOrigin = process.env.API_ORIGIN;
+    process.env.API_ORIGIN = apiOrigin;
+    try {
+      deps.runBundle(root);
+      deps.log(`[hs-upload] copying ${src} → ${tmp}`);
+      deps.copyProject(src, tmp);
+      deps.log(`[hs-upload] running '${HS_CLI} project upload' from ${tmp}`);
+      return deps.runUpload(tmp, args);
+    } finally {
+      if (previousApiOrigin === undefined) {
+        delete process.env.API_ORIGIN;
+      } else {
+        process.env.API_ORIGIN = previousApiOrigin;
+      }
+    }
   };
 }
 

--- a/scripts/hs-project-upload.ts
+++ b/scripts/hs-project-upload.ts
@@ -59,13 +59,21 @@ export interface UploadDeps {
  * Pure helper: pull the `--profile`/`-p` value out of argv.
  *
  * Returns `undefined` when the flag is absent, so callers can still throw
- * the "HubSpot profile required" error themselves.
+ * the "HubSpot profile required" error themselves. Throws a clear
+ * "Missing value for --profile flag" error when the flag is present but
+ * its value is missing (last arg) or another flag (starts with `-`), so
+ * `hs project upload -p --dry-run` fails fast instead of interpreting
+ * `--dry-run` as the profile name.
  */
 export function extractProfileName(args: string[]): string | undefined {
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === "--profile" || arg === "-p") {
-      return args[i + 1];
+      const next = args[i + 1];
+      if (next === undefined || next.startsWith("-")) {
+        throw new Error(`Missing value for --profile flag (got ${arg} with no value)`);
+      }
+      return next;
     }
     if (arg?.startsWith("--profile=")) {
       return arg.slice("--profile=".length);

--- a/scripts/hs-project-upload.ts
+++ b/scripts/hs-project-upload.ts
@@ -18,6 +18,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { cpSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   extractApiOrigin,
   loadProfile,
@@ -38,7 +39,7 @@ function repoRoot(): string {
 
 function runBundle(root: string): void {
   console.log("[hs-upload] bundling HubSpot card and settings page");
-  execFileSync("pnpm", ["tsx", "scripts/bundle-hubspot-card.ts"], {
+  execFileSync("pnpm", ["tsx", "scripts/bundle-hubspot-card-cli.ts"], {
     cwd: root,
     stdio: "inherit",
     env: process.env,
@@ -131,6 +132,20 @@ export function main(args = process.argv.slice(2)): number {
   })(args);
 }
 
-if (import.meta.main) {
+/**
+ * Portable "is this file the entry point?" check. `import.meta.main` works
+ * on native Node 21.2+ but is `undefined` under `tsx`. Fall back to
+ * comparing `import.meta.url` against the file:// URL of `process.argv[1]`.
+ */
+function isMain(): boolean {
+  if (typeof import.meta.main === "boolean") {
+    return import.meta.main;
+  }
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isMain()) {
   process.exit(main());
 }


### PR DESCRIPTION
## Summary

Closes the Slice 8 / Slice 9 / Slice 10 loop by threading the selected HubSpot profile's `variables.API_ORIGIN` through the real production upload path.

Previously `scripts/hs-project-upload.ts` invoked `scripts/bundle-hubspot-card.ts` which called `vite.build({ configFile: false, ... })` — bypassing `apps/hubspot-extension/vite.config.ts` and therefore the Slice 8 `define: { __HAP_API_ORIGIN__ }` contract. Real uploads shipped without origin substitution.

This PR:

- Parses `--profile`/`-p` in the upload wrapper, resolves the profile via Slice 9 helpers, extracts `variables.API_ORIGIN`, and sets `process.env.API_ORIGIN` with a try/finally restore around `runBundle`+`runUpload`. `MissingApiOriginError` surfaces **before** any bundling or upload.
- Refactors `bundle-hubspot-card.ts` into a library + `bundle-hubspot-card-cli.ts`. The pure `buildViteOptions(target, apiOrigin)` helper emits `define: { __HAP_API_ORIGIN__: JSON.stringify(apiOrigin) }`, so programmatic `vite.build` now embeds the origin at build time.
- Adds a portable `isMain()` (compares `import.meta.url` to `pathToFileURL(process.argv[1]).href`) because `import.meta.main` is `undefined` under `tsx` 4.21 / Node 22.
- Documents the Slice 10 upload contract in `apps/hubspot-project/UPLOAD.md`.

Post-review polish (latest commit):
- `extractProfileName` throws a clear `Missing value for --profile flag` when the flag has no value (last argv, or followed by another flag) — prevents `hs project upload -p --dry-run` from silently treating `--dry-run` as the profile name.
- E2E test now uses `mkdtempSync` for its scratch dir and cleans it up in `afterAll`.

## Accepted asymmetry

- **Card bundle**: build-time substitution via `__HAP_API_ORIGIN__` (verified with sentinel-in-bundle assertion).
- **Settings bundle**: runtime `context.variables.API_ORIGIN` read by `apps/hubspot-extension/src/settings/settings-entry.tsx` (Slice 8 surface, not touched here). Both paths resolve to the same profile `API_ORIGIN` in production.

## Test plan

- [x] `pnpm test scripts/__tests__/hs-project-upload.test.ts` — 21/21
- [x] `pnpm test scripts/__tests__/bundle-hubspot-card.test.ts` — 5/5
- [x] `pnpm test scripts/__tests__/hs-project-upload-e2e.test.ts` — 1/1 (sentinel embedded in real card bundle)
- [x] `pnpm test` — 679/679 across 77 files
- [x] `pnpm typecheck` — exit 0

## Stack

Stacked on `feature/slice-9-hubspot-build-wrapper`. Base will auto-retarget to `main` when #9 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads the selected HubSpot profile’s API_ORIGIN through both the production upload and the extension build, injecting it via Vite `define` so bundles call the right backend per profile.

- **New Features**
  - Upload wrapper parses `--profile`/`-p`, reads `variables.API_ORIGIN`, sets `process.env.API_ORIGIN` for the build, throws early if missing, and restores the env after.
  - Extension build reads `process.env.API_ORIGIN` in `vite.config.ts` and defines `__HAP_API_ORIGIN__`; `resolveApiBaseUrl()` prefers the injected constant, then env, then `DEFAULT_API_BASE_URL`.
  - Added profile-aware extension build wrapper (`scripts/build-with-profile.ts`, `scripts/build-with-profile-cli.ts`) and `pnpm build:with-profile -- --profile <name>`.

- **Refactors**
  - Split bundler into lib (`scripts/bundle-hubspot-card.ts`) and CLI (`scripts/bundle-hubspot-card-cli.ts`) using `vite` + `@vitejs/plugin-react`; upload path now invokes the CLI.
  - Hardened entry detection (`isMain`) and `extractProfileName` validation for missing values.
  - Tests pin the `define` contract and bundle determinism; docs updated in `apps/hubspot-project/UPLOAD.md` to note both profile-aware build paths.

<sup>Written for commit 6e62e6eaec552369cb59a9a7f7ca5a72a939ea54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

