### PR TITLE
Planning docs reconciliation: track referenced .claude/tasks slice plans

### DIFF
--- a/.claude/tasks/2026-04-16-slice-3-phase-3-rls-card-bundling.md
+++ b/.claude/tasks/2026-04-16-slice-3-phase-3-rls-card-bundling.md
@@ -1,0 +1,492 @@
+# Plan: Slice 3 Phase 3 — RLS, Replay-Nonce, Card Bundling, HubSpot Enrichment
+
+## Task Description
+
+Complete the remaining Slice 3 tasks that Phase 1+2 deferred. Phase 1 delivered OAuth install flow + DB migrations. Phase 2 delivered real Anthropic/Gemini/News adapters + mock-fallback removal. Phase 3 delivers the defense-in-depth layer and the card bundling bridge that makes the real extension render on HubSpot:
+
+1. **Replay-nonce middleware wiring** — the `signed_request_nonce` table and schema exist (migration 0006), but the middleware in `hubspot-signature.ts` doesn't yet record or check nonces. Wire `recordNonce()` into the signature verification flow + add a TTL sweep script.
+2. **RLS enforcement** — add Postgres RLS policies to all tenant-scoped tables (except `tenants`). Create `withTenantTx` / `withTenantTxHandle` helpers that run `SET LOCAL app.tenant_id` in a transaction. Refactor auth middleware to set a tenant-bound DB handle on Hono context. Add a Biome `noRestrictedImports`-equivalent rule to prevent route/service files from importing the process-wide `db`.
+3. **Real HubSpot-enrichment adapter** — replace the Phase 3 deferral stub with a real adapter that calls `HubSpotClient.getCompanyProperties` + engagement/notes fetch. Needs the RLS tx handle from task 2.
+4. **Card bundling bridge** — create a Vite UMD build entry (`hubspot-card-entry.tsx`), a bundle script, and rewrite `SignalCard.tsx` to re-export the bundled output so `hs project upload` ships the real extension.
+5. **QA walkthrough, docs sweep, security audit, code review, final validation** — ship-readiness gates.
+
+## Objective
+
+After this plan completes, the HubSpot Signal-First Account Workspace is fully installable via OAuth, renders the real `SnapshotStateRenderer` in HubSpot's CRM record tab, has defense-in-depth via RLS + replay-nonce, and all four signal/LLM adapter paths are real (no stubs or mocks in production code).
+
+## Problem Statement
+
+Phase 1+2 shipped the OAuth flow and real adapters, but three critical gaps remain:
+
+- **No replay protection**: within the 5-minute signature freshness window, the same HubSpot signed request can be replayed. The nonce table exists but isn't wired into middleware.
+- **No RLS enforcement**: tenant isolation is app-layer only (`eq(table.tenantId, ctx.tenantId)`). A bug in any route handler could leak cross-tenant data. RLS adds belt-and-braces Postgres-level enforcement.
+- **Placeholder card in HubSpot**: the `SignalCard.tsx` in `apps/hubspot-project/` is still the Slice 2 scaffold `EmptyState`. The real React extension (`apps/hubspot-extension/`) isn't bundled into the HubSpot project, so `hs project upload` ships a placeholder.
+- **HubSpot-enrichment stub**: the adapter throws "not yet implemented". It needs the RLS tx handle + per-tenant OAuth client to call HubSpot CRM APIs.
+
+## Solution Approach
+
+### Replay-nonce wiring
+
+Add `apps/api/src/lib/replay-nonce.ts` with `recordNonce(db, { tenantId, timestamp, bodyHash })` that does `INSERT ... ON CONFLICT DO NOTHING` and returns `{ duplicate: boolean }`. Wire it into `hubspot-signature.ts` AFTER signature verification and AFTER `tenantMiddleware` resolves `tenantId`. Reject duplicates with `401 { error: "replay_detected" }`. Add `scripts/sweep-nonces.ts` for TTL cleanup (rows older than 10 minutes).
+
+**Key constraint**: the nonce check must happen AFTER both signature verification AND tenant resolution, because `tenantId` is part of the composite key. This means the nonce check lives in a NEW middleware that runs after `authMiddleware` + `tenantMiddleware`, not inside `hubspot-signature.ts` itself.
+
+### RLS enforcement
+
+1. **Migration 0007**: `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` + `CREATE POLICY` for `snapshots`, `evidence`, `people`, `provider_config`, `llm_config`, `tenant_hubspot_oauth`, `signed_request_nonce`. Each policy: `USING (tenant_id = current_setting('app.tenant_id', true)::uuid)` for SELECT/UPDATE/DELETE, same for INSERT `WITH CHECK`. `tenants` is deliberately excluded.
+2. **`apps/api/src/lib/tenant-tx.ts`**: two helpers:
+   - `withTenantTx(db, tenantId, fn)` — wraps `fn` in a transaction that first runs `SET LOCAL app.tenant_id = tenantId`. For scripts/background jobs.
+   - `withTenantTxHandle(db, tenantId)` — returns a Drizzle-compatible handle where every query runs inside a `SET LOCAL` transaction. For request-scoped middleware injection.
+3. **RLS DB-handle injection** — canonicalized to ONE location: a new middleware in `apps/api/src/index.ts` mounted immediately AFTER `tenantMiddleware`. This middleware reads `c.get('tenantId')`, calls `withTenantTxHandle(getDb(), tenantId)`, and sets `c.set('db', rlsHandle)`. Neither `auth.ts` nor `tenant.ts` are modified for this concern — `auth.ts` stays as a signature/portal-id extractor, `tenant.ts` stays as a tenant resolver. The RLS handle is a separate middleware responsibility.
+4. **Mechanical sweep**: replace direct `db` imports in `apps/api/src/routes/` and `apps/api/src/services/` with `c.get('db')`.
+5. **Biome lint rule**: Biome 2.4 supports `noRestrictedImports` under `nursery`. The rule targets only runtime DB-client construction (`createDatabase` function), NOT schema/table imports or type-only imports from `@hap/db`. Route and service files legitimately import schema tables, types, and `eq`/`sql` helpers — those are safe. The banned import is the `createDatabase` factory and any module-level `db` singleton.
+
+### ProviderAdapter contract fix (prerequisite for HubSpot-enrichment)
+
+The current `ProviderAdapter.fetchSignals(tenantId, companyName, domain?)` interface is ambiguous — `snapshot-assembler.ts:121` passes `companyId` as the second arg (not a company name). The HubSpot-enrichment adapter needs `companyId` for CRM API lookups, while Exa/News use it as a search query term. Fix the contract BEFORE implementing the enrichment adapter:
+
+1. Change `ProviderAdapter.fetchSignals` signature to accept a structured arg:
+   `fetchSignals(tenantId: string, context: { companyId: string; companyName?: string; domain?: string }): Promise<Evidence[]>`
+2. Update `snapshot-assembler.ts` to pass `{ companyId, companyName, domain }` (companyName + domain resolved from CRM properties or the route params).
+3. Update all existing adapter implementations: `ExaAdapter`, `NewsAdapter`, `HubSpotEnrichmentAdapter`, mock adapters in `__tests__/`, and the `wrapSignalWithGuards` wrapper.
+4. Exa/News adapters use `context.companyName ?? context.companyId` as the query term (backward-compatible behavior).
+5. HubSpot-enrichment adapter uses `context.companyId` for CRM lookups.
+6. Update all affected tests.
+
+### HubSpot-enrichment adapter
+
+Replace the stub in `apps/api/src/adapters/signal/hubspot-enrichment.ts`. The adapter:
+
+- Accepts a `HubSpotClient` instance (injected by the factory).
+- Uses `context.companyId` (from the updated contract) to call `client.getCompanyProperties(companyId, ["name", "domain", "description", "notes_last_updated"])`.
+- Calls a new `client.getCompanyEngagements(companyId)` method (CRM v3 associations → engagement search).
+- Emits `Evidence[]` rows with `source: "hubspot-enrichment"`.
+- Update the signal factory to construct a `HubSpotClient` when no `deps.hubspotClient` is injected:
+  - Extend `SignalFactoryDeps` with optional `db: Database` and `tenantId: string` fields.
+  - In the `hubspot-enrichment` branch: if no `deps.hubspotClient`, construct `new HubSpotClient({ tenantId: deps.tenantId!, db: deps.db!, fetch: deps.fetch })`.
+  - Update `resolveSignalAdapter` in `routes/snapshot.ts` to pass `{ db: c.get('db'), tenantId }` into the factory deps.
+  - Add tests for both the injected-client and default-construction paths.
+
+### Card bundling bridge
+
+1. **New entry file**: `apps/hubspot-extension/src/hubspot-card-entry.tsx` — extracts the render tree into a shared `ExtensionRoot` component, re-exports as default. Also calls `hubspot.extend()` for local-dev parity.
+2. **Vite config**: `apps/hubspot-extension/vite.config.ts` — `build.lib.entry = "src/hubspot-card-entry.tsx"`, `formats: ["umd"]`, externalize `react`, `react-dom`, `@hubspot/ui-extensions`.
+3. **Bundle script**: `scripts/bundle-hubspot-card.ts` — runs the Vite build, copies output to `apps/hubspot-project/src/app/cards/dist/`.
+4. **Rewrite SignalCard.tsx**: `export { default } from "./dist/index.js"` — the HubSpot bundler picks up the real extension.
+5. **Update card-hsmeta.json**: point entrypoint at the new card file if needed.
+6. **Update `scripts/hs-project-upload.ts`**: invoke bundle script before upload.
+
+## Relevant Files
+
+### Existing Files to Modify
+
+- `apps/api/src/middleware/hubspot-signature.ts` — remove the replay-nonce TODO, but the actual nonce check goes in a new middleware (see below)
+- `apps/api/src/middleware/auth.ts` — re-export the signature middleware (unchanged)
+- `apps/api/src/middleware/tenant.ts` — types only (add `db` to `TenantVariables`); tenant resolution logic unchanged
+- `apps/api/src/index.ts` — mount the nonce middleware, mount the RLS DB-handle middleware (new, after tenantMiddleware)
+- `apps/api/src/adapters/provider-adapter.ts` — change `fetchSignals` signature to structured context arg
+- `apps/api/src/services/snapshot-assembler.ts` — update `fetchSignals` call to pass structured context
+- `apps/api/src/routes/snapshot.ts` — remove local `getDb()`, use `c.get('db')` from context
+- `apps/api/src/adapters/signal/hubspot-enrichment.ts` — replace stub with real implementation
+- `apps/api/src/adapters/signal/factory.ts` — update hubspot-enrichment branch to construct HubSpotClient from tenant context
+- `apps/api/src/lib/hubspot-client.ts` — add `getCompanyEngagements()` method
+- `apps/hubspot-extension/src/index.tsx` — extract render tree into shared `ExtensionRoot`
+- `apps/hubspot-extension/package.json` — add vite as devDependency
+- `apps/hubspot-project/src/app/cards/SignalCard.tsx` — rewrite to re-export bundled extension
+- `apps/hubspot-project/src/app/cards/card-hsmeta.json` — potentially update entrypoint
+- `packages/db/src/index.ts` — may need to export `sql` for RLS `SET LOCAL`
+- `biome.json` — add `noRestrictedImports` nursery rule
+- `scripts/hs-project-upload.ts` — invoke bundle script first
+- `docs/security/SECURITY.md` — add §17 (RLS) and §18 (replay-nonce)
+
+### New Files
+
+- `apps/api/src/lib/replay-nonce.ts` — `recordNonce()` function
+- `apps/api/src/lib/__tests__/replay-nonce.test.ts` — unit tests
+- `apps/api/src/middleware/nonce.ts` — nonce-check middleware (runs after auth + tenant)
+- `apps/api/src/middleware/__tests__/nonce.test.ts` — middleware integration tests
+- `apps/api/src/lib/tenant-tx.ts` — `withTenantTx` + `withTenantTxHandle`
+- `apps/api/src/lib/__tests__/tenant-tx.test.ts` — unit + integration tests
+- `packages/db/drizzle/0007_rls_policies.sql` — RLS migration
+- `apps/api/src/lib/__tests__/rls.test.ts` — cross-tenant isolation regression tests
+- `apps/api/src/adapters/signal/__tests__/hubspot-enrichment.test.ts` — real adapter tests
+- `apps/api/src/adapters/signal/__tests__/cassettes/hubspot-enrichment-company.json` — cassette
+- `apps/api/src/adapters/signal/__tests__/cassettes/hubspot-enrichment-engagements.json` — cassette
+- `apps/hubspot-extension/src/hubspot-card-entry.tsx` — UMD bundle entry
+- `apps/hubspot-extension/src/components/extension-root.tsx` — shared render tree
+- `apps/hubspot-extension/vite.config.ts` — Vite build config
+- `scripts/bundle-hubspot-card.ts` — bundle + copy script
+- `scripts/sweep-nonces.ts` — TTL nonce cleanup
+- `apps/hubspot-project/__validate__/bundle.test.ts` — bundle existence + re-export test
+- `docs/qa/slice-3-walkthrough.md` — QA walkthrough document
+
+## Implementation Phases
+
+### Phase 1: Foundation (Tasks 1-3)
+
+RLS migration + tenant-tx helpers + replay-nonce library. These are foundational — everything else depends on the RLS handle existing and the nonce function being available.
+
+### Phase 2: Core Implementation (Tasks 4-8)
+
+Wire RLS into middleware (Task 4), wire nonce into middleware (Task 5), fix ProviderAdapter contract (Task 6), implement HubSpot-enrichment adapter (Task 7), build card bundling bridge (Task 8). Partial parallelism: nonce wiring and card bundling are independent; HubSpot-enrichment depends on both RLS wiring and the contract fix.
+
+### Phase 3: Integration & Polish (Tasks 9-13)
+
+Biome lint rule, docs sweep, security audit, code review, final validation. Strictly sequential — each gate depends on all implementation being complete.
+
+## Team Orchestration
+
+- You operate as the team lead and orchestrate the team to execute the plan.
+- You're responsible for deploying the right team members with the right context to execute the plan.
+- IMPORTANT: You NEVER operate directly on the codebase. You dispatch specialist agents to handle building, validating, testing, and other tasks.
+  - This is critical. Your job is to act as a high-level director of the team, not a builder.
+  - Your role is to validate all work is going well and make sure the team is on track to complete the plan.
+  - Use agent-dispatch primitives (the Agent tool) to deploy team members. Create and update an in-conversation task list to track progress across agents.
+  - Communication is paramount. Monitor agent results, verify outputs, and coordinate handoffs between agents.
+- Take note of the session id of each team member. This is how you'll reference them.
+
+### Team Members
+
+- Specialist
+  - Name: builder-db
+  - Role: RLS migration, tenant-tx helpers, RLS wiring into middleware, cross-tenant regression tests
+  - Agent Type: backend-engineer
+  - Resume: true
+
+- Specialist
+  - Name: builder-backend
+  - Role: Replay-nonce library + middleware, HubSpot-enrichment adapter, nonce sweep script, mechanical db-import sweep
+  - Agent Type: backend-engineer
+  - Resume: true
+
+- Specialist
+  - Name: builder-frontend
+  - Role: Card bundling bridge (Vite config, entry file, bundle script, SignalCard rewrite)
+  - Agent Type: frontend-specialist
+  - Resume: true
+
+- Specialist
+  - Name: security-reviewer
+  - Role: Security audit of OAuth, RLS, and replay-nonce implementation
+  - Agent Type: security-auditor
+  - Resume: false
+
+- Quality Engineer (Validator)
+  - Name: validator
+  - Role: Validate completed work against acceptance criteria (read-only inspection mode)
+  - Agent Type: quality-engineer
+  - Resume: false
+
+## Step by Step Tasks
+
+- IMPORTANT: Execute every step in order, top to bottom. Track each task in the in-conversation task list; mark each complete as soon as it's done.
+- Before you start, create the task list so all agents can reference the plan's progress.
+- IMPORTANT: All work happens in the worktree at `/Users/romeoman/Documents/Dev/HubSpot/Account Plan App/.worktrees/slice-3-phase-3` on branch `feature/slice-3-phase-3-rls-card-bundling`.
+
+### 1. RLS Migration (0007)
+
+- **Task ID**: rls-migration
+- **Depends On**: none
+- **Assigned To**: builder-db
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Create `packages/db/drizzle/0007_rls_policies.sql`:
+  - `ALTER TABLE snapshots ENABLE ROW LEVEL SECURITY;`
+  - `ALTER TABLE evidence ENABLE ROW LEVEL SECURITY;`
+  - `ALTER TABLE people ENABLE ROW LEVEL SECURITY;`
+  - `ALTER TABLE provider_config ENABLE ROW LEVEL SECURITY;`
+  - `ALTER TABLE llm_config ENABLE ROW LEVEL SECURITY;`
+  - `ALTER TABLE tenant_hubspot_oauth ENABLE ROW LEVEL SECURITY;`
+  - `ALTER TABLE signed_request_nonce ENABLE ROW LEVEL SECURITY;`
+  - For EACH table above, create two policies:
+    - `CREATE POLICY {table}_tenant_select ON {table} FOR ALL USING (tenant_id = current_setting('app.tenant_id', true)::uuid);`
+    - `CREATE POLICY {table}_tenant_insert ON {table} FOR INSERT WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid);`
+  - `tenants` is deliberately NOT under RLS (bootstrap lookup table).
+  - ALSO add `ALTER ROLE` to ensure the app database role has RLS enforced (not superuser bypass): `ALTER TABLE {table} FORCE ROW LEVEL SECURITY;` so even the table owner is subject to policies.
+- TDD: write a migration test in `packages/db/src/schema/__tests__/slice3-phase3-migrations.test.ts` that applies the migration and verifies RLS is enabled on all 7 tables via `pg_catalog.pg_tables` query.
+- Run `pnpm test` to confirm all 531+ tests still pass.
+
+### 2. Tenant Transaction Helpers
+
+- **Task ID**: tenant-tx
+- **Depends On**: rls-migration
+- **Assigned To**: builder-db
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Create `apps/api/src/lib/tenant-tx.ts` with two exports:
+  - `withTenantTx(db, tenantId, fn)` — wraps `fn(tx)` in a Drizzle transaction that first runs `await tx.execute(sql.raw(\`SET LOCAL app.tenant_id = '${tenantId}'\`))`. For scripts and background jobs.
+  - `withTenantTxHandle(db, tenantId)` — returns a proxy/wrapper that provides the same Drizzle query surface (`select`, `insert`, `update`, `delete`, `query`) but every call goes through a `SET LOCAL` transaction. For request-scoped middleware injection.
+- TDD: write tests in `apps/api/src/lib/__tests__/tenant-tx.test.ts`:
+  - `withTenantTx` sets the session variable (verify via `current_setting('app.tenant_id')` inside the tx callback).
+  - `withTenantTxHandle` returns correct results scoped to the tenant.
+  - Cross-tenant isolation: seed rows for tenant A and B, use handle for tenant B, SELECT all from tenant-scoped table — must see only B's rows.
+- Run full test suite.
+
+### 3. Replay-Nonce Library
+
+- **Task ID**: replay-nonce-lib
+- **Depends On**: none
+- **Assigned To**: builder-backend
+- **Agent Type**: backend-engineer
+- **Parallel**: true (parallel with task 1+2)
+- Create `apps/api/src/lib/replay-nonce.ts`:
+  - `recordNonce(db, { tenantId, timestamp, bodyHash }): Promise<{ duplicate: boolean }>` — `INSERT INTO signed_request_nonce (tenant_id, timestamp, body_hash) VALUES ($1, $2, $3) ON CONFLICT (tenant_id, timestamp, body_hash) DO NOTHING` — check `rowCount === 0` for duplicate.
+  - `computeBodyHash(body: string): Buffer` — `createHash('sha256').update(body).digest()`.
+- TDD: write tests in `apps/api/src/lib/__tests__/replay-nonce.test.ts`:
+  - First insert returns `{ duplicate: false }`.
+  - Same `(tenantId, timestamp, bodyHash)` returns `{ duplicate: true }`.
+  - Different tenant with same `(timestamp, bodyHash)` returns `{ duplicate: false }` (proves tenant-scoped PK).
+  - Different bodyHash for same tenant returns `{ duplicate: false }`.
+- Create `scripts/sweep-nonces.ts`: deletes rows where `created_at < now() - interval '10 minutes'`, logs count deleted.
+- Run full test suite.
+
+### 4. RLS Middleware Wiring
+
+- **Task ID**: rls-wiring
+- **Depends On**: tenant-tx, rls-migration
+- **Assigned To**: builder-db
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- **Canonical injection point**: add a NEW middleware function in `apps/api/src/index.ts`, mounted immediately AFTER `tenantMiddleware` on the `/api/*` path. This middleware:
+  1. Reads `tenantId` from `c.get('tenantId')` (set by tenantMiddleware upstream).
+  2. Calls `withTenantTxHandle(getDb(), tenantId)` to create an RLS-bound DB handle.
+  3. Sets `c.set('db', rlsHandle)` on the Hono context.
+  - `auth.ts` is NOT modified for this concern (stays as signature verifier).
+  - `tenant.ts` is NOT modified for this concern (stays as tenant resolver). Only its exported `TenantVariables` type gains the `db` field.
+- Mechanical sweep in `apps/api/src/routes/snapshot.ts`:
+  - Remove the local `getDb()` function and `cachedDb` variable.
+  - Change the route handler to read `const db = c.get('db')` from Hono context.
+  - Update all DB calls to use the context-provided handle.
+- Add RLS regression test in `apps/api/src/lib/__tests__/rls.test.ts`:
+  - Seed tenant A + tenant B rows in `snapshots`, `evidence`, `people`, `provider_config`, `llm_config`, `tenant_hubspot_oauth`.
+  - Open a session with `withTenantTxHandle(db, tenantB.id)`.
+  - SELECT from each table — must return ONLY tenant B rows.
+  - Attempt to INSERT a row with `tenant_id = tenantA.id` via tenant B's handle — must fail (RLS WITH CHECK violation).
+- Run full test suite — all existing tests must still pass.
+
+### 5. Replay-Nonce Middleware Wiring
+
+- **Task ID**: nonce-wiring
+- **Depends On**: replay-nonce-lib, rls-wiring
+- **Assigned To**: builder-backend
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Create `apps/api/src/middleware/nonce.ts`:
+  - Reads the raw body text (already available on `c.req` after signature middleware consumed it — may need to re-read or stash it).
+  - Computes `bodyHash = computeBodyHash(body)`.
+  - Reads `timestamp` from `X-HubSpot-Request-Timestamp` header (already validated by signature middleware).
+  - Reads `tenantId` from `c.get('tenantId')` (set by tenant middleware).
+  - Calls `recordNonce(db, { tenantId, timestamp, bodyHash })`.
+  - If `duplicate`, returns `401 { error: "replay_detected" }`.
+  - Otherwise calls `next()`.
+- Mount in `apps/api/src/index.ts` AFTER `authMiddleware` + `tenantMiddleware`, BEFORE route handlers.
+- IMPORTANT: the signature middleware reads the body via `c.req.text()` which consumes the stream. The nonce middleware needs the same body. Solution: stash the raw body text on the Hono context in the signature middleware (`c.set('rawBody', body)`) and read it from context in the nonce middleware.
+- TDD: write tests in `apps/api/src/middleware/__tests__/nonce.test.ts`:
+  - First request passes through (nonce recorded).
+  - Replay of same request returns 401 `replay_detected`.
+  - Different body with same timestamp passes (different hash).
+  - Different tenant with same body+timestamp passes (tenant-scoped).
+- Update the `@todo Slice 3` comment in `hubspot-signature.ts` to reference the nonce middleware.
+- Run full test suite.
+
+### 6. ProviderAdapter Contract Fix
+
+- **Task ID**: provider-contract-fix
+- **Depends On**: rls-wiring
+- **Assigned To**: builder-backend
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Change `ProviderAdapter.fetchSignals` in `apps/api/src/adapters/provider-adapter.ts`:
+  - Old: `fetchSignals(tenantId: string, companyName: string, domain?: string): Promise<Evidence[]>`
+  - New: `fetchSignals(tenantId: string, context: SignalContext): Promise<Evidence[]>` where `SignalContext = { companyId: string; companyName?: string; domain?: string }`
+- Update `apps/api/src/services/snapshot-assembler.ts` line 121: change `fetchSignals(tenantId, companyId)` to `fetchSignals(tenantId, { companyId, companyName, domain })` (companyName/domain resolved from route params or CRM properties — can be undefined initially).
+- Update `ExaAdapter.fetchSignals`: use `context.companyName ?? context.companyId` as the query term (backward-compatible).
+- Update `NewsAdapter.fetchSignals`: same — `context.companyName ?? context.companyId`.
+- Update `HubSpotEnrichmentAdapter.fetchSignals`: use `context.companyId` for CRM API calls.
+- Update `wrapSignalWithGuards` in `apps/api/src/adapters/signal/factory.ts`: pass through the structured context.
+- Update all mock adapters in `__tests__/` and all test call sites.
+- TDD: update existing adapter tests to use the new signature. All must pass.
+- Run full test suite.
+
+### 7. HubSpot Enrichment Adapter
+
+- **Task ID**: hubspot-enrichment
+- **Depends On**: provider-contract-fix, rls-wiring
+- **Assigned To**: builder-backend
+- **Agent Type**: backend-engineer
+- **Parallel**: true (parallel with task 5 after dependencies met)
+- Add `getCompanyEngagements(companyId: string): Promise<Array<{ type: string; timestamp: string; subject?: string }>>` method to `apps/api/src/lib/hubspot-client.ts`:
+  - `GET /crm/v3/objects/companies/{companyId}/associations/engagements` to get engagement IDs.
+  - Then batch-fetch engagement properties.
+  - Return the 10 most recent.
+- Replace the stub in `apps/api/src/adapters/signal/hubspot-enrichment.ts`:
+  - `fetchSignals(tenantId, context)`:
+    - Use `context.companyId` to call `this.client.getCompanyProperties(context.companyId, ["name", "domain", "description", "notes_last_updated"])`.
+    - Use `this.client.getCompanyEngagements(context.companyId)` for recent engagement data.
+    - Map results to `Evidence[]` with `source: "hubspot-enrichment"`, appropriate `confidence` and `timestamp`.
+    - Handle missing data gracefully — return empty array if no enrichment data found.
+- Update signal factory (`apps/api/src/adapters/signal/factory.ts`):
+  - Extend `SignalFactoryDeps` with optional `db: Database` and `tenantId: string` fields.
+  - In the `hubspot-enrichment` branch, when no `deps.hubspotClient` is injected, construct `new HubSpotClient({ tenantId: deps.tenantId!, db: deps.db!, fetch: deps.fetch })`.
+  - Update `resolveSignalAdapter` in `routes/snapshot.ts` to pass `{ db: c.get('db'), tenantId }` into the factory deps.
+  - Add tests for both the injected-client path and the default-construction path.
+- Record cassettes:
+  - `apps/api/src/adapters/signal/__tests__/cassettes/hubspot-enrichment-company.json`
+  - `apps/api/src/adapters/signal/__tests__/cassettes/hubspot-enrichment-engagements.json`
+- TDD: write tests in `apps/api/src/adapters/signal/__tests__/hubspot-enrichment.test.ts`:
+  - Returns evidence from company properties.
+  - Returns evidence from engagements.
+  - Returns empty array on 404 company.
+  - Handles partial data (company exists but no engagements).
+- Add `"hubspot-enrichment"` to `REAL_SIGNAL_PROVIDERS` in `apps/api/src/routes/snapshot.ts`.
+- Run full test suite.
+
+### 8. Card Bundling Bridge
+
+- **Task ID**: card-bundler
+- **Depends On**: none
+- **Assigned To**: builder-frontend
+- **Agent Type**: frontend-specialist
+- **Parallel**: true (fully independent of backend tasks)
+- Extract the render tree from `apps/hubspot-extension/src/index.tsx` into a shared component:
+  - Create `apps/hubspot-extension/src/components/extension-root.tsx` that exports `ExtensionRoot` — accepts the same props as `Extension` and renders `SnapshotStateRenderer` with the loading/error/empty logic.
+  - Update `apps/hubspot-extension/src/index.tsx` to import and use `ExtensionRoot`.
+- Create `apps/hubspot-extension/src/hubspot-card-entry.tsx`:
+  - `export default` a React component that renders `ExtensionRoot`.
+  - Also calls `hubspot.extend<'crm.record.tab'>()` for local-dev parity.
+- Add `vite` as a devDependency to `apps/hubspot-extension/package.json`.
+- Create `apps/hubspot-extension/vite.config.ts`:
+  - `build.lib.entry: "src/hubspot-card-entry.tsx"`.
+  - `build.lib.formats: ["iife"]` (single self-executing bundle — simpler than UMD for HubSpot's card runtime which evaluates the file directly).
+  - `build.lib.name: "HapSignalCard"`.
+  - `build.outDir: "dist"`.
+  - `build.rollupOptions.output.entryFileNames: "index.js"` — lock the output filename to exactly `dist/index.js`. Do NOT rely on Vite's default naming convention (`index.umd.cjs`, `index.iife.js`, etc.) which varies by format and Vite version.
+  - Externalize: `react`, `react-dom`, `@hubspot/ui-extensions`, `@hubspot/ui-extensions/crm`.
+- Create `scripts/bundle-hubspot-card.ts`:
+  - Run `pnpm --filter @hap/hubspot-extension build` (Vite build).
+  - Verify `apps/hubspot-extension/dist/index.js` exists (fail loudly if not — catches Vite config drift).
+  - Copy `apps/hubspot-extension/dist/index.js` to `apps/hubspot-project/src/app/cards/dist/index.js`.
+  - Copy `apps/hubspot-extension/dist/style.css` to `apps/hubspot-project/src/app/cards/dist/index.css` if it exists.
+- Rewrite `apps/hubspot-project/src/app/cards/SignalCard.tsx`:
+  - Replace the scaffold placeholder with: `export { default } from "./dist/index.js";`
+- Update `scripts/hs-project-upload.ts` to run `bundle-hubspot-card.ts` first.
+- Add `.gitignore` entry for `apps/hubspot-project/src/app/cards/dist/` (build artifact).
+- TDD: write `apps/hubspot-project/__validate__/bundle.test.ts`:
+  - After running the bundle script, verify `apps/hubspot-project/src/app/cards/dist/index.js` exists.
+  - Verify `SignalCard.tsx` re-exports from the dist.
+- Verify all existing extension tests still pass.
+- Run full test suite.
+
+### 9. Biome Lint Rule for DB Client Imports
+
+- **Task ID**: lint-db-imports
+- **Depends On**: rls-wiring
+- **Assigned To**: builder-db
+- **Agent Type**: backend-engineer
+- **Parallel**: true (after rls-wiring, parallel with other tasks)
+- **Scope**: the rule targets ONLY runtime DB-client construction, NOT all `@hap/db` imports. Route/service files legitimately import schema tables (`tenants`, `snapshots`, etc.), types (`Database`, `Tenant`), and query helpers (`eq`, `sql`) from `@hap/db` — those are safe and must not be blocked.
+- **What to ban**: the `createDatabase` function import from `@hap/db` and any local module that exports a process-wide `db` singleton. These are the imports that bypass RLS.
+- **What to allow**: type-only imports, schema/table imports, `eq`/`sql`/`and` helpers, and the `Database` type (used as a parameter type for dependency injection).
+- Add a Biome `noRestrictedImports` rule (nursery) targeting `createDatabase`. If Biome doesn't support path-scoped restrictions, add a nested `biome.json` override in `apps/api/src/routes/` and `apps/api/src/services/`.
+- Verify with `pnpm lint` — should pass (all routes already use `c.get('db')` after task 4).
+- Run a targeted grep to confirm no runtime DB-client construction in routes/services:
+  `grep -rE "createDatabase|getDb\(\)" apps/api/src/routes apps/api/src/services` — returns no matches.
+  (This replaces the overly broad `from.*@hap/db` grep that would false-positive on schema/type imports.)
+
+### 10. Documentation Sweep
+
+- **Task ID**: docs-sweep
+- **Depends On**: hubspot-enrichment, nonce-wiring, card-bundler, lint-db-imports, provider-contract-fix
+- **Assigned To**: builder-backend
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Update `docs/security/SECURITY.md`:
+  - Mark §16 (OAuth migration) as complete.
+  - Add §17: RLS architecture — policies, `withTenantTx`, `withTenantTxHandle`, threat model coverage, `tenants` exclusion rationale.
+  - Add §18: Replay-nonce architecture — nonce middleware, composite PK design, TTL sweep, cross-tenant independence.
+- Update `CLAUDE.md` "Verified stack versions" if any new deps landed (e.g., `vite`).
+- Update `README.md` install instructions if present — point at OAuth install URL.
+- Remove or update stale `@todo Slice 3` comments across the codebase.
+
+### 11. Security Audit
+
+- **Task ID**: security-audit
+- **Depends On**: docs-sweep
+- **Assigned To**: security-reviewer
+- **Agent Type**: security-auditor
+- **Parallel**: false
+- OAuth flow audit: CSRF state HMAC, redirect-URL validation, token-refresh race, 401-loop prevention, log redaction.
+- RLS audit: every tenant-scoped table has RLS enabled + FORCE; every policy uses `current_setting('app.tenant_id', true)::uuid`; no `SECURITY DEFINER` functions bypass RLS.
+- Replay-nonce audit: TTL sweep runs, `ON CONFLICT DO NOTHING` is atomic, bodyHash is SHA-256, tenant-scoped PK prevents cross-tenant nonce collisions.
+- Card bundling audit: no secrets in the UMD bundle, externalized deps match runtime expectations.
+- Report PASS / FAIL per area with evidence.
+
+### 12. Code Review
+
+- **Task ID**: code-review
+- **Depends On**: security-audit
+- **Assigned To**: builder-backend
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Push the branch to origin.
+- Run CodeRabbit CLI: `coderabbit review --agent --base main --type committed`.
+- Also run an independent code-reviewer subagent against the diff.
+- Fix real findings, push back on incorrect ones with technical reasoning.
+- Push fixes and re-verify.
+
+### 13. Final Validation
+
+- **Task ID**: validate-all
+- **Depends On**: rls-migration, tenant-tx, replay-nonce-lib, rls-wiring, nonce-wiring, provider-contract-fix, hubspot-enrichment, card-bundler, lint-db-imports, docs-sweep, security-audit, code-review
+- **Assigned To**: validator
+- **Agent Type**: quality-engineer
+- **Parallel**: false
+- Run all validation commands.
+- Verify acceptance criteria met.
+- Operate in validation mode: inspect and report only, do not modify files.
+
+## Acceptance Criteria
+
+- RLS is enabled on all 7 tenant-scoped tables (`snapshots`, `evidence`, `people`, `provider_config`, `llm_config`, `tenant_hubspot_oauth`, `signed_request_nonce`). `tenants` is NOT under RLS.
+- `FORCE ROW LEVEL SECURITY` is set on all 7 tables (owner bypass disabled).
+- Cross-tenant SELECT under RLS returns zero rows (proven by `rls.test.ts`).
+- Cross-tenant INSERT under RLS fails with policy violation (proven by `rls.test.ts`).
+- `withTenantTx(db, tenantId, fn)` correctly sets `app.tenant_id` session variable inside the transaction.
+- `withTenantTxHandle(db, tenantId)` returns a handle that scopes all queries to the tenant.
+- No route or service file under `apps/api/src/routes/` or `apps/api/src/services/` calls `createDatabase` or constructs a process-wide DB client. Schema/table imports, type imports, and `eq`/`sql` helpers from `@hap/db` are allowed.
+- `ProviderAdapter.fetchSignals` accepts a structured `SignalContext` arg (`{ companyId, companyName?, domain? }`), not positional `(companyName, domain?)`. All adapters, tests, and the assembler use the new signature.
+- Replay-nonce: POSTing the same `(tenantId, timestamp, bodyHash)` twice returns 401 `replay_detected` on the second call.
+- Replay-nonce: two different tenants with identical `(timestamp, bodyHash)` BOTH succeed.
+- `scripts/sweep-nonces.ts` deletes rows older than 10 minutes.
+- HubSpot-enrichment adapter returns `Evidence[]` from real CRM data (cassette-tested).
+- `hubspot-enrichment` is listed in `REAL_SIGNAL_PROVIDERS`.
+- Card bundling: `apps/hubspot-project/src/app/cards/dist/index.js` exists after `pnpm tsx scripts/bundle-hubspot-card.ts`.
+- `SignalCard.tsx` re-exports from the bundled dist.
+- All existing Slice 1 + 2 + Phase 1-2 tests still pass (baseline 531).
+- `pnpm lint` passes with the new Biome restriction rule.
+- Security audit PASS on RLS, replay-nonce, and card bundling.
+- SECURITY.md updated with §17 (RLS) and §18 (replay-nonce).
+
+## Validation Commands
+
+Execute these commands to validate the task is complete:
+
+- `pnpm install --frozen-lockfile` — lockfile drift check
+- `pnpm lint` — Biome clean (no errors)
+- `pnpm test` — full Vitest suite passes (baseline 531 + ~40 new Phase 3 tests)
+- `pnpm typecheck` — TypeScript compilation passes
+- `pnpm db:migrate` — all migrations (0001-0007) apply idempotently
+- `pnpm tsx scripts/bundle-hubspot-card.ts` — extension bundles; output at `apps/hubspot-project/src/app/cards/dist/index.js`
+- `grep -rE "createDatabase|getDb\(\)" apps/api/src/routes apps/api/src/services` — returns no matches (targets runtime DB-client construction only; schema/type imports from `@hap/db` are allowed)
+- `grep -r "createMockLlmAdapter\|createMockSignalAdapter" apps/api/src/routes apps/api/src/services` — returns no matches
+- `grep -i "HUBSPOT_DEV_PORTAL_TOKEN" apps packages scripts .env.example` — returns no matches (excluding docs)
+
+## Notes
+
+- **Worktree**: all work happens in `.worktrees/slice-3-phase-3` on branch `feature/slice-3-phase-3-rls-card-bundling`. The worktree is already created and baseline tests pass (531/531).
+- **TDD is mandatory**: every task writes failing tests first, confirms failure, then implements. No exceptions.
+- **Cassette-based testing**: mandatory for the HubSpot-enrichment adapter. Use the same `__tests__/cassettes/*.json` + fetch injection pattern from Phase 1-2.
+- **RLS `current_setting` with `true` second arg**: the `true` parameter to `current_setting('app.tenant_id', true)` means "return NULL if the setting doesn't exist" instead of throwing. This is critical — without it, any query outside a `SET LOCAL` context (e.g., a migration, a health check) would crash.
+- **Card bundling approach**: the HubSpot project bundler (`hs project upload`) processes the `SignalCard.tsx` entrypoint. By making it re-export from a pre-built UMD, we bypass the HubSpot bundler's inability to resolve our pnpm workspace deps. The UMD bundle includes all workspace package code; only React and `@hubspot/ui-extensions` are externalized (provided by HubSpot's card runtime).
+- **Biome `noRestrictedImports`**: as of Biome 2.4, this rule is in `nursery`. It targets ONLY the `createDatabase` function import — NOT all `@hap/db` imports. Schema tables, types, and query helpers (`eq`, `sql`) are safe and must not be blocked. If Biome doesn't support path-scoped overrides, use a nested `biome.json` in `apps/api/src/routes/` and `apps/api/src/services/`.
+- **Phase 3 does NOT deliver**: settings/model-picker UI (Slice 4), marketplace listing submission (business workflow), token-revocation webhook (Slice 4), OpenRouter/custom-endpoint adapters (Slice 4 stubs).

--- a/.claude/tasks/2026-04-16-slice-4-settings-configuration.md
+++ b/.claude/tasks/2026-04-16-slice-4-settings-configuration.md
@@ -1,0 +1,357 @@
+# Plan: Slice 4 - Tenant Settings and Configuration UX
+
+## Task Description
+
+Slice 4 adds the first tenant-facing configuration surface to the product.
+After Slice 3, the app is installable, multi-tenant, OAuth-backed, RLS-hardened,
+and capable of serving real signal + LLM results. The remaining product gap is
+that tenants still cannot configure their own provider credentials, model
+selection, thresholds, or eligibility property from inside the app.
+
+Today the product handles missing config safely by returning
+`eligibilityState: "unconfigured"` and rendering `UnconfiguredState`, but that
+state is a dead end. The database schema, encryption layer, config resolver,
+RLS wiring, and tenant model already exist:
+
+- `provider_config` and `llm_config` support per-tenant config rows
+- `tenants.settings` exists for tenant-level settings
+- encrypted key storage already exists for `api_key_encrypted`
+- request-scoped tenant DB handles already exist after Slice 3
+- HubSpot’s latest developer platform supports a React-based `settings`
+  extension for installed apps
+
+Slice 4 turns those backend primitives into a real settings product surface:
+
+1. a HubSpot app `settings` extension UI
+2. tenant-scoped settings read/write APIs
+3. encrypted provider/LLM key management
+4. actionable UX from the current `unconfigured` state
+5. guardrails so no secret leaks to the client and no cross-tenant mutation is possible
+
+The plan should preserve the locked wedge. This is not a broad admin console or
+dashboard. It is the minimum self-serve configuration plane needed for a tenant
+to move from install → configured → live snapshot.
+
+Secret-handling contract for Slice 4:
+
+- settings reads never return plaintext credentials
+- settings reads return secret presence only via booleans such as
+  `hasApiKey: true | false`
+- secret inputs are **replace-only**
+- when a user leaves a secret field blank on save, the existing encrypted value
+  is preserved
+- when a user enters a new value, it replaces the stored encrypted secret
+- if explicit secret deletion is needed, it must be a deliberate separate
+  action/flag and not an accidental side effect of an empty text field
+- no “reveal current key” UX is in scope for Slice 4
+
+## Objective
+
+When Slice 4 is complete, an installed tenant can open the app’s HubSpot
+Settings page, view its current configuration, update provider + LLM settings
+for its own workspace only, save encrypted credentials safely, and return to the
+company record card with the `unconfigured` state resolved.
+
+## Relevant Files
+
+### Existing files to modify
+
+- `apps/hubspot-project/src/app/app-hsmeta.json`
+  - add the HubSpot `settings` feature/config entry for the app settings page
+- `apps/hubspot-extension/src/index.tsx`
+  - may share extracted UI primitives/patterns with the settings extension
+- `apps/hubspot-extension/src/shared/extension-root.tsx`
+  - reference for shared extension composition patterns
+- `apps/hubspot-extension/package.json`
+  - may need scripts/build updates if settings bundling uses the same workspace
+- `apps/api/src/index.ts`
+  - mount tenant settings routes under the existing middleware chain
+- `apps/api/src/middleware/tenant.ts`
+  - reuse existing tenant resolution contract for settings APIs
+- `apps/api/src/lib/config-resolver.ts`
+  - keep read models aligned with new write/update paths; add targeted invalidation hooks if needed
+- `apps/api/src/lib/encryption.ts`
+  - reuse envelope encryption for settings writes; no new crypto scheme
+- `apps/api/src/routes/snapshot.ts`
+  - optionally surface a richer setup hint only if it stays wedge-safe
+- `apps/hubspot-extension/src/features/snapshot/components/empty-states.tsx`
+  - make `UnconfiguredState` actionable without expanding scope
+- `packages/db/src/schema/provider-config.ts`
+  - confirm shape is sufficient; only evolve if a concrete settings need is missing
+- `packages/db/src/schema/llm-config.ts`
+  - same as above
+- `packages/db/src/schema/tenants.ts`
+  - use `settings` only for truly tenant-level values, not provider rows
+- `packages/validators/src/snapshot.ts`
+  - may need config-related runtime schema additions if settings APIs share validated DTOs
+- `docs/security/SECURITY.md`
+  - add Slice 4 settings-specific secret-handling and authorization notes
+- `CLAUDE.md`
+  - update active doc references only if the slice introduces a new binding planning artifact
+
+### New files
+
+- `apps/hubspot-project/src/app/settings/settings-hsmeta.json`
+  - HubSpot settings extension metadata
+- `apps/hubspot-extension/src/settings/index.tsx`
+  - local-dev/test entrypoint for the settings extension
+- `apps/hubspot-extension/src/settings/settings-entry.tsx`
+  - dedicated entry for bundling/exporting the settings surface
+- `apps/hubspot-extension/src/settings/components/settings-root.tsx`
+  - top-level settings component
+- `apps/hubspot-extension/src/settings/components/provider-settings-form.tsx`
+  - signal-provider config form
+- `apps/hubspot-extension/src/settings/components/llm-settings-form.tsx`
+  - LLM config form
+- `apps/hubspot-extension/src/settings/components/eligibility-settings-form.tsx`
+  - target-account property / threshold settings
+- `apps/hubspot-extension/src/settings/hooks/use-tenant-settings.ts`
+  - fetch + save tenant settings
+- `apps/hubspot-extension/src/settings/hooks/use-settings-form.ts`
+  - local form state and save/reset handling
+- `apps/hubspot-extension/src/settings/*.test.tsx`
+  - HubSpot settings renderer tests
+- `apps/api/src/routes/settings.ts`
+  - `GET /api/settings` + `PUT /api/settings` (or split resource routes if cleaner)
+- `apps/api/src/routes/__tests__/settings.test.ts`
+  - integration coverage for auth, tenant isolation, validation, write behavior
+- `apps/api/src/lib/settings-service.ts`
+  - read/write orchestration over `provider_config`, `llm_config`, and tenant-level settings
+- `apps/api/src/lib/__tests__/settings-service.test.ts`
+  - domain/service tests for updates, encryption, partial writes, invalidation
+- `packages/validators/src/settings.ts`
+  - request/response schemas for tenant settings APIs
+- `packages/validators/src/__tests__/settings.test.ts`
+  - schema coverage
+- `scripts/bundle-hubspot-settings.ts`
+  - if settings extension needs the same explicit bundle/copy flow as the record-tab card
+- `docs/qa/slice-4-settings-walkthrough.md`
+  - installer/admin walkthrough from unconfigured → configured → working card
+
+## Step by Step Tasks
+
+### Phase 0: Preflight and scope lock
+
+1. **Task ID: preflight-settings-docs**
+   - Verify current HubSpot settings-extension docs on the latest platform and record the implementation decision in a new preflight note.
+   - Confirm whether the settings extension can live in the existing app/project structure without a separate project.
+   - Confirm the correct `app-hsmeta` / `settings-hsmeta` shape and local-dev workflow.
+   - Dependency: none
+
+2. **Task ID: settings-scope-contract**
+   - Lock the initial Slice 4 settings scope so we do not overbuild an admin surface.
+   - Recommended V1 scope:
+     - signal provider enablement (`exa`, `news`, `hubspot-enrichment`)
+     - provider API key input where applicable
+     - default LLM provider + model
+     - LLM API key input + optional endpoint URL for `custom`
+     - thresholds: `freshnessMaxDays`, `minConfidence`
+     - eligibility property override (`hs_is_target_account` by default)
+   - Explicitly defer:
+     - broad team/user management
+     - audit history UI
+     - secret reveal/download flows
+     - multi-workspace admin consoles
+   - Dependency: preflight-settings-docs
+
+### Phase 1: API and data contracts
+
+3. **Task ID: settings-api-shapes**
+   - Define request/response schemas in `packages/validators`.
+   - Keep secrets write-only at the API boundary:
+     - responses may include `hasApiKey: boolean`
+     - responses must not return plaintext decrypted keys
+     - blank secret fields in update payloads must mean “preserve existing key”
+       rather than “clear key”
+     - explicit key removal, if supported in Slice 4 at all, must use a separate
+       boolean/operation and never implicit empty-string semantics
+   - Decide the canonical payload shape for:
+     - provider settings
+     - LLM settings
+     - eligibility settings
+   - Dependency: settings-scope-contract
+
+4. **Task ID: settings-service**
+   - Implement `settings-service` as the single backend orchestration layer for:
+     - reading tenant settings from `provider_config`, `llm_config`, and `tenants.settings`
+     - upserting config rows
+     - encrypting keys before persistence
+     - invalidating config resolver cache after writes
+     - preserving existing encrypted secrets when the incoming secret field is
+       omitted or blank
+     - replacing encrypted secrets only when a new plaintext value is supplied
+   - Use the request-scoped DB handle created by Slice 3.
+   - All writes must stay inside tenant-scoped transaction boundaries.
+   - Dependency: settings-api-shapes
+
+5. **Task ID: settings-routes**
+   - Add tenant-scoped settings routes to the API.
+   - Recommended surface:
+     - `GET /api/settings`
+     - `PUT /api/settings`
+   - Validate payloads with `packages/validators`.
+   - Reject malformed provider/model combinations explicitly.
+   - Do not accept tenant identifiers from the client body; always derive from middleware context.
+   - Dependency: settings-service
+
+6. **Task ID: settings-route-tests**
+   - TDD-first route tests for:
+     - happy-path read
+     - happy-path write
+     - partial update
+     - secret write-only behavior
+      - blank secret field preserves existing encrypted value
+      - new secret rotates/replaces existing encrypted value
+      - explicit delete path, if supported, clears the secret only when the
+        dedicated delete operation is used
+      - tenant A cannot read/write tenant B config
+      - invalid payloads return 400
+      - missing tenant/auth returns 401/403 according to current middleware behavior
+   - Dependency: settings-routes
+
+### Phase 2: HubSpot settings extension UI
+
+7. **Task ID: hubspot-settings-scaffold**
+   - Add the HubSpot app settings feature to the project config.
+   - Create the settings extension metadata file and local UI-extension entrypoint(s).
+   - Align with the latest HubSpot settings-page guidance:
+     - avoid nested enclosed tabs
+     - prefer simple grouped panels/sections
+   - Dependency: preflight-settings-docs
+
+8. **Task ID: settings-fetch-hook**
+   - Implement a hook for loading and saving tenant settings through the new backend endpoints.
+   - Required states:
+     - loading
+     - loaded
+     - saving
+     - save success
+     - save error
+   - Do not cache secrets in a way that leaks them back into rendered UI after save.
+   - Dependency: settings-routes
+
+9. **Task ID: settings-forms-ui**
+   - Build the minimal settings UI sections:
+     - signal provider section
+     - LLM section
+     - eligibility/thresholds section
+   - Use HubSpot UI extension primitives and current repo UI patterns.
+   - Keep the interface intentionally narrow and admin-oriented, not decorative.
+   - Dependencies: hubspot-settings-scaffold, settings-fetch-hook
+
+10. **Task ID: settings-ui-tests**
+    - TDD for the settings UI:
+      - initial load
+      - empty/unconfigured state
+      - save flow
+      - field validation/rendering
+      - success/error messaging
+    - Use HubSpot UI extension testing helpers where applicable.
+    - Dependency: settings-forms-ui
+
+### Phase 3: Integrate with current product flow
+
+11. **Task ID: unconfigured-recovery-path**
+    - Improve the current `UnconfiguredState` so the user is guided toward setup without blowing out the wedge.
+    - Options to evaluate during implementation:
+      - concise copy referencing app settings
+      - a button/link if the SDK allows opening app settings from the card context
+      - fallback plain text instructions if direct navigation is not supported
+    - Must stay compliant with current HubSpot SDK capabilities.
+    - Dependency: settings-ui-tests
+
+12. **Task ID: config-save-invalidation**
+    - After settings writes, ensure the runtime stops serving stale config:
+      - invalidate resolver cache
+      - verify next snapshot request uses the new settings
+    - Add an integration test that proves unconfigured → configured → live route behavior.
+    - Dependencies: settings-service, unconfigured-recovery-path
+
+13. **Task ID: secret-hygiene-audit**
+    - Review the full settings flow for secret exposure risks:
+      - API responses
+      - logs
+      - test fixtures
+      - UI rendered state
+    - PASS/FAIL per area, similar to the Slice 3 security audit style.
+    - Dependency: config-save-invalidation
+
+### Phase 4: Validation, docs, and rollout prep
+
+14. **Task ID: docs-sweep-slice4**
+    - Add/update:
+      - settings setup walkthrough
+      - security notes for write-only secrets and tenant-scoped config mutation
+      - any HubSpot upload/bundling docs if the settings extension changes packaging flow
+    - Remove stale “not configured yet” assumptions from docs where Slice 4 supersedes them.
+    - Dependency: secret-hygiene-audit
+
+15. **Task ID: code-review-slice4**
+    - Independent code review pass focused on:
+      - tenant isolation
+      - secret handling
+      - SDK correctness for HubSpot settings
+      - regressions in snapshot flow
+    - Fix only real findings.
+    - Dependency: docs-sweep-slice4
+
+16. **Task ID: validate-all-slice4**
+    - Final validation commands:
+      - `pnpm install --frozen-lockfile`
+      - `pnpm lint`
+      - `pnpm test`
+      - `pnpm typecheck`
+      - `pnpm db:migrate`
+      - any settings bundling/upload validation command introduced by the slice
+    - Final acceptance verification:
+      - tenant can configure the app without direct DB edits
+      - configured tenant stops receiving `unconfigured`
+      - secrets are never returned in plaintext
+      - cross-tenant writes remain impossible
+    - Dependency: code-review-slice4
+
+## Acceptance Criteria
+
+- The HubSpot app includes a working `settings` extension on the latest supported platform shape.
+- An installed tenant can open app settings and read its current config without direct DB or script intervention.
+- A tenant can save provider and LLM configuration for its own workspace only.
+- Plaintext secrets are accepted only on write and are never returned by the settings API or rendered back in the UI after save.
+- Blank secret fields preserve existing encrypted values; they do not clear them accidentally.
+- Secret rotation works by submitting a new plaintext value, and any explicit deletion path is deliberate and separately tested.
+- Settings writes use the existing encryption envelope and tenant-scoped DB transaction/RLS path.
+- `config-resolver` cache invalidation occurs after writes, and a newly configured tenant can successfully move from `eligibilityState: "unconfigured"` to a live snapshot path.
+- Cross-tenant tests prove tenant A cannot read or mutate tenant B settings.
+- Validation passes:
+  - `pnpm lint`
+  - `pnpm test`
+  - `pnpm typecheck`
+  - `pnpm db:migrate`
+- Documentation is updated for:
+  - tenant/admin setup flow
+  - secret handling rules
+  - any new HubSpot project upload/bundle steps
+
+## Team Orchestration
+
+- This slice should be executed from a fresh worktree off `main` after the plan is approved.
+- Execution should remain TDD-first per repo rules: failing test, confirm failure, minimal implementation, focused rerun, broader verification.
+- Parallelization opportunities:
+  - backend contract/service work can begin in parallel with HubSpot settings-extension scaffold after preflight is done
+  - docs can start once route/UI shapes stabilize
+- Sequential dependencies:
+  - settings API shapes must be locked before frontend save/load hooks
+  - backend write path must exist before meaningful settings UI behavior testing
+  - unconfigured recovery UX should be finalized only after the settings extension contract is confirmed
+- Taskmaster should be updated before implementation begins so Slice 4 becomes the execution board rather than relying on the now-complete root task set.
+- Use Context7 / official HubSpot docs for any settings-extension API uncertainty before implementation.
+
+### Team Members
+
+- `general-purpose` — **lead-backend-settings**
+  - Owns API shape, settings service, route wiring, encryption integration, and cache invalidation.
+- `general-purpose` — **lead-frontend-settings**
+  - Owns HubSpot settings extension scaffold, settings UI, hooks, and unconfigured recovery UX.
+- `general-purpose` — **integration-hardening**
+  - Owns cross-surface integration tests, route/UI regression coverage, and final wiring verification.
+- `quality-engineer`
+  - Owns security-focused review, validation sweep, and acceptance-criteria signoff.

--- a/.claude/tasks/2026-04-17-slice-10-upload-profile-wiring.md
+++ b/.claude/tasks/2026-04-17-slice-10-upload-profile-wiring.md
@@ -1,0 +1,210 @@
+# Plan: Slice 10 — Wire profile-aware API origin into the real HubSpot upload flow
+
+## Task Description
+
+Today `scripts/hs-project-upload.ts --profile <name>` is the only path that actually ships the extension to HubSpot. That script calls `scripts/bundle-hubspot-card.ts`, which builds two separate bundles (`card` + `settings`) via a programmatic `vite.build({ configFile: false, ... })` call. Because `configFile: false` bypasses `apps/hubspot-extension/vite.config.ts`, the Slice 8 `define: { __HAP_API_ORIGIN__ }` block is never applied during real uploads. The Slice 9 `build:with-profile` wrapper is also not reached, because the upload script does not call it. The deployed extension therefore always resolves `API_ORIGIN` to the hardcoded `DEFAULT_API_BASE_URL` fallback, regardless of which `--profile` flag is passed.
+
+Slice 10 closes that gap. The upload wrapper must extract the selected profile's `API_ORIGIN` via the Slice 9 helpers and thread it into the programmatic bundler so both the card and settings bundles embed the correct origin at build time.
+
+## Objective
+
+Invoking the upload runner with `--profile staging` produces card and settings bundles in which `__HAP_API_ORIGIN__` is the staging origin declared in `hsprofile.staging.json`, deterministically and with no manual env export. In automated verification this uses the existing `UploadDeps` seam to stub the final `hs project upload` subprocess while still exercising the real bundler.
+
+## Problem Statement
+
+- Slice 8 proved `vite.config.ts` emits the correct `define`, but only when `vite build` uses that config file.
+- Slice 9 proved `build:with-profile` reads the profile and sets `API_ORIGIN`, but the real upload does not call it.
+- `scripts/bundle-hubspot-card.ts` uses `configFile: false` and its own inline Vite config; it does not emit `define` at all.
+- The `--profile` flag passed to the upload script today reaches only the HubSpot CLI, never the bundler.
+
+Net effect: production uploads silently ship with the wrong origin. There is no failing build, no warning, and no runtime signal until the extension calls an unreachable host.
+
+## Solution Approach
+
+Thread the profile's `API_ORIGIN` through the existing upload pipeline with minimum surface area:
+
+1. Extract the profile name from the `--profile` / `-p` argv in `hs-project-upload.ts` via a small pure helper, so parsing behavior is testable without duplicating the current inline validation logic.
+2. Reuse the Slice 9 helpers (`resolveProfilePath`, `loadProfile`, `extractApiOrigin`) to read `hsprofile.<name>.json` from `apps/hubspot-project/` and pull out `variables.API_ORIGIN`.
+3. Set `process.env.API_ORIGIN` before calling `runBundle(root)`. Restore the prior value in `finally` so the wrapper stays side-effect free.
+4. Refactor `scripts/bundle-hubspot-card.ts` to be import-safe for tests: export `bundleTargets` and a pure helper such as `buildViteOptions(target, apiOrigin)`, and guard the CLI entry with `if (import.meta.main)` instead of executing `main()` on import.
+5. Add a matching `define: { __HAP_API_ORIGIN__: JSON.stringify(process.env.API_ORIGIN ?? "") }` block to the programmatic `build()` options for each target. This keeps the `configFile: false` structure (needed for the two-bundle `lib` mode) but reproduces the define contract Slice 8 pinned.
+6. Surface a clear error if the profile is missing `API_ORIGIN` instead of falling through to the hardcoded default.
+
+This keeps `build:with-profile` as the single-bundle ergonomic wrapper and the upload path as the two-bundle production pipeline, but both now share the same profile-driven origin contract.
+
+## Relevant Files
+
+Use these files to complete the task:
+
+- [scripts/hs-project-upload.ts](scripts/hs-project-upload.ts) — where profile extraction + env handoff are added.
+- [scripts/bundle-hubspot-card.ts](scripts/bundle-hubspot-card.ts) — where `define` block for `__HAP_API_ORIGIN__` is added per target.
+- [scripts/**tests**/hs-project-upload.test.ts](scripts/__tests__/hs-project-upload.test.ts) — existing DI-style tests; new cases added here.
+- [apps/hubspot-extension/scripts/build-with-profile.ts](apps/hubspot-extension/scripts/build-with-profile.ts) — exports `resolveProfilePath`, `loadProfile`, `extractApiOrigin` to reuse. Slice 9 code.
+- [apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts](apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts) — consumer of `__HAP_API_ORIGIN__`, unchanged but referenced in acceptance criteria.
+- [apps/hubspot-project/hsprofile.staging.example.json](apps/hubspot-project/hsprofile.staging.example.json) — profile shape.
+- [apps/hubspot-project/UPLOAD.md](apps/hubspot-project/UPLOAD.md) — update the Slice 5 production contract section.
+
+### New Files
+
+- [scripts/**tests**/bundle-hubspot-card.test.ts](scripts/__tests__/bundle-hubspot-card.test.ts) — pins the `define` contract on the programmatic bundler (JSON-encoded, empty-sentinel-when-unset, verbatim trailing slashes).
+
+### Expected Touch Set
+
+Keep Slice 10 narrow. Expected production-code changes should stay within:
+
+- `scripts/hs-project-upload.ts`
+- `scripts/bundle-hubspot-card.ts`
+- `apps/hubspot-project/UPLOAD.md`
+
+Expected test changes:
+
+- `scripts/__tests__/hs-project-upload.test.ts`
+- `scripts/__tests__/bundle-hubspot-card.test.ts`
+- an existing bundle-origin e2e test file, or one new e2e test file if extending is awkward
+
+## Team Orchestration
+
+### Team Members
+
+- Specialist
+  - Name: builder-upload-wiring
+  - Role: Implement profile extraction in `hs-project-upload.ts`, add `define` block to `bundle-hubspot-card.ts`, add tests. TDD red-green-refactor.
+  - Agent Type: backend-engineer
+  - Resume: true
+- Quality Engineer (Validator)
+  - Name: validator
+  - Role: Validate completed work against acceptance criteria (read-only inspection mode).
+  - Agent Type: quality-engineer
+  - Resume: false
+
+## Step by Step Tasks
+
+### 1. Write failing tests for profile-aware upload wrapper
+
+- **Task ID**: test-upload-profile-handoff
+- **Depends On**: none
+- **Assigned To**: builder-upload-wiring
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Extend `scripts/__tests__/hs-project-upload.test.ts` with cases asserting:
+  - profile name extracted from `--profile staging`, `--profile=staging`, `-p staging`, and `-p=staging` forms
+  - `process.env.API_ORIGIN` is set to the profile's `variables.API_ORIGIN` at the moment `runBundle` is called
+  - `process.env.API_ORIGIN` is restored to its prior value after the runner returns (success path)
+  - `process.env.API_ORIGIN` is restored even when `runUpload` throws
+  - a profile file missing `API_ORIGIN` surfaces `MissingApiOriginError` before any bundling or upload happens
+- Watch each test fail for the expected reason. Do NOT write production code yet.
+
+### 2. Write failing test for define contract in programmatic bundler
+
+- **Task ID**: test-bundle-define-contract
+- **Depends On**: none
+- **Assigned To**: builder-upload-wiring
+- **Agent Type**: backend-engineer
+- **Parallel**: true (with Task 1)
+- Create `scripts/__tests__/bundle-hubspot-card.test.ts`.
+- Refactor `bundle-hubspot-card.ts` so importing it in tests does not start a build: export the target list and a `buildViteOptions(target, apiOrigin)` pure helper, and move CLI execution behind `if (import.meta.main)`.
+- Parse the `define` block emitted by `bundle-hubspot-card.ts` by importing that pure helper rather than invoking the real build.
+- Assert: `JSON.stringify(apiOrigin)` encoding, empty-string sentinel when env unset, trailing slash preservation.
+
+### 3. Implement profile extraction + env handoff in `hs-project-upload.ts`
+
+- **Task ID**: impl-upload-profile-handoff
+- **Depends On**: test-upload-profile-handoff
+- **Assigned To**: builder-upload-wiring
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Add argv parser that returns the profile name (reuse the check already inlined in `buildUploadRunner`).
+- Import `resolveProfilePath`, `loadProfile`, `extractApiOrigin` from Slice 9's helper module via a **relative path** (e.g., `../apps/hubspot-extension/scripts/build-with-profile`). The root `tsconfig.json` does not define an `@hap/hubspot-extension/*` alias, so no path-alias import is available. If a shared helper is later extracted into a workspace package, migrate the import then — not as part of Slice 10.
+- Before `deps.runBundle(root)`: read profile from `apps/hubspot-project/`, extract `API_ORIGIN`, set `process.env.API_ORIGIN`.
+- Wrap the runner body in `try/finally` that restores the prior `API_ORIGIN`.
+- Surface `MissingApiOriginError` as a fatal runner error (non-zero exit, clear message).
+
+### 4. Implement define block in `bundle-hubspot-card.ts`
+
+- **Task ID**: impl-bundle-define
+- **Depends On**: test-bundle-define-contract
+- **Assigned To**: builder-upload-wiring
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Add `define: { __HAP_API_ORIGIN__: JSON.stringify(process.env.API_ORIGIN ?? "") }` to the programmatic `build()` call for each target.
+- Ensure the module remains import-safe after the refactor: production CLI behavior stays the same when executed directly, but tests can import helpers without side effects.
+- Compute the value once at module scope (or inside `buildTarget`), matching the pattern Slice 8 pinned for `vite.config.ts`.
+- Keep `configFile: false` — the two-bundle `lib` structure is not changing.
+
+### 5. Update UPLOAD.md production contract
+
+- **Task ID**: doc-upload-contract
+- **Depends On**: impl-upload-profile-handoff, impl-bundle-define
+- **Assigned To**: builder-upload-wiring
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Add a sentence to the `Current Slice 5 production contract` section stating that the upload wrapper now threads `API_ORIGIN` from the selected profile into the programmatic bundler. Reference Slice 10.
+- Note the separation: `build:with-profile` = single-bundle dev ergonomic; `hs-project-upload.ts` = production two-bundle path; both now profile-aware.
+
+### 6. End-to-end verification against real bundler
+
+- **Task ID**: e2e-upload-define
+- **Depends On**: impl-bundle-define, impl-upload-profile-handoff
+- **Assigned To**: builder-upload-wiring
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- Add an e2e test (or extend the existing `built-bundle-origin.test.ts` pattern) that writes a temp profile, invokes the upload wrapper with `runUpload` stubbed to exit 0, and asserts that the emitted `card/index.js` and `settings/index.js` contain the profile's origin string.
+- Stub `makeTempDir` / `runUpload` but run `runBundle` for real so the Vite pipeline is actually exercised.
+
+### 7. Final validation
+
+- **Task ID**: validate-all
+- **Depends On**: test-upload-profile-handoff, test-bundle-define-contract, impl-upload-profile-handoff, impl-bundle-define, doc-upload-contract, e2e-upload-define
+- **Assigned To**: validator
+- **Agent Type**: quality-engineer
+- **Parallel**: false
+- Run all validation commands below.
+- Verify acceptance criteria are met.
+- Inspect and report only; do not modify files.
+
+## Acceptance Criteria
+
+- Invoking the upload wrapper with a stubbed `runUpload` (exit 0, no real `hs project upload` call) produces `apps/hubspot-project/src/app/cards/dist/index.js` and `apps/hubspot-project/src/app/settings/dist/index.js` in which the staging `API_ORIGIN` string appears verbatim. No new CLI flag is introduced — stubbing happens in the test harness via the existing `UploadDeps` injection seam.
+- A profile file with no `API_ORIGIN` causes the upload wrapper to exit non-zero before any bundling or `hs project upload` subprocess runs.
+- `process.env.API_ORIGIN` is not leaked after the runner returns or throws.
+- Importing `scripts/bundle-hubspot-card.ts` in tests does not start a real build as a side effect; its CLI behavior only runs when invoked as the entrypoint.
+- No changes to `apps/hubspot-extension/vite.config.ts`, `build-with-profile.ts`, or `api-fetcher.ts` — Slice 10 only touches the programmatic bundler + upload wrapper.
+- All prior Slice 7/8/9 tests still pass.
+- `UPLOAD.md` reflects the new contract.
+
+## Validation Commands
+
+- `pnpm test scripts/__tests__/hs-project-upload.test.ts` — new upload wrapper tests pass.
+- `pnpm test scripts/__tests__/bundle-hubspot-card.test.ts` — new define-contract tests pass.
+- `pnpm test` — full repo test suite, no regressions.
+- `pnpm typecheck` — no TS errors.
+- `pnpm lint` — repo lint stays clean.
+- Manual end-to-end (after PRs #8, #9, #10 merged): copy `hsprofile.staging.example.json` → `hsprofile.staging.json`, set a sentinel `API_ORIGIN`, then run a tiny `tsx` harness that imports `buildUploadRunner`, stubs `runUpload` to return `0`, and greps the built card and settings bundles for the sentinel.
+
+## Notes
+
+### Branch timing recommendation
+
+**Wait for PR #9 and PR #8 to merge before branching Slice 10.**
+
+Open-PR reality (as of this plan):
+
+- **PR #9** — base `main`, head `feature/slice-8-extension-api-origin-profile` (Slice 8: extension resolver + Vite `define`).
+- **PR #8** — base `feature/slice-8-extension-api-origin-profile`, head `feature/slice-9-hubspot-build-wrapper` (Slice 9: `build:with-profile` wrapper). Stacked on #9.
+- **PR #10** — base `main`, head `feature/slice-7-lifecycle-webhook-receiver` (Slice 7 lifecycle webhook). Independent — only touches `apps/api/*`.
+
+Reasoning for the wait:
+
+- Slice 10 imports `resolveProfilePath`, `loadProfile`, `extractApiOrigin` from Slice 9's `build-with-profile.ts`. If Slice 10 branches off `main` before #8 merges, those exports don't exist on the base branch and the Slice 10 branch would need to stack on `feature/slice-9-hubspot-build-wrapper` to compile — adding a third layer to the existing stacked pair.
+- Slice 10 also adds a `define` block that mirrors the contract Slice 8 pinned in `vite.config.ts`. Keeping both changes on a single base branch simplifies review and keeps the "profile-aware origin" story linear.
+
+Recommended order: merge **#9 first** (brings Slice 8 to `main`), which auto-retargets **#8** onto `main`; merge **#8** next (brings Slice 9 to `main`); then branch Slice 10 from fresh `main`. **#10** can merge in any order — its file surface does not overlap.
+
+If speed matters more than stack depth, Slice 10 could branch off `feature/slice-9-hubspot-build-wrapper` now. But the cost (third stacked PR, auto-retarget churn on every base merge) outweighs the benefit unless there is a real delivery deadline.
+
+### Out of scope for Slice 10
+
+- Subscribing the app to HubSpot's lifecycle webhook (`POST /webhooks/v4/subscriptions`). Queued separately.
+- Root `/` → `/oauth/install` redirect. Queued separately.
+- Cleaning up stale `SLICE2_TRANSPORT_NOT_WIRED` / `v1UnwiredFetcher` code in `use-snapshot.ts`. Queued separately.
+- Retiring the `scripts/hs-project-upload.ts` temp-dir indirection (still required until `@hubspot/cli` handles worktrees).

--- a/.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md
+++ b/.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md
@@ -1,0 +1,246 @@
+# Plan: Slice 5 - Production and Marketplace Readiness
+
+## Task Description
+
+Slices 1 through 4 now cover the core product wedge:
+
+- HubSpot company-record card
+- real provider and LLM integrations
+- OAuth install flow
+- tenant-scoped RLS and replay protection
+- HubSpot settings UI for per-tenant configuration
+
+The next gap is not another feature surface. It is the path from a working local
+and staging-oriented app to a production-installable product that can survive a
+real pilot and prepare for HubSpot marketplace submission.
+
+Today the biggest remaining readiness gaps are operational and configuration
+oriented:
+
+- `apps/hubspot-project/src/app/app-hsmeta.json` still points OAuth callbacks at
+  `http://localhost:3000/oauth/callback`
+- production/staging origin handling is not yet locked as a first-class deploy contract
+- two-portal install validation is not yet represented as a clean, repeatable slice
+- installer-facing success/error/onboarding flow needs to be tightened for real usage
+- doc-stack drift means some older planning references are no longer the best active source
+
+Slice 5 should deliberately avoid broadening the wedge. This is not a dashboard
+slice, not a reporting slice, and not a new research feature. It is the minimum
+production-readiness and marketplace-pilot slice needed to make the shipped app
+operationally credible outside local development.
+
+## Objective
+
+When Slice 5 is complete, the app can be deployed against real staging/production
+origins, installed into more than one portal through the supported OAuth flow,
+guided through a clean post-install setup experience, and documented well enough
+for a controlled pilot and marketplace-preparation workflow.
+
+## Relevant Files
+
+### Existing files to modify
+
+- `apps/hubspot-project/src/app/app-hsmeta.json`
+  - replace localhost-only callback assumptions with profile-driven staging/production-ready config
+- `apps/api/src/routes/oauth.ts`
+  - verify redirect and callback behavior against non-local origins
+- `apps/api/src/lib/hubspot-client.ts`
+  - confirm production-safe assumptions for OAuth token use and refresh
+- `apps/api/src/routes/settings.ts`
+  - confirm post-install and first-run configuration flow works cleanly after OAuth install
+- `apps/hubspot-extension/src/features/snapshot/components/empty-states.tsx`
+  - tighten unconfigured/install guidance if the current text is not enough for pilot users
+- `apps/hubspot-extension/src/settings/settings-page.tsx`
+  - ensure onboarding-to-configured flow is clear for real installs
+- `scripts/hs-project-upload.ts`
+  - production/staging-safe packaging and upload path
+- `docs/security/SECURITY.md`
+  - add production-readiness and install-flow notes where needed
+- `README.md`
+  - update setup/deploy instructions if local-only assumptions remain
+- `PLANNING_INDEX.md`
+  - clean stale path expectations if Slice 5 introduces a better active-doc contract
+
+### New files
+
+- `docs/slice-5-preflight-notes.md`
+  - production + marketplace readiness contract and verified external assumptions
+- `docs/qa/slice-5-pilot-walkthrough.md`
+  - step-by-step pilot validation across install → configure → company-record usage
+- `docs/runbooks/production-deploy.md`
+  - deployment/runbook checklist if a dedicated runbook does not already exist
+- `apps/api/src/routes/__tests__/oauth-production.test.ts`
+  - focused coverage for non-local origin/callback assumptions
+- `apps/hubspot-extension/src/settings/__tests__/first-run-onboarding.test.tsx`
+  - optional if first-run UX needs explicit regression protection
+
+## Step by Step Tasks
+
+### Phase 0: Preflight and scope lock
+
+1. **Task ID: production-preflight**
+   - Verify current HubSpot docs for:
+     - marketplace/public app OAuth expectations
+     - redirect URL requirements
+     - permitted URL / app config requirements for production
+   - Verify current deployment assumptions for the API origin and callback flow.
+   - Record all verified decisions in `docs/slice-5-preflight-notes.md`.
+   - Dependency: none
+
+2. **Task ID: slice5-scope-contract**
+   - Lock Slice 5 to:
+     - production/staging origin readiness
+     - OAuth callback and app-config cleanup
+     - install/onboarding hardening
+     - two-portal pilot validation
+     - deployment and rollout docs
+   - Explicitly defer:
+     - marketplace listing copy/assets submission
+     - billing
+     - advanced admin analytics
+     - transcript or broader workspace features
+   - Dependency: production-preflight
+
+### Phase 1: App config and environment contract
+
+3. **Task ID: app-config-profiles**
+   - Replace localhost-only assumptions in `app-hsmeta.json` with a config-profile pattern that supports:
+     - local
+     - staging
+     - production
+   - Confirm redirect URLs, permitted fetch URLs, and distribution/auth shape are environment-safe.
+   - Dependency: slice5-scope-contract
+
+4. **Task ID: oauth-origin-hardening**
+   - Verify the OAuth install/callback route behavior under non-local origins.
+   - Tighten validation around:
+     - callback URL generation
+     - post-install redirect targets
+     - error handling for missing/misconfigured production origins
+   - Add focused tests for staging/production-style configuration.
+   - Dependency: app-config-profiles
+
+5. **Task ID: deploy-env-contract**
+   - Lock the required environment variables and origin semantics for:
+     - API base URL
+     - OAuth callback URL
+     - HubSpot app upload profile
+   - Update env docs and any validators as needed.
+   - Dependency: oauth-origin-hardening
+
+### Phase 2: Installer and first-run experience
+
+6. **Task ID: install-success-error-ux**
+   - Review the installer journey:
+     - OAuth install success
+     - OAuth install failure
+     - tenant created but still unconfigured
+   - Tighten copy and UX so the next action is clear.
+   - Dependency: oauth-origin-hardening
+
+7. **Task ID: first-run-settings-guidance**
+   - Make the first-run path cohesive from install → settings → working card.
+   - Ensure the company-record `unconfigured` guidance matches the actual supported setup path.
+   - Add regression coverage if the UX changes materially.
+   - Dependency: install-success-error-ux
+
+### Phase 3: Pilot validation and operational readiness
+
+8. **Task ID: two-portal-pilot-validation**
+   - Build a repeatable validation flow for at least two portals:
+     - install
+     - configure
+     - load company-record card
+     - verify tenant isolation and correct config usage
+   - Prefer scripted or checklist-backed verification over one-off manual memory.
+   - Dependency: first-run-settings-guidance
+
+9. **Task ID: upload-deploy-runbook**
+   - Document the production/staging deployment and HubSpot upload path:
+     - build/bundle
+     - upload
+     - deploy
+     - env setup
+     - rollback notes if needed
+   - Dependency: deploy-env-contract
+
+10. **Task ID: doc-stack-cleanup**
+    - Clean stale or misleading planning/doc references that would confuse a future implementation pass.
+    - At minimum, reconcile:
+      - `PLANNING_INDEX.md`
+      - `README.md`
+      - any local mirrors that still imply local-only or pre-Slice-5 assumptions
+    - Dependency: upload-deploy-runbook
+
+### Phase 4: Validation and merge prep
+
+11. **Task ID: security-audit-slice5**
+    - Audit the production/pilot path for:
+      - bad redirect handling
+      - origin misconfiguration
+      - secret leakage in onboarding/deploy docs
+      - multi-portal install correctness
+    - PASS/FAIL per area.
+    - Dependency: two-portal-pilot-validation
+
+12. **Task ID: code-review-slice5**
+    - Review the slice with focus on:
+      - environment drift bugs
+      - install flow regressions
+      - documentation correctness
+      - deploy/runbook accuracy
+    - Fix only real findings.
+    - Dependency: security-audit-slice5
+
+13. **Task ID: validate-all-slice5**
+    - Run final validation:
+      - `pnpm install --frozen-lockfile`
+      - `pnpm lint`
+      - `pnpm test`
+      - `pnpm typecheck`
+      - `pnpm db:migrate`
+      - upload/bundle validation commands relevant to this slice
+    - Final acceptance:
+      - no localhost-only production assumptions remain in the shipped app config
+      - pilot install flow is documented and repeatable
+      - docs point to the correct active sources
+    - Dependency: code-review-slice5
+
+## Acceptance Criteria
+
+- The app config no longer assumes `http://localhost:3000/oauth/callback` as the only meaningful OAuth callback path.
+- Environment/profile handling is clear for local, staging, and production.
+- OAuth install/callback behavior is verified for non-local deployment assumptions.
+- A two-portal pilot walkthrough exists and is specific enough to repeat reliably.
+- The first-run path from install → configure → working company-record card is coherent and documented.
+- Deployment/upload steps are documented clearly enough for a real pilot.
+- Documentation no longer points contributors at obviously stale planning paths for active implementation work.
+- Final validation passes:
+  - `pnpm lint`
+  - `pnpm test`
+  - `pnpm typecheck`
+  - `pnpm db:migrate`
+
+## Team Orchestration
+
+- Planning can be done on `main` with no new worktree.
+- Implementation should use a fresh Slice 5 branch/worktree off `main` once this plan is approved.
+- TDD stays mandatory for any code changes.
+- Parallelization opportunities:
+  - app-config/env contract work can proceed alongside deploy/runbook drafting after preflight
+  - onboarding UX polish can proceed alongside pilot walkthrough drafting once the install contract is stable
+- Sequential dependencies:
+  - preflight must happen before app config hardening
+  - app config/origin contract must be stable before pilot validation
+  - docs cleanup should happen after the real production contract is settled
+
+### Team Members
+
+- `general-purpose` — **production-contract**
+  - owns app config, env contract, OAuth origin hardening
+- `general-purpose` — **installer-experience**
+  - owns install/onboarding/first-run UX polish
+- `general-purpose` — **pilot-ops**
+  - owns two-portal walkthrough, upload/deploy runbook, and rollout documentation
+- `quality-engineer`
+  - owns security audit, final validation, and acceptance signoff

--- a/.claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md
+++ b/.claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md
@@ -1,0 +1,236 @@
+# Slice 7 Plan: HubSpot Lifecycle Journal Ingestion
+
+## Task Description
+
+Implement the primary HubSpot install-lifecycle signal path that Slice 6
+documented but intentionally did not automate yet.
+
+Today the system correctly handles lifecycle fallback at runtime:
+
+- revoked refresh tokens soft-deactivate tenants
+- inactive tenants are blocked at middleware
+- reinstall reactivates the same tenant identity
+
+What is still missing is the primary automation path for HubSpot lifecycle
+events themselves. Slice 7 should add the real lifecycle-ingestion/control-plane
+path so uninstall/install state does not depend mainly on refresh-token failure.
+
+This slice should stay narrow:
+
+- yes: lifecycle journal ingestion, cursoring, event application, operational
+  sync path, verified uninstall/install automation
+- no: billing, analytics, broad background-job platform, marketplace asset
+  submission, hard-delete data workflows
+
+## Objective
+
+When Slice 7 is complete, the system should be able to:
+
+1. authenticate to the HubSpot lifecycle-management surface using the verified
+   app-level auth model
+2. ingest lifecycle events from the documented HubSpot journal path
+3. apply `app_install` / `app_uninstall` events idempotently to the existing
+   tenant lifecycle service
+4. checkpoint progress so repeated syncs are safe and resumable
+5. keep Slice 6 fallback behavior as the safety net, not the primary mechanism
+
+## Relevant Files
+
+- `apps/api/src/lib/tenant-lifecycle.ts`
+- `apps/api/src/lib/hubspot-client.ts`
+- `apps/api/src/index.ts`
+- `apps/api/src/routes/oauth.ts`
+- `apps/api/src/middleware/tenant.ts`
+- `apps/api/src/routes/snapshot.ts`
+- `packages/db/src/schema/tenants.ts`
+- `packages/db/drizzle/`
+- `docs/slice-6-preflight-notes.md`
+- `docs/security/slice-6-audit.md`
+- `docs/runbooks/tenant-offboarding.md`
+- `docs/security/SECURITY.md`
+- `README.md`
+
+Likely new files:
+
+- `apps/api/src/lib/hubspot-app-auth.ts`
+- `apps/api/src/lib/hubspot-lifecycle-journal.ts`
+- `apps/api/src/lib/lifecycle-sync.ts`
+- `apps/api/src/routes/lifecycle.ts`
+- `apps/api/src/lib/__tests__/hubspot-lifecycle-journal.test.ts`
+- `apps/api/src/lib/__tests__/lifecycle-sync.test.ts`
+- `apps/api/src/routes/__tests__/lifecycle.test.ts`
+- `docs/slice-7-preflight-notes.md`
+- `docs/security/slice-7-audit.md`
+- `docs/runbooks/lifecycle-sync.md`
+
+Possible schema additions:
+
+- a checkpoint/cursor table for journal consumption
+- an idempotency/audit table for applied lifecycle events if the docs confirm
+  this is needed
+
+## Step by Step Tasks
+
+1. `slice7-preflight`
+   - Re-verify the current HubSpot docs for:
+     - Webhooks Journal API auth model
+     - event paging/checkpoint semantics
+     - `APP_LIFECYCLE_EVENT` payload shape
+     - install/uninstall event identifiers
+     - whether polling, callback delivery, or hybrid is the intended pattern
+   - Confirm whether `DELETE /appinstalls/v3/external-install` belongs in scope
+     for this slice or remains an ops-only capability.
+   - Output: `docs/slice-7-preflight-notes.md`
+
+2. `slice7-scope-contract`
+   - Lock the ingestion model explicitly:
+     - journal polling only
+     - callback + journal reconciliation
+     - hybrid
+   - Lock cursor semantics:
+     - global cursor vs per-subscription cursor
+     - replay/idempotency policy
+     - operator recovery path when a sync partially fails
+   - Lock what happens on unknown lifecycle event types:
+     - ignore and log
+     - store and surface as audit noise
+
+3. `lifecycle-sync-schema`
+   - Add the minimum schema needed for primary lifecycle automation.
+   - Likely needs:
+     - lifecycle journal cursor/checkpoint state
+     - possibly applied-event dedupe/audit storage
+   - Keep tenant identity keyed to `tenants.hubspot_portal_id`.
+   - Do not duplicate tenant lifecycle state outside `tenants`.
+
+4. `hubspot-app-auth-client`
+   - Implement the verified app-level auth/token acquisition flow for lifecycle
+     journal access.
+   - Keep it separate from tenant-scoped OAuth.
+   - Add strict tests for:
+     - missing env/config
+     - token fetch failures
+     - token caching/refresh if needed
+
+5. `journal-adapter`
+   - Implement a HubSpot lifecycle journal adapter:
+     - fetch page(s) from the journal
+     - decode lifecycle events into a local normalized shape
+     - carry through portal id, event type, event timestamp, and any cursor
+       token needed for the next page
+   - This stays behind an adapter boundary, not inline in routes.
+
+6. `lifecycle-processor`
+   - Implement a processor that:
+     - takes normalized events
+     - resolves tenant by `hubspot_portal_id`
+     - calls `applyHubSpotLifecycleEvent(...)`
+     - records cursor/idempotency state
+   - Unknown portals must remain a safe no-op with telemetry.
+   - Repeated events must be idempotent.
+
+7. `sync-entrypoint`
+   - Add the narrowest operational entrypoint for running lifecycle sync:
+     - cron-safe route
+     - internal admin route
+     - script entrypoint
+   - Preflight should decide which is safest for the current deployment model.
+   - Protect it appropriately:
+     - no public anonymous trigger
+     - explicit auth or internal-only execution path
+
+8. `uninstall-control-plane`
+   - If Slice 7 preflight confirms it is appropriate, add a thin wrapper around
+     HubSpot’s uninstall API for controlled/manual uninstall operations.
+   - Keep this clearly separated from tenant-scoped runtime APIs.
+   - If docs or product intent say “ops only,” document it and leave code out.
+
+9. `observability-and-recovery`
+   - Add stable logs and metrics-like breadcrumbs for:
+     - sync start/end
+     - cursor advance
+     - event application counts
+     - unknown portal ids
+     - partial failure / replay / retry conditions
+   - Add a recovery runbook:
+     - rerun sync safely
+     - inspect cursor state
+     - reconcile a portal manually if needed
+
+10. `docs-and-security`
+    - Update:
+      - `docs/security/SECURITY.md`
+      - `README.md`
+      - lifecycle runbooks
+      - `PLANNING_INDEX.md` if this slice becomes active execution
+    - Add:
+      - `docs/security/slice-7-audit.md`
+      - `docs/runbooks/lifecycle-sync.md`
+
+11. `security-audit`
+    - Audit for:
+      - accidental public exposure of sync/uninstall controls
+      - cross-tenant lifecycle application
+      - replay/idempotency gaps in journal processing
+      - cursor corruption / double-apply behavior
+      - silent install-state drift
+
+12. `code-review`
+    - Push branch
+    - run bot review + independent review
+    - fix only real findings
+
+13. `validate-all`
+    - Run full validation:
+      - `pnpm install --frozen-lockfile`
+      - `pnpm lint`
+      - `pnpm test`
+      - `pnpm typecheck`
+      - `pnpm db:migrate`
+
+## Acceptance Criteria
+
+- The primary lifecycle path is no longer only documented; it is implemented.
+- HubSpot lifecycle journal ingestion can be run safely and repeatedly.
+- `app_uninstall` deactivates the correct tenant idempotently.
+- `app_install` reactivates the correct tenant idempotently.
+- Unknown portals do not cause cross-tenant mutation.
+- Cursor/checkpoint state prevents accidental double-application during normal
+  reruns.
+- Slice 6 fallback behavior still works if journal ingestion is delayed or
+  temporarily unavailable.
+- The sync/uninstall control plane is not publicly exposed.
+- Runbook + security docs explain both the automated path and the manual
+  recovery path.
+
+## Team Orchestration
+
+### Team Members
+
+- **Track A — Lifecycle Core**
+  - owns schema changes, journal cursor model, event processor, idempotency
+  - must keep tenant identity centered on `hubspot_portal_id`
+
+- **Track B — HubSpot App Integration**
+  - owns app-level auth, journal adapter, optional uninstall control-plane path
+  - must verify docs before implementation and keep tenant OAuth separate from
+    app-level auth
+
+- **Track C — Operations + Verification**
+  - owns runbooks, security audit, observability, and end-to-end sync tests
+  - ensures the slice is operationally understandable, not just code-complete
+
+Suggested execution order:
+
+1. Preflight + scope contract
+2. Schema + auth client
+3. Journal adapter + processor
+4. Sync entrypoint
+5. Docs/security/review/validation
+
+Parallelism notes:
+
+- Track A and Track B can move in parallel after preflight locks the auth and
+  ingestion model.
+- Track C should start once the processor contract is stable, not at the very
+  end.

--- a/.claude/tasks/2026-04-18-planning-docs-reconcile.md
+++ b/.claude/tasks/2026-04-18-planning-docs-reconcile.md
@@ -1,0 +1,237 @@
+# Plan: Planning-Docs Reconciliation (tracked task docs vs references)
+
+## Task Description
+
+`PLANNING_INDEX.md`, `AGENTS.md`, and newer tracking metadata in active local
+branches all cite slice task docs under `.claude/tasks/` as canonical
+execution artifacts. Only
+ONE of those docs (`2026-04-17-slice-6-install-lifecycle-offboarding.md`) is
+actually tracked in git. The rest live in developers' local working trees and
+never made it onto `origin/main`. This is because `.gitignore:83` has
+`.claude/*` with no exception for `tasks/`, so every task doc must be
+force-added to land in the repo. Slice-6 was force-added once; no other slice
+followed that precedent.
+
+PR #12 (`chore/post-slice-10-tracking`, metadata-only) extended the same
+pattern by adding slice-7 and slice-10 references to `PLANNING_INDEX.md`
+without committing the underlying files. Reviewer flagged the drift as
+pre-existing, and the user deferred the full reconciliation to this branch.
+
+This task reconciles the references and the tracked files so `origin/main`
+tells the truth about what exists today, and so PR #12's already-open metadata
+additions become truthful automatically when that PR lands. It also makes the
+invariant durable by adding a `.gitignore` exception so future task docs land
+without `-f`.
+
+## Objective
+
+When this plan is complete:
+
+1. Every `.claude/tasks/*.md` path referenced by any tracked planning artifact
+   on `origin/main` resolves to a tracked file in the same tree.
+2. `.gitignore` contains an explicit `!.claude/tasks/` exception so new slice
+   task docs land via normal `git add` without force.
+3. Slice-7 and Slice-10 task docs are also tracked in this branch so PR #12's
+   already-open metadata additions become truthful without amending PR #12.
+4. The reconciliation branch contains no product code changes, no runtime
+   changes, and no edits to existing PRs in the stack.
+
+## Problem Statement
+
+Repo-truth vs reference-truth is out of sync:
+
+| File                                                     | On disk (dirty main) | Tracked on `origin/main` | Referenced by now vs next                                                                  |
+| -------------------------------------------------------- | :------------------: | :----------------------: | ------------------------------------------------------------------------------------------ |
+| `2026-04-16-slice-3-phase-3-rls-card-bundling.md`        |         yes          |            no            | `PLANNING_INDEX.md` §2, `AGENTS.md:20` on `origin/main`                                    |
+| `2026-04-16-slice-4-settings-configuration.md`           |         yes          |            no            | `PLANNING_INDEX.md` §2 on `origin/main`; newer Taskmaster metadata in local/PR branches    |
+| `2026-04-17-slice-5-production-marketplace-readiness.md` |         yes          |            no            | `PLANNING_INDEX.md` §2 on `origin/main`                                                    |
+| `2026-04-17-slice-6-install-lifecycle-offboarding.md`    |         yes          |         **yes**          | `PLANNING_INDEX.md` §2 on `origin/main`; newer Taskmaster metadata in local/PR branches    |
+| `2026-04-17-slice-7-lifecycle-journal-ingestion.md`      |         yes          |            no            | not referenced on `origin/main` today; referenced by already-open PR #12 metadata updates  |
+| `2026-04-17-slice-10-upload-profile-wiring.md`           |         yes          |            no            | not referenced on `origin/main` today; referenced by already-open PR #12 metadata updates  |
+
+Root cause: `.gitignore:83` line `.claude/*` with only three un-ignores
+(`settings.json`, `scripts/`, `skills/`). `tasks/` is not un-ignored. Slice-6
+was landed with `git add -f`; no other slice was.
+
+Downstream consequences if unfixed:
+
+- Anyone cloning `origin/main` fresh cannot open five of the six slice plans
+  cited by their own `PLANNING_INDEX.md`.
+- `.taskmaster/tasks/tasks.json` task 18 (slice-4) and task 21 (slice-7)
+  cite `details` files that don't exist in the clone.
+- `AGENTS.md:20` instructs readers to read `slice-3-phase-3-rls-card-bundling.md`
+  first. Fresh clones cannot.
+
+## Solution Approach
+
+**Hybrid: commit the missing task docs + codify the invariant.**
+
+Rationale for rejecting the alternatives:
+
+- **Trim references to slice-6 only** — would force rewriting `AGENTS.md:20`
+  and demoting `tasks.json` task details from canonical pointers to inline
+  prose. Discards execution history and lies about what the team produced.
+- **Commit missing docs with no gitignore change** — fixes this round but
+  leaves the same trap for slice-11+. The next slice author hits the silent
+  `.gitignore` block and either doesn't notice (docs-drift reappears) or
+  force-adds ad-hoc (unprincipled precedent).
+
+The chosen hybrid:
+
+1. Add `!.claude/tasks/` (and `!.claude/tasks/**`) exceptions under the
+   existing `.claude/*` block so `git add .claude/tasks/foo.md` works.
+2. Commit the three docs required to make current `origin/main` references
+   truthful immediately: slices 3, 4, and 5.
+3. Commit the two additional docs required to make PR #12's already-open
+   metadata additions truthful as soon as that PR lands: slices 7 and 10.
+4. Leave `PLANNING_INDEX.md`, `AGENTS.md`, and `tasks.json` content
+   **unchanged**. Their references become truthful automatically once the
+   files exist.
+
+## Relevant Files
+
+Use these files to complete the task:
+
+- `.gitignore` — add `!.claude/tasks/` and `!.claude/tasks/**` under the
+  `# Claude Code` block alongside the existing `!.claude/settings.json`,
+  `!.claude/scripts/`, `!.claude/skills/` lines.
+- `PLANNING_INDEX.md` — read-only; used to verify reference list matches
+  committed files. No edits.
+- `AGENTS.md` — read-only; verify slice-3-phase-3 reference is satisfied. No edits.
+- `.taskmaster/tasks/tasks.json` — read-only in this branch; verify whether any
+  tracked state here references task docs, but do not edit Taskmaster in this
+  PR.
+
+### New Files (copy from dirty main working tree at repo root)
+
+Copy these five files from `/Users/romeoman/Documents/Dev/HubSpot/Account Plan App/.claude/tasks/` into the worktree's `.claude/tasks/` directory, then commit:
+
+- `.claude/tasks/2026-04-16-slice-3-phase-3-rls-card-bundling.md`
+- `.claude/tasks/2026-04-16-slice-4-settings-configuration.md`
+- `.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md`
+- `.claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md`
+- `.claude/tasks/2026-04-17-slice-10-upload-profile-wiring.md`
+
+**Already tracked — do not re-copy:** `2026-04-17-slice-6-install-lifecycle-offboarding.md`.
+
+**This plan file itself:** `.claude/tasks/2026-04-18-planning-docs-reconcile.md` — commit alongside the five above so the reconciliation branch documents its own intent.
+
+## Team Orchestration
+
+Because this is a docs-only, deterministic, no-codegen task with no
+contract chain between components, the team is intentionally minimal. One
+builder moves files + edits `.gitignore`; one validator confirms the
+reconciliation holds.
+
+### Team Members
+
+- Specialist
+  - Name: `docs-reconciler`
+  - Role: Copy five task docs from dirty main working tree into the worktree, edit `.gitignore`, stage, commit, verify `git ls-files` matches the reference set.
+  - Agent Type: `general-purpose`
+  - Resume: true
+- Quality Engineer (Validator)
+  - Name: `reconcile-validator`
+  - Role: Validate acceptance criteria in read-only inspection mode: every reference resolves, `.gitignore` exception present, no product code touched.
+  - Agent Type: `quality-engineer`
+  - Resume: false
+
+## Step by Step Tasks
+
+### 1. Update `.gitignore` to un-ignore `.claude/tasks/`
+
+- **Task ID**: gitignore-exception
+- **Depends On**: none
+- **Assigned To**: docs-reconciler
+- **Agent Type**: general-purpose
+- **Parallel**: false
+- Under the existing `# Claude Code` block, after the three existing `!` lines, add:
+  ```
+  !.claude/tasks/
+  !.claude/tasks/**
+  ```
+- Run `git check-ignore -v .claude/tasks/foo.md` and confirm output changes from matching `.claude/*` to matching neither (exit code 1).
+
+### 2. Copy missing task docs into worktree
+
+- **Task ID**: copy-task-docs
+- **Depends On**: gitignore-exception
+- **Assigned To**: docs-reconciler
+- **Agent Type**: general-purpose
+- **Parallel**: false
+- Copy the five files listed under "New Files" above from `/Users/romeoman/Documents/Dev/HubSpot/Account Plan App/.claude/tasks/` to the worktree's `.claude/tasks/` directory.
+- Do NOT modify content. Byte-for-byte copy.
+- Verify via `ls .claude/tasks/ | sort` that exactly 7 files are present: slices 3, 4, 5, 6, 7, 10, and this reconcile plan.
+- In validation notes, distinguish the reason for each group:
+  - slices 3/4/5 satisfy current `origin/main` references
+  - slices 7/10 pre-seed truth for already-open PR #12
+
+### 3. Stage and commit
+
+- **Task ID**: stage-and-commit
+- **Depends On**: copy-task-docs
+- **Assigned To**: docs-reconciler
+- **Agent Type**: general-purpose
+- **Parallel**: false
+- `git add .gitignore .claude/tasks/` — should now work without `-f` thanks to the exception.
+- Verify `git status --short` shows only these paths (6 new `.claude/tasks/*.md` files + modified `.gitignore`).
+- Commit with message:
+
+  ```
+  chore(docs): track .claude/tasks/ slice plans referenced by index
+
+  - Add !.claude/tasks/ exception under the .claude/* ignore rule so
+    slice task docs land via normal git add going forward.
+  - Commit slice-3/4/5 task docs already cited by `origin/main` execution
+    docs, plus slice-7/10 task docs needed to make PR #12's metadata
+    additions truthful when that PR lands. Slice-6 was already tracked.
+  - Add this reconciliation plan so the branch documents its own intent.
+
+  No product code changes.
+  ```
+
+### 4. Validate the reconciliation
+
+- **Task ID**: validate-all
+- **Depends On**: gitignore-exception, copy-task-docs, stage-and-commit
+- **Assigned To**: reconcile-validator
+- **Agent Type**: quality-engineer
+- **Parallel**: false
+- Run all Validation Commands below.
+- Confirm every `.claude/tasks/*.md` reference in the tracked planning files on
+  this branch resolves to a tracked file.
+- Confirm slices 7 and 10 are tracked even though they are not referenced on
+  `origin/main` yet, because they are needed to make PR #12 truthful once it
+  merges.
+- Confirm diff contains no files outside `.gitignore` and `.claude/tasks/`.
+- Operate in validation mode: report only, do not modify files.
+
+## Acceptance Criteria
+
+- `git ls-files .claude/tasks/` returns exactly 7 paths: slices 3, 4, 5, 6, 7, 10, and this reconcile plan.
+- `git diff --name-only origin/main..HEAD` returns only `.gitignore` and paths under `.claude/tasks/`.
+- `git check-ignore .claude/tasks/anything.md` exits 1 (not ignored) after the exception is in place.
+- Every path in `grep -oE "\.claude/tasks/[^\"'\`\ ]+\.md" PLANNING_INDEX.md AGENTS.md .taskmaster/tasks/tasks.json` on this branch resolves to a tracked file.
+- `git ls-files --error-unmatch .claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md .claude/tasks/2026-04-17-slice-10-upload-profile-wiring.md` succeeds so PR #12's already-open metadata additions become truthful once it merges.
+- No files under `apps/`, `scripts/`, `docs/`, or `packages/` changed.
+- Branch is `chore/planning-docs-reconcile` based on `origin/main`.
+
+## Validation Commands
+
+Execute these commands from the worktree root `/Users/romeoman/Documents/Dev/HubSpot/Account Plan App/.worktrees/planning-docs-reconcile`:
+
+- `git status --short --branch` — expect clean tree on `chore/planning-docs-reconcile...origin/main` after commit.
+- `git diff --name-only origin/main..HEAD` — expect only `.gitignore` + `.claude/tasks/*.md`.
+- `git ls-files .claude/tasks/ | sort` — expect 7 entries.
+- `git check-ignore -v .claude/tasks/sentinel.md; echo "exit=$?"` — expect exit=1.
+- `for f in $(grep -hoE "\.claude/tasks/[^\"'\`\ ]+\.md" PLANNING_INDEX.md AGENTS.md .taskmaster/tasks/tasks.json | sort -u); do printf "%-70s " "$f"; git ls-files --error-unmatch "$f" >/dev/null 2>&1 && echo OK || echo MISSING; done` — expect all OK for the references that exist on this branch today.
+- `git ls-files --error-unmatch .claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md .claude/tasks/2026-04-17-slice-10-upload-profile-wiring.md` — expect success, even though those two are not referenced on `origin/main` yet.
+- `git grep -n "\.claude/tasks/" -- ':!*.md' ':!*.json' || true` — sanity check that no code files reference task docs (they shouldn't).
+
+## Notes
+
+- PR #12 (`chore/post-slice-10-tracking`) stays narrow as-is. It does not need amendment — once this reconciliation PR merges, PR #12's PLANNING_INDEX additions become truthful.
+- Slice-6 was force-added historically. After the `.gitignore` exception, its tracked status remains correct; no re-add needed.
+- This plan deliberately leaves `PLANNING_INDEX.md` content unchanged. Trimming it would be the opposite intervention (reference-truth conforms to repo-truth). We chose the other direction because `AGENTS.md:20` and `tasks.json` treat the missing docs as canonical; silencing the references would degrade those execution artifacts.
+- Slice-7 and Slice-10 are included intentionally even though they are not referenced on `origin/main` yet. They are already canonical local slice docs and are referenced by the open metadata-tracking PR #12. Landing them here avoids a second drift window without having to amend PR #12.
+- Out of scope: reconciling `docs/superpowers/plans/` references (those files already exist and are tracked — see `PLANNING_INDEX.md` lines 58–60 on `origin/main`).

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ apps/hubspot-project/local.json
 !.claude/settings.json
 !.claude/scripts/
 !.claude/skills/
+!.claude/tasks/
+!.claude/tasks/**
 
 # Taskmaster local state (keep config and docs)
 .taskmaster/tasks/


### PR DESCRIPTION
## Summary

Docs/tracking reconciliation only. **No product code changes.**

`PLANNING_INDEX.md`, `AGENTS.md`, and `.taskmaster/tasks/tasks.json` on `origin/main` cite slice task docs under `.claude/tasks/` as canonical execution artifacts, but only one of those docs (`2026-04-17-slice-6-install-lifecycle-offboarding.md`) was actually tracked in git. The rest existed only in developers' local working trees. This PR closes that drift for the whole series and codifies the invariant so it stops recurring.

## Root cause

`.gitignore:83` had `.claude/*` with explicit `!` exceptions only for `settings.json`, `scripts/`, and `skills/` — not `tasks/`. Every task doc had to be force-added to land on `main`. Slice 6 was force-added once; no other slice followed that precedent, so slices 3/4/5/7/10 stayed local-only while their references accumulated in tracked planning artifacts.

## What changed

Diff from `origin/main` is exactly 7 paths:

- `.gitignore` — add `!.claude/tasks/` and `!.claude/tasks/**` under the existing `# Claude Code` block, so `git add .claude/tasks/foo.md` works without `-f` going forward.
- `.claude/tasks/2026-04-16-slice-3-phase-3-rls-card-bundling.md` — satisfies `PLANNING_INDEX.md` §2 and `AGENTS.md:20`.
- `.claude/tasks/2026-04-16-slice-4-settings-configuration.md` — satisfies `PLANNING_INDEX.md` §2.
- `.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md` — satisfies `PLANNING_INDEX.md` §2.
- `.claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md` — intentionally included so PR #12's already-open `PLANNING_INDEX.md` addition becomes truthful once this merges. Not referenced on `origin/main` today.
- `.claude/tasks/2026-04-17-slice-10-upload-profile-wiring.md` — same rationale as slice-7. Not referenced on `origin/main` today.
- `.claude/tasks/2026-04-18-planning-docs-reconcile.md` — the plan document for this reconciliation; records intent alongside the change.

Task-doc content was copied byte-for-byte from the main working tree. Existing references in `PLANNING_INDEX.md`, `AGENTS.md`, and `.taskmaster/tasks/tasks.json` are unchanged — they become truthful automatically once these files exist.

## Verification

Run from the worktree root:

- `git status --short --branch` → `## chore/planning-docs-reconcile...origin/chore/planning-docs-reconcile` (clean)
- `git diff --name-only origin/main..HEAD` → exactly the 7 paths listed above
- `git ls-files .claude/tasks/ | sort` → 7 tracked files (slices 3, 4, 5, 6, 7, 10 + reconcile plan)
- `git check-ignore .claude/tasks/sentinel.md; echo "exit=$?"` → `exit=1` (bare form; path is no longer ignored)
- Reference resolution against `PLANNING_INDEX.md`, `AGENTS.md`, `.taskmaster/tasks/tasks.json` → every `.claude/tasks/*.md` reference resolves to a tracked file. The only non-match is the literal template placeholder `.claude/tasks/<current-slice>.md` in `AGENTS.md`, which is a documentation placeholder, not a path reference — explicitly out of scope.
- `git grep -n "\.claude/tasks/" -- ':!*.md' ':!*.json'` → only the `.gitignore` negation lines. No code references task docs.
- Scope check: `git diff --name-only origin/main..HEAD | grep -E '^(apps/|scripts/|docs/|packages/)'` → empty. **No product code changed.**

## Scope / non-goals

- **No product code changes.** Diff is limited to `.gitignore` and `.claude/tasks/*.md`.
- No runtime changes, no test changes, no dependency changes.
- No edits to `PLANNING_INDEX.md`, `AGENTS.md`, or `.taskmaster/tasks/tasks.json` — this PR aligns repo-truth to reference-truth, not the other way around.
- **PR #12 (`chore/post-slice-10-tracking`) does not need amendment.** Its `PLANNING_INDEX.md` additions for slice-7 and slice-10 become truthful on its own once this PR merges to `main`.
- The `<current-slice>.md` literal placeholder in `AGENTS.md` is out of scope.

## Remaining risks or follow-ups

- **Task-doc drift going forward.** The `.gitignore` exception fixes the add path, but nothing enforces that a new slice task doc is committed alongside its references. Future defense would be a pre-commit or CI check that verifies every `.claude/tasks/*.md` path cited by `PLANNING_INDEX.md` / `AGENTS.md` / `tasks.json` resolves to a tracked file. Not part of this PR.
- **ChatPRD mirror drift** (separate, pre-existing issue). `PLANNING_INDEX.md` §1 already notes that several ChatPRD mirrors referenced by older versions of the index no longer exist at those exact paths. Out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciled planning references by tracking missing `.claude/tasks/` slice plans and updating `.gitignore` so task docs are committed by default. No product code changes.

- **Bug Fixes**
  - Added `!.claude/tasks/` and `!.claude/tasks/**` to `.gitignore` so new task docs don’t require force-add.
  - Committed slice task docs for 3, 4, 5, 7, 10 and the reconciliation plan; references in `PLANNING_INDEX.md`, `AGENTS.md`, and `.taskmaster/tasks/tasks.json` now resolve.
  - Makes PR #12’s slice-7 and slice-10 `PLANNING_INDEX.md` entries accurate once merged.

<sup>Written for commit 0033bc94abfeb9ab9b3893e68d3a58c885961a7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

