### PR TITLE
Slice 9: profile-aware extension build wrapper

### DIFF
--- a/apps/hubspot-extension/__tests__/built-bundle-origin.test.ts
+++ b/apps/hubspot-extension/__tests__/built-bundle-origin.test.ts
@@ -1,0 +1,74 @@
+/**
+ * End-to-end determinism check for the extension bundle.
+ *
+ * Loads the Vite config with different `API_ORIGIN` values, runs a real
+ * `vite build` under each, and proves the produced bundle carries the
+ * expected origin string verbatim. This closes the gap that
+ * `vite-config.test.ts` cannot — the config contract is correct *and* the
+ * bundler actually performs the substitution.
+ *
+ * Builds are slow (~1-2s each) so we scope to two targeted origins rather
+ * than the full matrix. Bundle output is written to a temporary directory
+ * outside `dist/` so local dev state isn't touched.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { build } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const EXTENSION_ROOT = resolvePath(__dirname, "..");
+
+async function buildWith(apiOrigin: string, outDir: string): Promise<string> {
+  const prev = process.env.API_ORIGIN;
+  process.env.API_ORIGIN = apiOrigin;
+  try {
+    await build({
+      configFile: resolvePath(EXTENSION_ROOT, "vite.config.ts"),
+      root: EXTENSION_ROOT,
+      logLevel: "error",
+      build: {
+        outDir,
+        emptyOutDir: true,
+      },
+    });
+  } finally {
+    if (prev === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = prev;
+    }
+  }
+  return readFileSync(join(outDir, "index.js"), "utf8");
+}
+
+let scratchRoot: string;
+
+beforeAll(() => {
+  scratchRoot = mkdtempSync(join(tmpdir(), "hap-ext-build-"));
+  mkdirSync(scratchRoot, { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(scratchRoot, { recursive: true, force: true });
+});
+
+describe("hubspot-extension built bundle — origin determinism", () => {
+  it("embeds a staging API_ORIGIN literally into the bundle", async () => {
+    const origin = "https://hap-signal-workspace-staging.vercel.app";
+    const out = join(scratchRoot, "staging");
+    const bundle = await buildWith(origin, out);
+
+    expect(bundle).toContain(origin);
+    // Sanity: the unrelated prod URL must NOT appear when staging built.
+    expect(bundle).not.toContain("https://hap-signal-workspace.vercel.app/api/snapshot/");
+  }, 30_000);
+
+  it("embeds a local API_ORIGIN literally into the bundle", async () => {
+    const origin = "https://hap-signal-workspace-local.vercel.app";
+    const out = join(scratchRoot, "local");
+    const bundle = await buildWith(origin, out);
+
+    expect(bundle).toContain(origin);
+  }, 30_000);
+});

--- a/apps/hubspot-extension/__tests__/vite-config.test.ts
+++ b/apps/hubspot-extension/__tests__/vite-config.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the HubSpot extension's Vite config.
+ *
+ * The build pipeline is the only place where `process.env.API_ORIGIN` can
+ * flow INTO the bundled JavaScript: HubSpot's `hs project upload` expands
+ * `${API_ORIGIN}` inside `hsmeta.json` from the active profile, but it does
+ * NOT propagate the variable into the TypeScript source. We close that gap
+ * by having the HubSpot-side build wrapper set `API_ORIGIN` in the env
+ * before invoking `vite build`, and have Vite replace the global constant
+ * `__HAP_API_ORIGIN__` at build time via `define`.
+ *
+ * This test pins the contract of the `define` block so a future refactor
+ * can't silently drop the substitution.
+ */
+import { resolve as resolvePath } from "node:path";
+import type { UserConfig } from "vite";
+import { describe, expect, it } from "vitest";
+
+async function loadConfigWithEnv(
+  envOverride: Partial<NodeJS.ProcessEnv>,
+): Promise<UserConfig | Awaited<UserConfig>> {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(envOverride)) {
+    previous[key] = process.env[key];
+    const value = envOverride[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    // Bust the module cache so Vite re-reads process.env on each call.
+    const configPath = resolvePath(__dirname, "../vite.config.ts");
+    const modUrl = `${configPath}?env=${encodeURIComponent(JSON.stringify(envOverride))}`;
+    const mod = (await import(/* @vite-ignore */ modUrl)) as {
+      default: UserConfig | (() => UserConfig | Promise<UserConfig>);
+    };
+    const raw = mod.default;
+    return typeof raw === "function" ? await raw() : raw;
+  } finally {
+    for (const [key, prevValue] of Object.entries(previous)) {
+      if (prevValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prevValue;
+      }
+    }
+  }
+}
+
+function defineFor(config: UserConfig): Record<string, string> {
+  const defineBlock = (config.define ?? {}) as Record<string, string>;
+  return defineBlock;
+}
+
+describe("hubspot-extension vite.config.ts", () => {
+  it("injects __HAP_API_ORIGIN__ from process.env.API_ORIGIN as a JSON string literal", async () => {
+    const cfg = await loadConfigWithEnv({
+      API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+    });
+
+    const block = defineFor(cfg);
+    expect(block.__HAP_API_ORIGIN__).toBe(
+      JSON.stringify("https://hap-signal-workspace-staging.vercel.app"),
+    );
+  });
+
+  it("injects an empty-string literal when API_ORIGIN is unset, so the runtime resolver falls through", async () => {
+    const cfg = await loadConfigWithEnv({ API_ORIGIN: undefined });
+
+    const block = defineFor(cfg);
+    // `JSON.stringify("")` → '""'. An empty string is how we signal
+    // "no build-time configuration; use runtime/default fallback" in the
+    // resolver. See resolve-api-base-url.test.ts for the consumer side.
+    expect(block.__HAP_API_ORIGIN__).toBe(JSON.stringify(""));
+  });
+
+  it("preserves the API_ORIGIN value verbatim (no trailing-slash normalization)", async () => {
+    // Clarity: the resolver does NOT strip trailing slashes. If a profile
+    // supplies "https://host/" the built bundle carries that exact string
+    // and any downstream URL construction (`${baseUrl}/api/snapshot/...`)
+    // is responsible for reconciling it. Pin this as an explicit decision
+    // so a later "helpful" normalization doesn't break signed fetch URLs.
+    const cfg = await loadConfigWithEnv({
+      API_ORIGIN: "https://hap-signal-workspace.vercel.app/",
+    });
+
+    const block = defineFor(cfg);
+    expect(block.__HAP_API_ORIGIN__).toBe(
+      JSON.stringify("https://hap-signal-workspace.vercel.app/"),
+    );
+  });
+});

--- a/apps/hubspot-extension/package.json
+++ b/apps/hubspot-extension/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "echo 'Use hs project dev for local HubSpot extension development'",
-    "build": "vite build"
+    "build": "vite build",
+    "build:with-profile": "tsx scripts/build-with-profile-cli.ts"
   },
   "dependencies": {
     "@hap/config": "workspace:*",

--- a/apps/hubspot-extension/scripts/__tests__/build-with-profile.e2e.test.ts
+++ b/apps/hubspot-extension/scripts/__tests__/build-with-profile.e2e.test.ts
@@ -1,0 +1,69 @@
+/**
+ * End-to-end proof that the wrapper produces a bundle containing the
+ * profile's API_ORIGIN. Complements the unit tests in
+ * `build-with-profile.test.ts` by exercising the actual Vite build.
+ *
+ * Slower than unit tests (one real `vite build`), so kept narrow — a single
+ * profile round-trip. The companion Slice 8 determinism test
+ * (`built-bundle-origin.test.ts`) already covers multi-origin determinism
+ * at the Vite level; this test covers the profile-file → env → build path.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { build } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runBuildWithProfile } from "../build-with-profile";
+
+const EXTENSION_ROOT = resolvePath(__dirname, "..", "..");
+
+let scratch: string;
+
+beforeAll(() => {
+  scratch = mkdtempSync(join(tmpdir(), "hap-build-wrapper-e2e-"));
+});
+
+afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("build-with-profile (end-to-end)", () => {
+  it("builds the extension bundle with the profile's API_ORIGIN baked in", async () => {
+    const profileDir = join(scratch, "profiles");
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(
+      join(profileDir, "hsprofile.staging.json"),
+      JSON.stringify({
+        accountId: 12345678,
+        variables: {
+          OAUTH_REDIRECT_URI: "https://hap-signal-workspace-staging.vercel.app/oauth/callback",
+          API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+        },
+      }),
+    );
+
+    const outDir = join(scratch, "out");
+    mkdirSync(outDir, { recursive: true });
+
+    await runBuildWithProfile({
+      profileName: "staging",
+      profileDir,
+      runBuild: async () => {
+        await build({
+          configFile: resolvePath(EXTENSION_ROOT, "vite.config.ts"),
+          root: EXTENSION_ROOT,
+          logLevel: "error",
+          build: {
+            outDir,
+            emptyOutDir: true,
+          },
+        });
+      },
+    });
+
+    const bundle = readFileSync(join(outDir, "index.js"), "utf8");
+    expect(bundle).toContain("https://hap-signal-workspace-staging.vercel.app");
+    // Sanity: prod URL is not what the staging build shipped as the target.
+    expect(bundle).not.toContain("https://hap-signal-workspace.vercel.app/api/snapshot/");
+  }, 45_000);
+});

--- a/apps/hubspot-extension/scripts/__tests__/build-with-profile.test.ts
+++ b/apps/hubspot-extension/scripts/__tests__/build-with-profile.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the HubSpot-project profile-aware extension build wrapper.
+ *
+ * The wrapper lives here (inside the extension package) because
+ * `apps/hubspot-project/` is intentionally excluded from the pnpm workspace
+ * and cannot host runnable TypeScript. It reads a profile file from the
+ * sibling `apps/hubspot-project/hsprofile.<name>.json`, extracts the
+ * `API_ORIGIN` variable, and invokes the existing extension build with
+ * `process.env.API_ORIGIN` set to that value.
+ *
+ * The build itself is covered by `__tests__/built-bundle-origin.test.ts`
+ * (Slice 8). Here we pin the profile-parsing + env-handoff contract.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  extractApiOrigin,
+  InvalidProfileNameError,
+  loadProfile,
+  MissingApiOriginError,
+  MissingProfileFileError,
+  resolveProfilePath,
+  runBuildWithProfile,
+} from "../build-with-profile";
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "hap-build-wrapper-"));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+function writeProfile(name: string, contents: unknown): string {
+  const path = join(scratch, `hsprofile.${name}.json`);
+  writeFileSync(path, JSON.stringify(contents));
+  return path;
+}
+
+describe("resolveProfilePath()", () => {
+  it("maps a profile name to the expected hsprofile.<name>.json path", () => {
+    expect(resolveProfilePath("staging", scratch)).toBe(join(scratch, "hsprofile.staging.json"));
+  });
+
+  it("accepts the three shipped profile names", () => {
+    for (const name of ["local", "staging", "production"]) {
+      expect(() => resolveProfilePath(name, scratch)).not.toThrow();
+    }
+  });
+
+  it.each([
+    "",
+    "..",
+    "../leak",
+    "with space",
+    "UP",
+    "semi;colon",
+  ])("rejects malformed profile name %j", (bad) => {
+    expect(() => resolveProfilePath(bad, scratch)).toThrow(InvalidProfileNameError);
+  });
+});
+
+describe("loadProfile()", () => {
+  it("parses a valid profile file into its JSON shape", () => {
+    const path = writeProfile("staging", {
+      accountId: 12345678,
+      variables: {
+        OAUTH_REDIRECT_URI: "https://x/oauth/callback",
+        API_ORIGIN: "https://x",
+      },
+    });
+
+    const loaded = loadProfile(path);
+    expect(loaded.accountId).toBe(12345678);
+    expect(loaded.variables.API_ORIGIN).toBe("https://x");
+  });
+
+  it("throws a clear MissingProfileFileError when the path does not exist", () => {
+    const path = join(scratch, "hsprofile.nope.json");
+    expect(() => loadProfile(path)).toThrow(MissingProfileFileError);
+  });
+
+  it("throws on malformed JSON rather than silently returning an empty object", () => {
+    const path = join(scratch, "hsprofile.bad.json");
+    writeFileSync(path, "{not json");
+
+    expect(() => loadProfile(path)).toThrow(/profile file is not valid JSON/i);
+  });
+});
+
+describe("extractApiOrigin()", () => {
+  it("returns the API_ORIGIN variable when present", () => {
+    const origin = "https://hap-signal-workspace-staging.vercel.app";
+    expect(extractApiOrigin({ accountId: 1, variables: { API_ORIGIN: origin } })).toBe(origin);
+  });
+
+  it("throws MissingApiOriginError when variables object is missing", () => {
+    expect(() =>
+      extractApiOrigin({ accountId: 1 } as unknown as {
+        accountId: number;
+        variables: Record<string, string>;
+      }),
+    ).toThrow(MissingApiOriginError);
+  });
+
+  it("throws MissingApiOriginError when API_ORIGIN is empty or whitespace", () => {
+    expect(() => extractApiOrigin({ accountId: 1, variables: { API_ORIGIN: "" } })).toThrow(
+      MissingApiOriginError,
+    );
+    expect(() => extractApiOrigin({ accountId: 1, variables: { API_ORIGIN: "   " } })).toThrow(
+      MissingApiOriginError,
+    );
+  });
+});
+
+describe("runBuildWithProfile() — env handoff", () => {
+  it("sets process.env.API_ORIGIN to the profile value before invoking the build", async () => {
+    writeProfile("staging", {
+      accountId: 1,
+      variables: {
+        API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+      },
+    });
+
+    // Capture the env the build sees at invocation time, NOT after.
+    let envAtBuildTime: string | undefined;
+    const runBuild = vi.fn(async () => {
+      envAtBuildTime = process.env.API_ORIGIN;
+    });
+
+    await runBuildWithProfile({
+      profileName: "staging",
+      profileDir: scratch,
+      runBuild,
+    });
+
+    expect(runBuild).toHaveBeenCalledTimes(1);
+    expect(envAtBuildTime).toBe("https://hap-signal-workspace-staging.vercel.app");
+  });
+
+  it("restores the previous API_ORIGIN after the build completes (no env leakage)", async () => {
+    writeProfile("staging", {
+      accountId: 1,
+      variables: {
+        API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+      },
+    });
+
+    const previous = process.env.API_ORIGIN;
+    process.env.API_ORIGIN = "https://sentinel.example.com";
+    try {
+      await runBuildWithProfile({
+        profileName: "staging",
+        profileDir: scratch,
+        runBuild: async () => {
+          // no-op
+        },
+      });
+      expect(process.env.API_ORIGIN).toBe("https://sentinel.example.com");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.API_ORIGIN;
+      } else {
+        process.env.API_ORIGIN = previous;
+      }
+    }
+  });
+
+  it("restores env even when the build throws", async () => {
+    writeProfile("staging", {
+      accountId: 1,
+      variables: {
+        API_ORIGIN: "https://hap-signal-workspace-staging.vercel.app",
+      },
+    });
+
+    const previous = process.env.API_ORIGIN;
+    delete process.env.API_ORIGIN;
+    try {
+      await expect(
+        runBuildWithProfile({
+          profileName: "staging",
+          profileDir: scratch,
+          runBuild: async () => {
+            throw new Error("vite build failed");
+          },
+        }),
+      ).rejects.toThrow(/vite build failed/);
+      expect(process.env.API_ORIGIN).toBeUndefined();
+    } finally {
+      if (previous !== undefined) {
+        process.env.API_ORIGIN = previous;
+      }
+    }
+  });
+
+  it("surfaces a readable error when the profile file is missing", async () => {
+    await expect(
+      runBuildWithProfile({
+        profileName: "local",
+        profileDir: scratch,
+        runBuild: async () => {
+          throw new Error("should not run");
+        },
+      }),
+    ).rejects.toThrow(MissingProfileFileError);
+  });
+});

--- a/apps/hubspot-extension/scripts/build-with-profile-cli.ts
+++ b/apps/hubspot-extension/scripts/build-with-profile-cli.ts
@@ -1,0 +1,68 @@
+/**
+ * CLI entry for the profile-aware build wrapper.
+ *
+ * Usage:
+ *   pnpm --filter @hap/hubspot-extension exec tsx \
+ *     scripts/build-with-profile-cli.ts --profile staging
+ *
+ * OR via the matching package script:
+ *   pnpm --filter @hap/hubspot-extension run build:with-profile -- --profile staging
+ *
+ * Resolution order for the profile name:
+ *   1. `--profile <name>` CLI flag
+ *   2. `HS_PROFILE` env var
+ *   3. error (we refuse to guess a default — production and staging must be
+ *      selected deliberately).
+ *
+ * The profile directory defaults to the sibling `apps/hubspot-project/`
+ * tree resolved relative to this file. Override with `--profile-dir` if the
+ * wrapper is invoked from outside the monorepo (e.g., a packaged release).
+ */
+import { resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "vite";
+import { runBuildWithProfile } from "./build-with-profile";
+
+function parseArgs(argv: string[]): { profile?: string; profileDir?: string } {
+  const out: { profile?: string; profileDir?: string } = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--profile" || arg === "-p") {
+      out.profile = argv[++i];
+    } else if (arg === "--profile-dir") {
+      out.profileDir = argv[++i];
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const profileName = args.profile ?? process.env.HS_PROFILE;
+  if (!profileName) {
+    throw new Error("Profile name is required. Pass --profile <name> or set HS_PROFILE.");
+  }
+
+  const here = fileURLToPath(new URL(".", import.meta.url));
+  const extensionRoot = resolvePath(here, "..");
+  const defaultProfileDir = resolvePath(extensionRoot, "..", "hubspot-project");
+  const profileDir = args.profileDir
+    ? resolvePath(process.cwd(), args.profileDir)
+    : defaultProfileDir;
+
+  await runBuildWithProfile({
+    profileName,
+    profileDir,
+    runBuild: async () => {
+      await build({
+        configFile: resolvePath(extensionRoot, "vite.config.ts"),
+        root: extensionRoot,
+      });
+    },
+  });
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/apps/hubspot-extension/scripts/build-with-profile.ts
+++ b/apps/hubspot-extension/scripts/build-with-profile.ts
@@ -1,0 +1,161 @@
+/**
+ * Profile-aware extension build wrapper.
+ *
+ * Closes the Slice 8 gap: the Vite `define` block reads
+ * `process.env.API_ORIGIN` but nothing sets that env per HubSpot profile
+ * (`hsprofile.local.json`, `hsprofile.staging.json`, `hsprofile.production.json`).
+ * This wrapper reads the selected profile file, extracts its
+ * `variables.API_ORIGIN`, sets the env, and invokes the existing build.
+ *
+ * Library (this file): pure helpers + orchestrator. The CLI entry lives in
+ * `build-with-profile-cli.ts` so tests can import the helpers without
+ * triggering a build as a side effect of import.
+ *
+ * Intended production usage (from the HubSpot project build step):
+ *
+ *   pnpm --filter @hap/hubspot-extension exec tsx \
+ *     scripts/build-with-profile-cli.ts --profile staging
+ *
+ * Profile files live in `apps/hubspot-project/` (gitignored real files,
+ * committed `.example.json` templates).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Error thrown when the caller asks for a profile name we refuse to resolve. */
+export class InvalidProfileNameError extends Error {
+  constructor(name: string) {
+    super(
+      `Invalid profile name: ${JSON.stringify(name)}. Only lowercase ` +
+        `alphanumerics, dashes, and underscores are allowed — no slashes, ` +
+        `dots, spaces, or shell metacharacters.`,
+    );
+    this.name = "InvalidProfileNameError";
+  }
+}
+
+/** Error thrown when the resolved profile path does not exist on disk. */
+export class MissingProfileFileError extends Error {
+  constructor(path: string) {
+    super(
+      `HubSpot profile file not found: ${path}. Copy ` +
+        `hsprofile.<name>.example.json to hsprofile.<name>.json and fill in ` +
+        `the account-specific values before running the build.`,
+    );
+    this.name = "MissingProfileFileError";
+  }
+}
+
+/** Error thrown when the profile's `variables.API_ORIGIN` is missing/empty. */
+export class MissingApiOriginError extends Error {
+  constructor() {
+    super(
+      "Profile is missing a non-empty variables.API_ORIGIN. The wrapper " +
+        "refuses to invoke the build without it — the produced bundle " +
+        "would hard-code the prod fallback instead of the profile's origin.",
+    );
+    this.name = "MissingApiOriginError";
+  }
+}
+
+export type HsProfile = {
+  accountId: number;
+  variables: Record<string, string>;
+};
+
+/**
+ * Allowed profile-name regex. Intentionally strict:
+ *   - lowercase ASCII letters, digits, dashes, underscores
+ *   - at least one character
+ *   - rejects `..`, `/`, `.`, whitespace, and anything that would let a
+ *     caller pivot the resolved path outside the profile directory.
+ */
+const PROFILE_NAME_RE = /^[a-z0-9_-]+$/;
+
+/**
+ * Resolve a profile name to its on-disk path without ever escaping
+ * `profileDir`. Throws on any name that fails {@link PROFILE_NAME_RE}.
+ */
+export function resolveProfilePath(profileName: string, profileDir: string): string {
+  if (!PROFILE_NAME_RE.test(profileName)) {
+    throw new InvalidProfileNameError(profileName);
+  }
+  return join(profileDir, `hsprofile.${profileName}.json`);
+}
+
+/** Read + parse the profile file. Throws typed errors on IO / JSON failures. */
+export function loadProfile(profilePath: string): HsProfile {
+  if (!existsSync(profilePath)) {
+    throw new MissingProfileFileError(profilePath);
+  }
+  const raw = readFileSync(profilePath, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    throw new Error(
+      `Profile file is not valid JSON: ${profilePath}`,
+      cause instanceof Error ? { cause } : undefined,
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as { accountId?: unknown }).accountId !== "number" ||
+    typeof (parsed as { variables?: unknown }).variables !== "object" ||
+    (parsed as { variables?: unknown }).variables === null
+  ) {
+    throw new Error(
+      `Profile file has unexpected shape (expected { accountId: number, ` +
+        `variables: object }): ${profilePath}`,
+    );
+  }
+  return parsed as HsProfile;
+}
+
+/** Return `variables.API_ORIGIN` or throw if absent / empty / whitespace. */
+export function extractApiOrigin(profile: HsProfile): string {
+  const value = profile.variables?.API_ORIGIN;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new MissingApiOriginError();
+  }
+  return value;
+}
+
+export type RunBuildWithProfileOptions = {
+  profileName: string;
+  profileDir: string;
+  /**
+   * Injected build callable. In production this runs `vite build`; in tests
+   * it is a captured spy. Keeping the build out of this function means the
+   * unit tests never touch Vite and execute in milliseconds.
+   */
+  runBuild: () => Promise<void>;
+};
+
+/**
+ * Orchestrate the wrapper flow:
+ *   1. resolve profile path (validated)
+ *   2. read + parse profile
+ *   3. extract API_ORIGIN
+ *   4. set `process.env.API_ORIGIN` for the duration of the build
+ *   5. invoke `runBuild`
+ *   6. restore the previous env (success OR failure path)
+ */
+export async function runBuildWithProfile(opts: RunBuildWithProfileOptions): Promise<void> {
+  const profilePath = resolveProfilePath(opts.profileName, opts.profileDir);
+  const profile = loadProfile(profilePath);
+  const apiOrigin = extractApiOrigin(profile);
+
+  const previous = process.env.API_ORIGIN;
+  process.env.API_ORIGIN = apiOrigin;
+  try {
+    await opts.runBuild();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = previous;
+    }
+  }
+}

--- a/apps/hubspot-extension/src/features/snapshot/hooks/__tests__/resolve-api-base-url.test.ts
+++ b/apps/hubspot-extension/src/features/snapshot/hooks/__tests__/resolve-api-base-url.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for `resolveApiBaseUrl()` — profile/build-time API origin resolver.
+ *
+ * Resolution precedence (highest wins):
+ *   1. A build-time global constant `__HAP_API_ORIGIN__` (injected by Vite
+ *      `define` from `process.env.API_ORIGIN` at `vite build` time). This
+ *      is the production path — the HubSpot project build runs once per
+ *      profile, so each bundle carries the correct origin literally.
+ *   2. `process.env.API_ORIGIN` — the test/runtime escape hatch. Applies
+ *      only in Node runtimes (vitest, SSR). In the real HubSpot extension
+ *      environment `process` is undefined, so this branch never fires.
+ *   3. The hardcoded `DEFAULT_API_BASE_URL` (prod Vercel), so an
+ *      unconfigured build still has a safe default rather than crashing.
+ *
+ * A value of `""`, whitespace-only, or a non-string is treated as absent so
+ * an empty `process.env.API_ORIGIN` doesn't silently nuke the fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_API_BASE_URL, resolveApiBaseUrl } from "../api-fetcher";
+
+const INJECTED_KEY = "__HAP_API_ORIGIN__";
+
+type GlobalWithInjected = typeof globalThis & { [INJECTED_KEY]?: unknown };
+
+function setInjected(value: unknown): void {
+  (globalThis as GlobalWithInjected)[INJECTED_KEY] = value;
+}
+
+function clearInjected(): void {
+  delete (globalThis as GlobalWithInjected)[INJECTED_KEY];
+}
+
+describe("resolveApiBaseUrl()", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.API_ORIGIN;
+    delete process.env.API_ORIGIN;
+    clearInjected();
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.API_ORIGIN;
+    } else {
+      process.env.API_ORIGIN = savedEnv;
+    }
+    clearInjected();
+  });
+
+  it("returns the build-time injected constant when it is a non-empty string", () => {
+    setInjected("https://hap-signal-workspace-staging.vercel.app");
+
+    expect(resolveApiBaseUrl()).toBe("https://hap-signal-workspace-staging.vercel.app");
+  });
+
+  it("prefers the build-time injected constant over a runtime env override", () => {
+    setInjected("https://hap-signal-workspace.vercel.app");
+    process.env.API_ORIGIN = "http://localhost:3001";
+
+    expect(resolveApiBaseUrl()).toBe("https://hap-signal-workspace.vercel.app");
+  });
+
+  it("falls back to process.env.API_ORIGIN when the build-time constant is missing", () => {
+    process.env.API_ORIGIN = "http://localhost:3001";
+
+    expect(resolveApiBaseUrl()).toBe("http://localhost:3001");
+  });
+
+  it("falls back to DEFAULT_API_BASE_URL when the build-time constant is an empty string", () => {
+    setInjected("");
+
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+
+  it("falls back to DEFAULT_API_BASE_URL when the build-time constant is whitespace only", () => {
+    setInjected("   ");
+
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+
+  it("falls back to DEFAULT_API_BASE_URL when nothing is configured", () => {
+    // Neither injected constant nor env var — the safe prod default.
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+
+  it("ignores a non-string injected value rather than coercing it", () => {
+    // A misconfigured Vite `define` that passes a raw number instead of
+    // `JSON.stringify(...)` would leave us with a non-string. Treat it as
+    // absent — the fallback is always a string URL.
+    setInjected(123);
+
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+});

--- a/apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts
+++ b/apps/hubspot-extension/src/features/snapshot/hooks/api-fetcher.ts
@@ -13,9 +13,13 @@
  *     tenant-resolution middleware (Slice 2 Step 4) reads these from the
  *     signed payload — NOT from any client-supplied header.
  *   - The destination URL MUST appear in `permittedUrls.fetch[]` inside
- *     `apps/hubspot-project/src/app/app-hsmeta.json`. `DEFAULT_API_BASE_URL`
- *     below is kept in sync with that file via
- *     `apps/hubspot-project/__validate__/scaffold.test.ts`.
+ *     `apps/hubspot-project/src/app/app-hsmeta.json`. That file lists the
+ *     template variable `${API_ORIGIN}`, which HubSpot expands at upload
+ *     time from the active profile (hsprofile.*.json). The Vite build
+ *     passes the matching `process.env.API_ORIGIN` through to the bundled
+ *     JS via `define`, and `resolveApiBaseUrl()` (below) reads it at
+ *     runtime. The scaffold anti-regression test keeps the placeholder +
+ *     profile variable contract intact.
  *   - Per-account outbound limits: 20 concurrent requests, 15s timeout cap,
  *     1MB payload cap. The snapshot route is well inside these bounds.
  *
@@ -27,14 +31,55 @@ import { hubspot } from "@hubspot/ui-extensions";
 import type { SnapshotFetcher } from "./use-snapshot";
 
 /**
- * Default production API origin for the snapshot backend.
- *
- * MUST be kept in sync with `permittedUrls.fetch[0]` in
- * `apps/hubspot-project/src/app/app-hsmeta.json`. The scaffold anti-regression
- * test binds the two together; if you change this string, change that file
- * and the test's expected value at the same time.
+ * Hard-coded prod fallback. Only reached when both the build-time
+ * `__HAP_API_ORIGIN__` injection and the runtime `process.env.API_ORIGIN`
+ * escape hatch are absent — see {@link resolveApiBaseUrl}. Kept as a string
+ * literal (not derived from env) so a misconfigured build is still safe.
  */
 export const DEFAULT_API_BASE_URL = "https://hap-signal-workspace.vercel.app";
+
+/**
+ * Build-time constant injected by Vite `define` from
+ * `process.env.API_ORIGIN` at `vite build` time. The HubSpot project build
+ * wrapper sets the env per-profile before invoking vite, so each uploaded
+ * bundle literalizes its own target origin. At runtime inside the HubSpot
+ * extension host, this symbol is replaced with a string literal (e.g.,
+ * `"https://hap-signal-workspace-staging.vercel.app"`) by the time the
+ * code executes, and the `typeof` guard is evaluated against that literal.
+ */
+declare const __HAP_API_ORIGIN__: string | undefined;
+
+/**
+ * Resolve the API origin the extension fetcher should target.
+ *
+ * Precedence (highest wins):
+ *   1. `__HAP_API_ORIGIN__` — build-time substitution (the production path).
+ *   2. `process.env.API_ORIGIN` — runtime override for Node environments
+ *      (vitest, SSR). `process` is undefined inside the HubSpot extension
+ *      host, so this branch is Node-only.
+ *   3. {@link DEFAULT_API_BASE_URL} — safe prod default.
+ *
+ * A value of `""`, whitespace-only, or a non-string is treated as absent.
+ * This matters because Vite `define` must emit *some* replacement for
+ * `__HAP_API_ORIGIN__` even when the env is unset; we emit `""` and rely on
+ * this function to fall through.
+ */
+export function resolveApiBaseUrl(): string {
+  const injected =
+    typeof __HAP_API_ORIGIN__ !== "undefined" ? (__HAP_API_ORIGIN__ as unknown) : undefined;
+  if (typeof injected === "string" && injected.trim().length > 0) {
+    return injected;
+  }
+
+  if (typeof process !== "undefined") {
+    const envOrigin = process.env?.API_ORIGIN;
+    if (typeof envOrigin === "string" && envOrigin.trim().length > 0) {
+      return envOrigin;
+    }
+  }
+
+  return DEFAULT_API_BASE_URL;
+}
 
 /**
  * Transport-layer error thrown when the snapshot API returns a non-2xx
@@ -55,9 +100,10 @@ export class ApiFetcherError extends Error {
 
 export type HubSpotApiFetcherDeps = {
   /**
-   * API origin to target. Defaults to `DEFAULT_API_BASE_URL`. Tests override
-   * this; in V1 production we pin the single prod origin and rely on the
-   * HubSpot project's `permittedUrls.fetch` to gate it.
+   * API origin to target. Defaults to the result of {@link resolveApiBaseUrl},
+   * which honors the build-time injected origin first, then
+   * `process.env.API_ORIGIN`, then {@link DEFAULT_API_BASE_URL}. Tests that
+   * want a deterministic origin pass it explicitly.
    */
   baseUrl?: string;
 };
@@ -74,7 +120,7 @@ export type HubSpotApiFetcherDeps = {
  * failure. Schema validation + Date coercion happens in `useSnapshot`.
  */
 export function createHubSpotApiFetcher(deps: HubSpotApiFetcherDeps = {}): SnapshotFetcher {
-  const baseUrl = deps.baseUrl ?? DEFAULT_API_BASE_URL;
+  const baseUrl = deps.baseUrl ?? resolveApiBaseUrl();
 
   return async function fetchSnapshot(companyId: string): Promise<unknown> {
     const url = `${baseUrl}/api/snapshot/${companyId}`;

--- a/apps/hubspot-extension/vite.config.ts
+++ b/apps/hubspot-extension/vite.config.ts
@@ -2,18 +2,38 @@ import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-export default defineConfig({
-  plugins: [react()],
-  build: {
-    emptyOutDir: true,
-    lib: {
-      entry: resolve(__dirname, "src/hubspot-card-entry.tsx"),
-      formats: ["es"],
+/**
+ * Vite config is a factory so `process.env.API_ORIGIN` is read EACH time
+ * `vite build` runs. The HubSpot project build wrapper sets that env per
+ * active profile before invoking the build, and the value flows through
+ * `define` into the bundled JavaScript as the literal string constant
+ * `__HAP_API_ORIGIN__` — consumed at runtime by
+ * `src/features/snapshot/hooks/api-fetcher.ts::resolveApiBaseUrl`.
+ *
+ * Contract (pinned by `__tests__/vite-config.test.ts`):
+ *   - `API_ORIGIN=...`  → `__HAP_API_ORIGIN__ = JSON.stringify(value)`
+ *   - `API_ORIGIN`unset → `__HAP_API_ORIGIN__ = JSON.stringify("")`
+ *   - values are preserved verbatim (no trailing-slash normalization).
+ */
+export default defineConfig(() => {
+  const apiOrigin = process.env.API_ORIGIN ?? "";
+
+  return {
+    plugins: [react()],
+    define: {
+      __HAP_API_ORIGIN__: JSON.stringify(apiOrigin),
     },
-    rollupOptions: {
-      output: {
-        entryFileNames: "index.js",
+    build: {
+      emptyOutDir: true,
+      lib: {
+        entry: resolve(__dirname, "src/hubspot-card-entry.tsx"),
+        formats: ["es"],
+      },
+      rollupOptions: {
+        output: {
+          entryFileNames: "index.js",
+        },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
## Summary

Adds a small build wrapper that closes the profile → extension-bundle handoff. The wrapper reads the selected HubSpot profile file (`apps/hubspot-project/hsprofile.<name>.json`), extracts `variables.API_ORIGIN`, exports it into `process.env.API_ORIGIN`, and invokes the existing `vite build`. The Vite `define` block (Slice 8) then literalizes that origin into the bundled JavaScript as `__HAP_API_ORIGIN__`, and `resolveApiBaseUrl()` reads it at runtime.

**Depends on the slice-8 branch/PR** (`feature/slice-8-extension-api-origin-profile`). This PR targets that branch deliberately so the diff view shows only the 5 slice-9 files. When slice-8 merges to `main`, GitHub will auto-retarget this PR.

## Root cause

Slice 8 wired a profile-aware API origin resolver through Vite's `define`:
- Extension code reads `__HAP_API_ORIGIN__` (build-time constant) via `resolveApiBaseUrl()`.
- Vite injects the constant from `process.env.API_ORIGIN` at `vite build` time.

But nothing in the repo actually set `process.env.API_ORIGIN` per active HubSpot profile. `hs project upload` expands `${API_ORIGIN}` inside `hsmeta.json` from the active profile variables, but it does not propagate the variable into the TypeScript build. Running the raw `pnpm --filter @hap/hubspot-extension run build` therefore always produced a bundle that fell through to `DEFAULT_API_BASE_URL` (prod), regardless of which profile was active.

This slice supplies the missing wrapper that bridges profile → env → build.

## What changed

**New files**
- `apps/hubspot-extension/scripts/build-with-profile.ts` — pure helpers and orchestrator:
  - `resolveProfilePath(name, dir)` — strict `^[a-z0-9_-]+$` regex blocks path traversal (`..`, `../leak`, etc.).
  - `loadProfile(path)` — reads and JSON-parses with typed error on missing file and on invalid JSON / shape.
  - `extractApiOrigin(profile)` — returns `variables.API_ORIGIN` or throws on missing / empty / whitespace.
  - `runBuildWithProfile({ profileName, profileDir, runBuild })` — sets `process.env.API_ORIGIN`, awaits the injected `runBuild`, and restores the previous env in `finally` (including when the build throws).
  - Typed errors: `InvalidProfileNameError`, `MissingProfileFileError`, `MissingApiOriginError`.
- `apps/hubspot-extension/scripts/build-with-profile-cli.ts` — CLI shim that parses `--profile <name>` (or `HS_PROFILE` env) and `--profile-dir`, defaults the profile directory to the sibling `apps/hubspot-project/`, and wires a real `vite.build()` as `runBuild`.
- `apps/hubspot-extension/scripts/__tests__/build-with-profile.test.ts` — 18 unit tests (path resolution / malformed name rejection / file loading / JSON error / API_ORIGIN extraction / env set-and-restore on success, throw, and missing-file paths).
- `apps/hubspot-extension/scripts/__tests__/build-with-profile.e2e.test.ts` — end-to-end: writes a temp profile, runs the real `vite build` via the wrapper, reads `index.js`, asserts the profile's origin appears verbatim and that the prod URL does not leak in.

**Modified**
- `apps/hubspot-extension/package.json` — additive: `"build:with-profile": "tsx scripts/build-with-profile-cli.ts"`. `tsx` is already a root devDependency so no install impact.

Zero changes to `apps/hubspot-project/` (profile templates untouched), zero changes to existing extension or API source outside the new `scripts/` tree and the single package.json line.

## Verification

```
pnpm typecheck                  # tsc --build, exit 0
pnpm test                       # 75 files / 655 passed (was 73/636 on slice-8 baseline; +2 files / +19 tests)
```

Fresh run immediately before the commit:

| Check | Result |
|---|---|
| Typecheck | ✅ exit 0 |
| Full test suite | ✅ 75/75 files, 655/655 tests |
| Slice-9 unit tests (`build-with-profile.test.ts`) | ✅ 18/18 |
| Slice-9 end-to-end test (`build-with-profile.e2e.test.ts`) | ✅ 1/1, ≈800ms for a real `vite build` |

RED→GREEN was verified cleanly before implementation: both test files initially failed with `Cannot find module '../build-with-profile'` against a bare branch, then went green with the wrapper in place.

## Scope / non-goals

**In scope (this PR):**
- Profile parsing (name validation, file read, JSON shape check).
- `API_ORIGIN` extraction with strict validation.
- Env set-and-restore around an injected build call.
- CLI shim for operational use.
- TDD coverage at unit and end-to-end levels.

**Explicitly out of scope (queued for separate PRs):**
- Lifecycle webhook subscription bootstrap (HubSpot-side `POST /webhooks/v4/subscriptions`).
- Root `/` → `/oauth/install` redirect.
- Committing the Slice 7 lifecycle webhook receiver branch.
- Any `hsmeta.json` or `hsprofile.*.json` modifications — the template placeholder contract is already right; this slice only fills the missing transport between it and Vite.
- `use-snapshot.ts` dead-code cleanup (`SLICE2_TRANSPORT_NOT_WIRED`, stale `@todo Slice 3` comment).
- Any runtime behaviour change inside the extension — no API, route, or component touched.

## Remaining risks or follow-ups

- **Operator wiring.** The wrapper exists and is tested; the HubSpot project upload flow still needs to be updated to call `pnpm --filter @hap/hubspot-extension run build:with-profile -- --profile $PROFILE` instead of the raw `build`. Without that wiring the wrapper sits unused — the rest of the chain is already correct. Recommend following this PR with a small ops PR that updates whatever orchestrates `hs project upload` per environment.
- **Stacked-PR rebase risk.** If the slice-8 PR receives change requests that rename or delete any of the paths this PR touches (unlikely — slice-9 only adds new files and adds a single line to `package.json`), a rebase will be required. Current overlap is zero-file modifications; a clean rebase is the expected outcome.
- **Profile file hygiene.** `apps/hubspot-project/hsprofile.<name>.json` files are gitignored (contain account-specific ids). The `.example.json` templates are committed. Operators must copy + fill before running the wrapper; `MissingProfileFileError` gives a readable message pointing at that step.
- **Scaffold anti-regression coverage.** `apps/hubspot-project/__validate__/scaffold.test.ts` does not currently assert the presence of the new `build:with-profile` package script. Worth adding as a follow-up so a future refactor can not silently drop the entry point.

## After slice-8 merges

1. GitHub auto-retargets this PR to `main` and offers an auto-rebase.
2. If clean (expected, no file overlap): accept.
3. Otherwise: `git fetch origin && git rebase origin/main && git push --force-with-lease`.
4. Merge this PR. Worktree at `.worktrees/slice-9-build-wrapper-profile` can then be removed via `git worktree remove`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a profile-aware build wrapper for the HubSpot extension that reads the selected profile and bakes its API origin into the bundle. It sets `process.env.API_ORIGIN` from `apps/hubspot-project/hsprofile.<name>.json` and runs `vite` so each build targets the right environment.

- **New Features**
  - Wrapper library + CLI to read `API_ORIGIN` from a profile, validate it, set the env, and invoke the build (strict name validation and clear errors).
  - Adds `build:with-profile` script using `tsx` in `@hap/hubspot-extension`; CLI accepts `--profile <name>` or `HS_PROFILE` and optional `--profile-dir`.
  - Unit and end-to-end tests cover env handoff and bundle output.

- **Migration**
  - Use: pnpm --filter `@hap/hubspot-extension` run build:with-profile -- --profile <name>
  - Ensure `apps/hubspot-project/hsprofile.<name>.json` exists and includes a non-empty `variables.API_ORIGIN`.

<sup>Written for commit 142c4e389940b93e25314a6054a57b75c95698bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

> **Note:** This PR replaces the original [#8](https://github.com/romeoman/hubspot-account-plan-app/pull/8), which was auto-closed by GitHub when its base branch (`feature/slice-8-extension-api-origin-profile`) was deleted after merging [#9](https://github.com/romeoman/hubspot-account-plan-app/pull/9) into `main`. The code, commits, and CI history are unchanged — just the base retargeted from the now-merged Slice 8 branch to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Slice 9 — Profile-Aware Extension Build Wrapper

## Overview

This PR implements a **profile-aware build wrapper** that reads HubSpot project configuration (hsprofile files), extracts the API origin, and injects it into the extension bundle at compile time. This enables environment-specific API endpoints to be baked into the production bundle without runtime environment variables, improving deployment safety and predictability.

---

## 🎯 Feature Capability

### What It Does

- **Profile Reading**: Validates and loads HubSpot profile files (`hsprofile.<name>.json`) from the project directory
- **API Origin Extraction**: Safely extracts `variables.API_ORIGIN` with strict validation
- **Compile-Time Injection**: Injects the origin into Vite's `define` block as `__HAP_API_ORIGIN__` 
- **Runtime Resolution**: Falls back through: build-time injected value → runtime `process.env.API_ORIGIN` → default production URL
- **CLI Interface**: New `build:with-profile` npm script for operator-friendly deployment

### Data Flow Architecture

```mermaid
graph LR
    A["hsprofile.staging.json<br/>(HubSpot Project)"]
    B["build-with-profile-cli.ts<br/>(Parse --profile flag)"]
    C["build-with-profile.ts<br/>(Load + Validate Profile)"]
    D["process.env.API_ORIGIN<br/>(Temporary Set)"]
    E["vite.config.ts<br/>(define block)"]
    F["__HAP_API_ORIGIN__<br/>(Compile-time Constant)"]
    G["index.js Bundle"]
    H["Runtime: resolveApiBaseUrl()"]
    I["API Client"]
    
    A --> B
    B --> C
    C --> D
    D --> E
    E --> F
    F --> G
    G --> H
    H --> I
    
    style A fill:#e1f5e1
    style D fill:#fff4e1
    style F fill:#e1e5ff
    style G fill:#f0e1ff
    style H fill:#ffe1e1
    style I fill:#e1f0ff
```

### Resolution Precedence (Runtime)

```mermaid
flowchart TD
    A["resolveApiBaseUrl() Called"]
    B{"__HAP_API_ORIGIN__<br/>defined & non-empty?"}
    C["Use __HAP_API_ORIGIN__"]
    D{"process.env.API_ORIGIN<br/>set & non-empty?"}
    E["Use process.env.API_ORIGIN"]
    F["Use DEFAULT_API_BASE_URL<br/>(Production)"]
    
    A --> B
    B -->|YES| C
    B -->|NO| D
    D -->|YES| E
    D -->|NO| F
    
    style C fill:#c8e6c9
    style E fill:#fff9c4
    style F fill:#ffccbc
```

---

## 📦 Changes Summary

### New Files Added

| File | Purpose | Lines |
|------|---------|-------|
| `scripts/build-with-profile.ts` | Core build wrapper logic with profile validation, loading, and environment management | +161 |
| `scripts/build-with-profile-cli.ts` | CLI entrypoint parsing `--profile` and `--profile-dir` flags | +68 |
| `scripts/__tests__/build-with-profile.test.ts` | Unit tests for profile handling, validation, env restoration (12 tests) | +212 |
| `scripts/__tests__/build-with-profile.e2e.test.ts` | End-to-end test: real Vite build with temp profile | +69 |
| `__tests__/vite-config.test.ts` | Validates Vite `define` block injects `__HAP_API_ORIGIN__` correctly | +94 |
| `__tests__/built-bundle-origin.test.ts` | Determinism test: verifies origin is baked into final bundle | +74 |
| `src/features/snapshot/hooks/__tests__/resolve-api-base-url.test.ts` | Tests resolution precedence logic (6 scenarios) | +95 |

### Files Modified

| File | Changes | Impact |
|------|---------|--------|
| `vite.config.ts` | Factory pattern + `define` block for `__HAP_API_ORIGIN__` | Enables per-build origin injection |
| `src/features/snapshot/hooks/api-fetcher.ts` | Added `resolveApiBaseUrl()` function + updated default behavior | Runtime fallback chain implemented |
| `package.json` | Added `build:with-profile` script | Operator-facing entrypoint |

---

## ✅ Testing & Deployment-Driven Design

### Test Coverage: **19 Tests (100% Slice-9 Scope)**

#### Unit Tests (12 tests in `build-with-profile.test.ts`)
- ✅ Profile name validation (whitelist: staging, production, local)
- ✅ Invalid profile names rejected with `InvalidProfileNameError`
- ✅ Missing profile files raise `MissingProfileFileError`
- ✅ Malformed JSON parsing fails gracefully
- ✅ Missing/empty `variables.API_ORIGIN` raises `MissingApiOriginError`
- ✅ Environment variable set-and-restore (success path)
- ✅ Environment variable restore on build failure (error path)
- ✅ Restoration prevents environment leakage

#### Integration Tests (1 E2E in `build-with-profile.e2e.test.ts`)
- ✅ Real Vite build execution with temp profile
- ✅ Generated bundle verifies origin is present
- ✅ Negative assertion: unrelated production URL absent

#### Config Tests (1 test in `vite-config.test.ts`)
- ✅ Vite `define` block correctly injects `__HAP_API_ORIGIN__`
- ✅ Cache-busting ensures per-test re-evaluation

#### Determinism Tests (1 test in `built-bundle-origin.test.ts`)
- ✅ Bundle created twice with different origins remains deterministic
- ✅ Exact origin strings preserved verbatim (no normalization)
- ✅ Trailing slashes preserved

#### Resolution Tests (6 tests in `resolve-api-base-url.test.ts`)
- ✅ Build-time injected value takes precedence
- ✅ Runtime env falls back when injection missing
- ✅ Default fallback when both absent
- ✅ Empty string treated as missing
- ✅ Non-string types safely handled

### Test Verification Status

```
All tests: PASSING ✅
├─ TypeScript: typecheck ✅
├─ Unit tests (18): pnpm test ✅
├─ E2E tests (1): pnpm test ✅
└─ Full suite: PASSING ✅
```

### Deployment Traceability

**Operator Workflow:**
```bash
# Step 1: Deploy with profile-aware build
pnpm build:with-profile --profile staging --profile-dir ./path/to/profiles

# Step 2: Verify bundle contains correct origin
grep "__HAP_API_ORIGIN__" dist/index.js

# Step 3: Deploy generated bundle
# (origin is now immutable in the bundle)
```

**Deployment Guarantee:**
- Origin is compile-time constant → immutable in bundle
- No runtime env variable required in production
- Test coverage ensures build toolchain correctness
- Negative assertions prevent accidental misconfigurations

---

## 🔒 Error Handling & Validation

### Typed Errors (Strict Validation)

```typescript
// Exported error types enable programmatic error handling:
InvalidProfileNameError      // name not in whitelist (staging, production, local)
MissingProfileFileError      // hsprofile.<name>.json not found
MissingApiOriginError        // variables.API_ORIGIN missing or empty
```

### Validation Rules

| Check | Location | Failure Mode |
|-------|----------|--------------|
| Profile name whitelist | `resolveProfilePath()` | `InvalidProfileNameError` |
| Profile file existence | `loadProfile()` | `MissingProfileFileError` |
| JSON parsing | `loadProfile()` | JSON parse error (no wrapping) |
| API_ORIGIN presence | `extractApiOrigin()` | `MissingApiOriginError` |
| API_ORIGIN non-empty | `extractApiOrigin()` | Whitespace trimmed, then validated |

---

## 📋 Scope & Non-Goals

### ✅ In-Scope (Implemented)
- Profile parsing and validation
- API_ORIGIN extraction
- Environment variable management with strict restoration
- CLI interface with flag parsing
- TDD-first test coverage (12 unit + 1 e2e + 6 integration tests)
- Compile-time injection via Vite `define`
- Runtime resolution precedence

### ❌ Out-of-Scope (Not Included)
- HubSpot webhook bootstrap
- OAuth redirect flows
- Profile/hsmeta template changes
- Orchestration workflow integration (operator will wire into existing deploys)

---

## 🚀 Deployment Readiness

**What Operators Must Do Next:**
1. **Update deploy/orchestration scripts** to call `pnpm build:with-profile --profile <name>` instead of `pnpm build`
2. **Verify profile directories** are present in deployment environment
3. **Validate bundle** after build to ensure origin was injected (optional but recommended)

**What's Already Done:**
- ✅ Build wrapper implementation (161 lines)
- ✅ CLI interface (68 lines)
- ✅ Comprehensive test coverage (19 tests across 6 test files)
- ✅ Runtime fallback logic with precedence
- ✅ Typed error handling

---

## 📊 Code Quality Metrics

| Metric | Value | Status |
|--------|-------|--------|
| Test Count | 19 | ✅ Complete |
| Coverage (Scope) | 100% | ✅ Full |
| Lines Added | +773 | ✅ Reasonable |
| Lines Modified | +80 | ✅ Focused |
| Type Safety | 100% | ✅ TypeScript strict |
| Error Paths | All Tested | ✅ restore on failure |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->