### PR TITLE
Slice 11: add lifecycle subscription bootstrap

### DIFF
--- a/.claude/tasks/2026-04-18-slice-11-lifecycle-subscription-bootstrap.md
+++ b/.claude/tasks/2026-04-18-slice-11-lifecycle-subscription-bootstrap.md
@@ -1,0 +1,485 @@
+# Plan: Slice 11 — HubSpot Lifecycle Subscription Bootstrap
+
+## Task Description
+
+Slice 7 shipped the **webhook receiver transport**: `POST /webhooks/hubspot/lifecycle`
+with HMAC `v3` signature verification, event-id mapping for
+`4-1909196` (app_install) / `4-1916193` (app_uninstall), and idempotent
+delegation to the existing `applyHubSpotLifecycleEvent` service (which itself
+came from Slice 6). Source of truth:
+
+- `apps/api/src/routes/lifecycle.ts` — receiver, already live on `main`
+- `apps/api/src/lib/tenant-lifecycle.ts` — service, from Slice 6
+
+What is still **not automated** — and what the original Slice 7 plan
+(`.claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md`) documented
+but explicitly deferred — is the step **before** the receiver can ever fire:
+the HubSpot app must have an `APP_LIFECYCLE_EVENT` **subscription** registered
+against it, so that HubSpot actually delivers install/uninstall webhooks to
+the receiver URL.
+
+Today, for the primary automation path to work end-to-end, an operator has to
+manually go into the HubSpot developer UI and toggle subscriptions. That is a
+marketplace-submission blocker and a silent-drift risk: if nobody toggles it,
+the receiver is live but never gets called, and the system falls back to the
+Slice 6 oauth-failure path as the _only_ signal — exactly the posture Slice 7
+was meant to exit.
+
+Slice 11 closes **just that gap**: give the app a small, auditable,
+config-driven way to register and verify its lifecycle subscription against
+HubSpot using the documented app-level (client-credentials) auth flow. Nothing
+more.
+
+## Current Frontier
+
+Discovery performed against `origin/main` at commit `baeaf4a` (Slice 10):
+
+- **Slices 6, 7, 8, 9, 10 are merged.** No open PRs. Worktree cleanup done.
+- Verification in this section is against the **git object at `origin/main`**,
+  not against any possibly-dirty local root checkout. When local `main`
+  drifts, use `git show origin/main:...` as the source of truth for Slice 11
+  planning and validation.
+- `apps/api/src/routes/lifecycle.ts` exists and is complete — verified:
+  - `POST /webhooks/hubspot/lifecycle` mounted outside `/api/*`
+  - HMAC v3 verification via `verifyHubSpotSignatureV3`
+  - Event-id mapping `4-1909196` → `app_install`, `4-1916193` → `app_uninstall`
+  - Unknown portals + unknown event ids → safe no-op with 200 (no retry storm)
+- `apps/api/src/lib/tenant-lifecycle.ts` exposes `applyHubSpotLifecycleEvent`
+  and the soft-deactivate / reactivate primitives from Slice 6.
+- `.taskmaster/tasks/tasks.json` already carries an entry
+  `"Slice 11 — Lifecycle Subscription Bootstrap and Journal Automation"` with
+  status `pending`, describing the ambiguity this plan resolves: _"whether to
+  ship a narrow subscription bootstrap helper first or continue into the
+  fuller journal-ingestion/control-plane plan."_
+- The original Slice 7 plan
+  (`.claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md`) proposed
+  a 13-task superset including `lifecycle-sync-schema`, a journal adapter,
+  cursor processor, and uninstall control-plane wrapper. That superset is
+  **explicitly the thing Slice 11 narrows.**
+
+## Scope Selection — Three Axes
+
+The originally-scoped "primary lifecycle automation path" has three distinct
+axes. Slice 11 ships exactly one.
+
+| Axis                                         | Status                               | Where it lives                         |
+| -------------------------------------------- | ------------------------------------ | -------------------------------------- |
+| **A. Webhook receiver transport**            | **DONE** (Slice 7)                   | `apps/api/src/routes/lifecycle.ts`     |
+| **B. Subscription bootstrap**                | **SLICE 11**                         | new `hubspot-subscription-bootstrap`   |
+| **C. Journal ingestion / cursor automation** | **DEFERRED** (queued as later slice) | not in this slice                      |
+| **D. Slice 6 oauth-failure fallback**        | **PRESERVED UNCHANGED**              | `apps/api/src/lib/tenant-lifecycle.ts` |
+
+Rationale for this selection:
+
+- **B is the smallest unit that moves the marketplace posture forward** — the
+  receiver from A has zero real-world effect until a subscription is
+  registered against the app.
+- **C is only valuable if B is unreliable or as a reconciliation sweep.**
+  HubSpot's documented delivery semantics treat webhooks as the primary
+  channel; the journal is the operational backstop. We have D as a stronger
+  backstop at the tenant-identity level (oauth revocation is observable
+  synchronously from runtime). Therefore C is a low-value add-on right now
+  and should not expand Slice 11.
+- **D is already a safety net and must not regress.** Any Slice 11 change
+  that touches `tenant-lifecycle.ts` is out of scope by construction.
+
+Recommended Slice 11 scope: **B only.** C and A are explicitly not reopened.
+
+## Objective
+
+When Slice 11 is complete:
+
+1. The app can acquire an **app-level access token** via HubSpot's documented
+   client-credentials flow (separate from per-tenant OAuth).
+2. The app exposes an **operator-only bootstrap entrypoint** that ensures the
+   `APP_LIFECYCLE_EVENT` subscription is registered against the correct target
+   URL for `app_install` and `app_uninstall`.
+3. The bootstrap is **idempotent**: re-running it on an already-subscribed app
+   is a safe no-op with clear logs.
+4. The bootstrap is **observable**: logs + return payload describe current vs
+   desired subscription state.
+5. **Slice 6 fallback behavior is preserved unchanged** — oauth-refresh failure
+   still soft-deactivates the tenant, so a delayed or misconfigured subscription
+   cannot leave a revoked-install tenant active.
+6. The operator runbook documents how to run the bootstrap, how to rotate the
+   app credentials, and how to roll back.
+
+## Problem Statement
+
+The receiver route from Slice 7 is plumbing with no faucet. Unless a HubSpot
+subscription is registered for `APP_LIFECYCLE_EVENT`, no install/uninstall
+webhook will ever be delivered, and the primary automation path documented in
+`docs/slice-6-preflight-notes.md` stays theoretical. That forces operators to
+configure subscriptions by hand in the HubSpot developer UI per environment
+(dev / preview / prod), which is error-prone, undiffable, and blocks
+marketplace submission posture.
+
+## Solution Approach
+
+Add a narrow **subscription bootstrap** layer with three parts:
+
+1. **App auth client** (`apps/api/src/lib/hubspot-app-auth.ts`)
+   Acquire an app-level access token via HubSpot's client-credentials flow,
+   using `HUBSPOT_APP_CLIENT_ID` / `HUBSPOT_APP_CLIENT_SECRET` /
+   `HUBSPOT_APP_ID` from env. Cache in memory with expiry. Strict tests for
+   missing env, token-fetch failure, and expiry handling.
+
+2. **Subscription bootstrap service**
+   (`apps/api/src/lib/hubspot-subscription-bootstrap.ts`)
+   - List current subscriptions via
+     `GET https://api.hubapi.com/webhooks-journal/subscriptions/2026-03`.
+   - Compute the desired set from the locked event-id constants in
+     `apps/api/src/routes/lifecycle.ts`: `APP_LIFECYCLE_EVENT` for
+     `app_install` (`4-1909196`) and `app_uninstall` (`4-1916193`).
+   - Diff on `(subscriptionType, eventTypeId)` only. **Correction from
+     preflight (2026-03 docs):** HubSpot's subscription API is app-scoped
+     and does not accept a per-subscription `targetUrl` or `portalId` in
+     the body; the webhook target URL lives in `app-hsmeta.json` / the
+     developer-UI webhooks config, NOT on the subscription record.
+     Therefore there is no "mismatched target URL" diff case to handle at
+     the API level. `LIFECYCLE_TARGET_URL` is kept as a passthrough field
+     in the JSON report for operator visual verification at runbook time.
+   - Create missing subscriptions via
+     `POST .../webhooks-journal/subscriptions/2026-03` with body
+     `{ "subscriptionType": "APP_LIFECYCLE_EVENT", "eventTypeId": "..." }`.
+   - Return a typed report:
+     `{ targetUrl, created: [{ eventTypeId, subscriptionId }], alreadyPresent: [{ eventTypeId, subscriptionId }] }`.
+
+3. **Operator entrypoint**
+   (`apps/api/src/routes/admin/lifecycle-bootstrap.ts`)
+   - `POST /admin/lifecycle/bootstrap`, mounted OUTSIDE `/api/*`, guarded by
+     `X-Internal-Bootstrap-Token` equality against an env-configured shared
+     secret using a length-safe constant-time comparison. No public anonymous
+     trigger.
+   - Wire it to the bootstrap service. Return the typed report as JSON.
+   - Leave a script shim (`pnpm --filter @hap/api lifecycle:bootstrap`) that
+     calls the same service locally for CI / preview bootstraps without HTTP.
+
+Explicitly **not in Slice 11**:
+
+- Journal polling / cursor checkpointing / reconciliation sweeps
+  (queue separately as Slice 12 if ever needed — current webhook-first model
+  plus Slice 6 fallback is sufficient for the locked V1 wedge).
+- `DELETE /appinstalls/v3/external-install` wrapping
+  (still an ops-only capability per Slice 7 preflight notes).
+- Any change to `apps/api/src/routes/lifecycle.ts` or `tenant-lifecycle.ts`.
+
+## Relevant Files
+
+Use these files to complete the task:
+
+- `apps/api/src/routes/lifecycle.ts` — **read-only reference** for event-id
+  mapping; must not change. Our new subscriptions must target the event ids
+  declared in `HUBSPOT_LIFECYCLE_EVENT_IDS`.
+- `apps/api/src/lib/tenant-lifecycle.ts` — **read-only reference**; Slice 6
+  fallback behavior must keep working.
+- `apps/api/src/middleware/hubspot-signature.ts` — reference for HMAC shape
+  and the repo's existing length-safe `timingSafeEqual` pattern (no changes).
+- `apps/api/src/lib/oauth.ts` — reference for constant-time secret comparison
+  shape in auth-sensitive code (no changes).
+- `apps/api/src/index.ts` — mount point for the new admin route.
+- `apps/api/package.json` — tiny script addition to expose the operator shim
+  as `pnpm --filter @hap/api lifecycle:bootstrap`.
+- `docs/slice-6-preflight-notes.md` — verified source summary for the
+  Webhooks API auth model and lifecycle event ids.
+- `docs/phase-6-doc-alignment.md` — confirms soft-deactivate policy stays.
+- `.claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md` — the
+  parent plan this slice carves a narrow piece off of.
+- `docs/security/SECURITY.md` — update with the new admin route surface and
+  the `HUBSPOT_APP_*` env requirements.
+- `docs/runbooks/tenant-offboarding.md` — cross-link the new bootstrap
+  runbook.
+- `.taskmaster/tasks/tasks.json` — Slice 11 task entry already exists;
+  update status when work begins.
+- `PLANNING_INDEX.md` — register the new plan file.
+
+### New Files
+
+- `apps/api/src/lib/hubspot-app-auth.ts` — client-credentials token client.
+- `apps/api/src/lib/__tests__/hubspot-app-auth.test.ts`
+- `apps/api/src/lib/hubspot-subscription-bootstrap.ts` — diff + ensure logic.
+- `apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts`
+- `apps/api/src/routes/admin/lifecycle-bootstrap.ts` — guarded HTTP entry.
+- `apps/api/src/routes/admin/__tests__/lifecycle-bootstrap.test.ts`
+- `apps/api/scripts/lifecycle-bootstrap.ts` — local/CI script shim.
+- `docs/slice-11-preflight-notes.md` — re-verified HubSpot docs.
+- `docs/security/slice-11-audit.md` — security review.
+- `docs/runbooks/lifecycle-subscription-bootstrap.md` — operator runbook.
+
+Note: `apps/api/src/routes/admin/` does not need to pre-exist. Creating that
+subtree as part of Slice 11 is in scope.
+
+## Implementation Phases
+
+### Phase 1: Foundation
+
+- Re-verify HubSpot Webhooks Subscription management API (endpoints, required
+  scopes, client-credentials lifetime, idempotency semantics). Output:
+  `docs/slice-11-preflight-notes.md`.
+- Lock config contract: exactly which env vars feed the bootstrap
+  (`HUBSPOT_APP_ID`, `HUBSPOT_APP_CLIENT_ID`, `HUBSPOT_APP_CLIENT_SECRET`,
+  `LIFECYCLE_TARGET_URL`, `INTERNAL_BOOTSTRAP_TOKEN`).
+- Write failing tests for `hubspot-app-auth`: missing env, token fetch
+  success (mocked `fetch`), token fetch failure, cache hit inside TTL,
+  cache miss past TTL.
+
+### Phase 2: Core Implementation
+
+- Implement `hubspot-app-auth.ts` to pass Phase 1 tests.
+- Write failing tests for `hubspot-subscription-bootstrap`:
+  - all missing → creates two subscriptions
+  - partial present → creates missing one only
+  - both present → no creates, both reported as `alreadyPresent`
+  - list-subscriptions API failure → propagates
+  - create-subscription API failure → propagates (previously-created partial
+    state visible in the returned report)
+  - (NO "mismatched target URL" case — the subscription API is app-scoped and
+    does not carry a per-subscription target URL; see Solution Approach.)
+- Implement the bootstrap service to pass.
+- Write failing tests for the admin route: missing token → 401, bad token
+  → 403, valid token → 200 with JSON report, upstream failure → 502.
+- Implement the route and mount it in `apps/api/src/index.ts` outside
+  `/api/*` and outside tenant middleware.
+- Add the script shim that invokes the service with env-provided config and
+  prints the report as JSON.
+
+### Phase 3: Integration & Polish
+
+- Runbook: `docs/runbooks/lifecycle-subscription-bootstrap.md` covering
+  first-run, rotation of `HUBSPOT_APP_CLIENT_SECRET`, rollback (leaving
+  subscriptions in place is safe — they simply deliver to the receiver;
+  teardown requires manual HubSpot UI action).
+- Security audit note: `docs/security/slice-11-audit.md` — confirms the
+  admin route is not public-anonymous, that the internal token is compared
+  with constant-time equality, and that we never log `HUBSPOT_APP_CLIENT_SECRET`
+  or bearer tokens.
+- Update `docs/security/SECURITY.md` with the new env and new route.
+- Update `PLANNING_INDEX.md` to include this plan + the preflight note.
+- Update the Slice 11 Taskmaster entry with implementation notes as work
+  progresses.
+
+## Team Orchestration
+
+- Team lead orchestrates via `Agent` calls with `mode: "bypassPermissions"`
+  and a `team_name`. Team lead does not write code.
+- Contract chain: preflight → app-auth → bootstrap-service → admin-route +
+  runbook/security in parallel → validator.
+
+### Team Members
+
+- Specialist
+  - Name: `preflight-researcher`
+  - Role: Re-verify HubSpot Webhooks Subscription management API (auth model,
+    endpoints, idempotency). Produces `docs/slice-11-preflight-notes.md` and
+    the config contract table. Read-only on code.
+  - Agent Type: context7-docs-researcher
+  - Resume: true
+
+- Specialist
+  - Name: `builder-app-auth`
+  - Role: Implement `hubspot-app-auth.ts` + tests. Owns
+    `apps/api/src/lib/hubspot-app-auth.ts` and its test file only.
+  - Agent Type: backend-engineer
+  - Resume: true
+
+- Specialist
+  - Name: `builder-subscription-bootstrap`
+  - Role: Implement the subscription diff/ensure service + tests. Consumes
+    the app-auth contract. Owns
+    `apps/api/src/lib/hubspot-subscription-bootstrap.ts` and its test file.
+  - Agent Type: backend-engineer
+  - Resume: true
+
+- Specialist
+  - Name: `builder-admin-route`
+  - Role: Implement the guarded admin route + script shim + index mount.
+    Owns `apps/api/src/routes/admin/lifecycle-bootstrap.ts`,
+    `apps/api/scripts/lifecycle-bootstrap.ts`, the route test, and the tiny
+    edit to `apps/api/src/index.ts`.
+  - Agent Type: backend-engineer
+  - Resume: true
+
+- Specialist
+  - Name: `security-and-docs`
+  - Role: Author runbook, security audit, and SECURITY.md / PLANNING_INDEX.md
+    updates. Owns everything under `docs/` relevant to Slice 11.
+  - Agent Type: security-auditor
+  - Resume: true
+
+- Quality Engineer (Validator)
+  - Name: `validator`
+  - Role: Validate completed work against acceptance criteria (read-only
+    inspection mode). Runs the validation commands. Reports gaps.
+  - Agent Type: quality-engineer
+  - Resume: false
+
+## Step by Step Tasks
+
+### 1. Slice 11 Preflight
+
+- **Task ID**: `slice11-preflight`
+- **Depends On**: none
+- **Assigned To**: `preflight-researcher`
+- **Agent Type**: context7-docs-researcher
+- **Parallel**: false
+- Re-verify HubSpot Webhooks **subscription management** endpoints
+  (create / list / delete) and required `webhooks` scope on the app token.
+- Confirm client-credentials flow details (endpoint, grant type, token
+  lifetime, refresh policy).
+- Confirm that `APP_LIFECYCLE_EVENT` is the correct subscription type id and
+  that `4-1909196` / `4-1916193` are the correct event type ids (cross-check
+  with `apps/api/src/routes/lifecycle.ts`).
+- Produce `docs/slice-11-preflight-notes.md` including a locked config
+  contract listing the exact env vars and their roles.
+
+### 2. App-Level Auth Client
+
+- **Task ID**: `builder-app-auth`
+- **Depends On**: `slice11-preflight`
+- **Assigned To**: `builder-app-auth`
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- TDD: write failing tests first under
+  `apps/api/src/lib/__tests__/hubspot-app-auth.test.ts` covering missing env,
+  success, failure, in-memory cache hit, cache expiry.
+- Implement `apps/api/src/lib/hubspot-app-auth.ts` to pass.
+- Export `getAppAccessToken()` with a typed return; never log secrets.
+
+### 3. Subscription Bootstrap Service
+
+- **Task ID**: `builder-subscription-bootstrap`
+- **Depends On**: `builder-app-auth`
+- **Assigned To**: `builder-subscription-bootstrap`
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- TDD: write failing tests under
+  `apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts`
+  covering: (a) all missing → creates two, (b) partial present → creates one,
+  (c) both present → `alreadyPresent` × 2, (d) list failure propagates,
+  (e) create failure propagates. No "mismatched target URL" case — the
+  subscription API is app-scoped and does not carry a target URL; see
+  Solution Approach.
+- Implement `apps/api/src/lib/hubspot-subscription-bootstrap.ts` exporting
+  `ensureLifecycleSubscriptions({ targetUrl }) -> Report`, where `targetUrl`
+  is a passthrough into the report only (not sent to HubSpot).
+- Diff only on `(subscriptionType, eventTypeId)`.
+
+### 4. Admin Route + Script Shim
+
+- **Task ID**: `builder-admin-route`
+- **Depends On**: `builder-subscription-bootstrap`
+- **Assigned To**: `builder-admin-route`
+- **Agent Type**: backend-engineer
+- **Parallel**: false
+- TDD: write failing tests under
+  `apps/api/src/routes/admin/__tests__/lifecycle-bootstrap.test.ts` for
+  missing token / bad token / success / upstream failure.
+- Implement `POST /admin/lifecycle/bootstrap` with constant-time token
+  comparison using the repo's existing length-safe pattern (`timingSafeEqual`
+  guarded for unequal lengths). Mount it in `apps/api/src/index.ts`
+  **outside `/api/*`** and outside tenant middleware.
+- Implement `apps/api/scripts/lifecycle-bootstrap.ts` as a thin wrapper that
+  reads env, calls the service, prints JSON report, exits 0 on success and
+  non-zero on any upstream/service failure.
+- Add the matching `lifecycle:bootstrap` script entry in
+  `apps/api/package.json`.
+
+### 5. Security + Docs (parallel with Task 4's tail)
+
+- **Task ID**: `security-and-docs`
+- **Depends On**: `builder-subscription-bootstrap`
+- **Assigned To**: `security-and-docs`
+- **Agent Type**: security-auditor
+- **Parallel**: true (may run alongside Task 4 — different files)
+- Write `docs/runbooks/lifecycle-subscription-bootstrap.md`:
+  first-run, rotation of `HUBSPOT_APP_CLIENT_SECRET`, rollback, and
+  operator verification that `LIFECYCLE_TARGET_URL` in the JSON report
+  matches the receiver URL configured in the app's
+  `app-hsmeta.json` / developer-UI webhooks config (since HubSpot's
+  subscription API is app-scoped and does not carry a per-subscription
+  target URL).
+- Write `docs/security/slice-11-audit.md`: route exposure, secret handling,
+  logging posture, preservation of Slice 6 fallback.
+- Update `docs/security/SECURITY.md` with the new admin route and env vars.
+- Update `PLANNING_INDEX.md` to register this plan + the preflight note.
+- Update `.taskmaster/tasks/tasks.json` Slice 11 entry with implementation
+  notes.
+
+### 6. Final Validation
+
+- **Task ID**: `validate-all`
+- **Depends On**: `slice11-preflight`, `builder-app-auth`,
+  `builder-subscription-bootstrap`, `builder-admin-route`,
+  `security-and-docs`
+- **Assigned To**: `validator`
+- **Agent Type**: quality-engineer
+- **Parallel**: false
+- Run all validation commands listed below.
+- Verify every acceptance criterion.
+- Operate in validation mode: inspect and report only, do not modify files.
+
+## Acceptance Criteria
+
+- `pnpm typecheck`, `pnpm lint`, and `pnpm test` all pass from the workspace
+  root on the Slice 11 branch.
+- The three new targeted suites pass:
+  - `apps/api/src/lib/__tests__/hubspot-app-auth.test.ts`
+  - `apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts`
+  - `apps/api/src/routes/admin/__tests__/lifecycle-bootstrap.test.ts`
+- `apps/api/src/routes/lifecycle.ts` and `apps/api/src/lib/tenant-lifecycle.ts`
+  are **unchanged** (verified by `git diff` against `main`).
+- `getAppAccessToken()` acquires a HubSpot app-level token via
+  client-credentials, caches it in memory, and refreshes after expiry.
+- `ensureLifecycleSubscriptions({ targetUrl })` is idempotent: re-running on
+  an already-subscribed app is a no-op that reports `alreadyPresent` for both
+  event types.
+- `LIFECYCLE_TARGET_URL` passes through into the JSON report as-is (HubSpot's
+  subscription API is app-scoped and does not carry a per-subscription target
+  URL, so there is no API-level mismatch case — the runbook handles visual
+  verification against `app-hsmeta.json`).
+- `POST /admin/lifecycle/bootstrap` rejects requests without the internal
+  token (401) and with a wrong token (403), and succeeds with it (200).
+- The admin route's token check uses a length-safe constant-time comparison;
+  the provided token value is never echoed in logs or error payloads.
+- The admin route is **not** mounted under `/api/*`, and does not flow through
+  tenant middleware.
+- Secrets (`HUBSPOT_APP_CLIENT_SECRET`, bearer tokens,
+  `INTERNAL_BOOTSTRAP_TOKEN`) never appear in logs.
+- Slice 6 fallback behavior is unchanged: refresh-token revocation still
+  soft-deactivates the tenant.
+- `docs/slice-11-preflight-notes.md`,
+  `docs/runbooks/lifecycle-subscription-bootstrap.md`,
+  `docs/security/slice-11-audit.md` exist and are linked from
+  `PLANNING_INDEX.md` / `docs/security/SECURITY.md`.
+
+## Validation Commands
+
+Execute these commands to validate the task is complete:
+
+- `pnpm install --frozen-lockfile` — confirm workspace integrity
+- `pnpm test apps/api/src/lib/__tests__/hubspot-app-auth.test.ts apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts apps/api/src/routes/admin/__tests__/lifecycle-bootstrap.test.ts`
+  — targeted Slice 11 suites
+- `pnpm test` — workspace test suite
+- `pnpm typecheck` — workspace typecheck
+- `pnpm lint` — workspace lint
+- `git diff --stat origin/main -- apps/api/src/routes/lifecycle.ts apps/api/src/lib/tenant-lifecycle.ts`
+  — must be empty (0 files changed)
+- the idempotency proof comes from the targeted bootstrap-service test above;
+  do not leave this slice depending on an optional `--dry-run` CLI surface
+
+## Notes
+
+- **Scope discipline**: do NOT introduce journal polling / cursor tables /
+  reconciliation sweeps in this slice. Those belong in a later, explicitly
+  separate slice if ever needed. The shipped webhook receiver + Slice 6
+  fallback is the locked V1 posture.
+- **Tenant isolation**: the bootstrap operates at the **app** level, not the
+  tenant level — it has no `tenant_id` scope because subscriptions are a
+  property of the HubSpot app itself, not a property of any one installed
+  portal. This is deliberate and must be called out in the security audit.
+- **Marketplace posture**: completing Slice 11 is a precondition for
+  marketplace submission, because HubSpot requires the app to subscribe to
+  `APP_LIFECYCLE_EVENT` and prove install/uninstall handling.
+- **Runbook**: the bootstrap is operator-invoked on first deploy per
+  environment. After that it's idempotent; CI can safely call it on every
+  prod deploy as a guardrail.

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -26,9 +26,7 @@
             "id": 9,
             "title": "Install and Verify HubSpot CLI and Vercel CLI",
             "description": "Install both CLIs, verify versions, authenticate where needed, and document their intended use in the stack.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Install latest @hubspot/cli and Vercel CLI. Verify HubSpot CLI can auth and run project/dev commands. Verify Vercel CLI can login and is treated as deployment/preview infrastructure tooling, not the primary data host. Document versions and commands in repo docs.",
             "status": "done",
             "testStrategy": "Run hs --version, hs account auth readiness check, vercel --version, and vercel login/whoami verification before depending on either CLI in implementation.",
@@ -39,9 +37,7 @@
             "id": 2,
             "title": "Setup TypeScript Configurations and Monorepo tsconfig.json",
             "description": "Configure root tsconfig.json with paths for frontend/backend/shared, composite project references, and Google TS style guide compliance.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Create tsconfig.json with 'composite': true, 'paths' mapping @frontend/* to frontend/src/* etc., strict mode enabled. Add package.json with workspaces: ['frontend', 'backend', 'shared']. Use Google naming conventions.",
             "status": "done",
             "testStrategy": "Vitest test: tsc --noEmit should pass without errors on empty projects, verify path resolution by importing shared types in test files first.",
@@ -52,9 +48,7 @@
             "id": 3,
             "title": "Configure Docker Compose with Postgres, Backend, and Frontend Services",
             "description": "Create docker-compose.yml with postgres service, backend dev server, frontend dev server per standards.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Define services: postgres (latest, DATABASE_URL env), backend (node:20, vol mount backend), frontend (node:20, vol mount frontend). Add healthchecks and depends_on for postgres.",
             "status": "done",
             "testStrategy": "Shell script test via Vitest: docker-compose up -d && docker-compose ps shows all services healthy, no errors in logs before implementation.",
@@ -65,9 +59,7 @@
             "id": 4,
             "title": "Setup Environment Variables and Validation with .env.example",
             "description": "Create .env.example with HUBSPOT_APP_ID, EXA_API_KEY, DATABASE_URL and basic validation schema.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Use zod or env-schema for validation. Add validation script in package.json: 'validate-env'. Ensure vars match HubSpot extension docs for crm.record.tab context.",
             "status": "done",
             "testStrategy": "Vitest test: validate-env script passes with sample .env values, fails gracefully with missing vars before any app code.",
@@ -78,9 +70,7 @@
             "id": 5,
             "title": "Configure Linting, Formatting, Husky, and Lint-Staged",
             "description": "Setup ESLint/Prettier per Google TS style guide, husky pre-commit hooks, lint-staged for monorepo.",
-            "dependencies": [
-              2
-            ],
+            "dependencies": [2],
             "details": "Root .eslintrc.js with Google TS rules, .prettierrc. Husky install, lint-staged config for staged files across workspaces. Kebab-case filename lint rule.",
             "status": "done",
             "testStrategy": "Vitest test: Run lint/format on dummy files, husky hooks trigger correctly on git commit simulation before real code.",
@@ -91,9 +81,7 @@
             "id": 6,
             "title": "Initialize Vitest Testing Framework Across Monorepo",
             "description": "Setup Vitest configs for frontend/backend/shared with monorepo workspace support and TDD readiness.",
-            "dependencies": [
-              2
-            ],
+            "dependencies": [2],
             "details": "package.json scripts: 'test', 'test:watch'. vitest.config.ts per workspace with globals, coverage. Hono testing with app.request(), React with jsdom.",
             "status": "done",
             "testStrategy": "Self-test: Vitest passes empty test suite (e.g., test('bootstrap', () => expect(true).toBe(true)) across all workspaces first.",
@@ -104,10 +92,7 @@
             "id": 7,
             "title": "Create CI Skeleton with GitHub Actions Workflow",
             "description": "Add .github/workflows/ci.yml for lint, test, build on push/PR with monorepo path filtering.",
-            "dependencies": [
-              5,
-              6
-            ],
+            "dependencies": [5, 6],
             "details": "Matrix strategy for frontend/backend/shared. Steps: checkout, setup-node/uv, validate-env, lint, vitest, docker-compose build. Selective builds on changed paths.",
             "status": "done",
             "testStrategy": "Local test: act or manual trigger verifies workflow syntax and runs successfully on bootstrap state before full implementation.",
@@ -118,13 +103,7 @@
             "id": 8,
             "title": "Verification: Run Full Bootstrap Tests and Structure Audit",
             "description": "Execute complete bootstrap verification: lint, test, docker up, env validation, HubSpot docs check.",
-            "dependencies": [
-              3,
-              4,
-              5,
-              6,
-              7
-            ],
+            "dependencies": [3, 4, 5, 6, 7],
             "details": "Create verify-bootstrap script: git status clean, docker-compose up healthy, lint/test pass, folder structure audit vs Bulletproof React spec, verify HubSpot crm.record.tab docs integration readiness.",
             "status": "done",
             "testStrategy": "Vitest integration test suite: Run verify-bootstrap script programmatically, assert all checks pass (exit code 0), docker services responsive, no lint errors.",
@@ -141,9 +120,7 @@
         "details": "Create Drizzle schema per https://orm.drizzle.team/docs/sql-schema-declaration: tables for snapshots (company_id, eligibility_state, reason_to_contact, created_at, trust_score), evidence (id, source, timestamp, confidence, content), people (id, company_snapshot_id, name, reason_to_talk, evidence_refs), config (provider_settings, thresholds). Generate migrations. Use Supabase/Postgres. Add TypeScript types in /shared.",
         "testStrategy": "Run migrations, verify schema with Drizzle Studio, insert/query test data via generated client, ensure all required fields present",
         "priority": "high",
-        "dependencies": [
-          "1"
-        ],
+        "dependencies": ["1"],
         "status": "done",
         "subtasks": [
           {
@@ -161,9 +138,7 @@
             "id": 2,
             "title": "Create Tenants/Workspaces Table",
             "description": "Define tenants table with id, hubspot_portal_id (unique), name, created_at, settings jsonb using pgTable.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Use serial/integer for id, varchar for hubspot_portal_id with unique index, text for name, timestamp for created_at, jsonb for settings. Add primary key on id.",
             "status": "done",
             "testStrategy": "Insert tenant record via Drizzle client, verify unique constraint on hubspot_portal_id.",
@@ -174,10 +149,7 @@
             "id": 3,
             "title": "Define Snapshots Table with Tenant Isolation",
             "description": "Create snapshots table including tenant_id FK, company_id, eligibility_state, reason_to_contact, created_at, trust_score with composite indexes.",
-            "dependencies": [
-              1,
-              2
-            ],
+            "dependencies": [1, 2],
             "details": "Add tenant_id integer references tenants(id) onDelete cascade. Composite index on (tenant_id, company_id). Fields: eligibility_state enum, reason_to_contact text, trust_score numeric.",
             "status": "done",
             "testStrategy": "Insert snapshot for tenant A, verify query scoped by tenant_id returns correct data.",
@@ -188,10 +160,7 @@
             "id": 4,
             "title": "Define Evidence Table with Tenant Isolation",
             "description": "Create evidence table with id, tenant_id FK, source, timestamp, confidence, content.",
-            "dependencies": [
-              1,
-              2
-            ],
+            "dependencies": [1, 2],
             "details": "tenant_id references tenants(id) cascade. id uuid or serial, source varchar, timestamp timestamptz, confidence numeric(0,2), content text. Index on (tenant_id, timestamp).",
             "status": "done",
             "testStrategy": "Insert evidence for different tenants, verify tenant-scoped queries isolate data correctly.",
@@ -202,11 +171,7 @@
             "id": 5,
             "title": "Define People Table with Tenant Isolation",
             "description": "Create people table with id, tenant_id FK, company_snapshot_id FK, name, reason_to_talk, evidence_refs jsonb.",
-            "dependencies": [
-              1,
-              2,
-              3
-            ],
+            "dependencies": [1, 2, 3],
             "details": "tenant_id and company_snapshot_id (references snapshots(id)) both cascade. evidence_refs as jsonb array of evidence ids. Composite index (tenant_id, company_snapshot_id).",
             "status": "done",
             "testStrategy": "Insert people linked to snapshot, verify FK constraints and tenant isolation.",
@@ -217,10 +182,7 @@
             "id": 6,
             "title": "Create Provider and LLM Config Tables",
             "description": "Define provider_config and llm_config tables both with tenant_id FK for per-tenant settings.",
-            "dependencies": [
-              1,
-              2
-            ],
+            "dependencies": [1, 2],
             "details": "llm_config: tenant_id, provider_name enum, model_name varchar, api_key_encrypted text, endpoint_url varchar, settings jsonb. provider_config similar structure. Unique constraint (tenant_id, provider_name).",
             "status": "done",
             "testStrategy": "Insert config for tenant A, verify cannot insert duplicate provider for same tenant.",
@@ -231,14 +193,7 @@
             "id": 7,
             "title": "Generate Migrations and Run Schema",
             "description": "Generate and apply Drizzle migrations, verify schema in Supabase with all tenant_id columns and indexes.",
-            "dependencies": [
-              1,
-              2,
-              3,
-              4,
-              5,
-              6
-            ],
+            "dependencies": [1, 2, 3, 4, 5, 6],
             "details": "Run npx drizzle-kit generate:pg && npx drizzle-kit push:pg. Verify via Supabase dashboard or Drizzle Studio. Check FKs cascade on tenant delete.",
             "status": "done",
             "testStrategy": "Run migrations, use Drizzle Studio to verify all tables/columns/indexes/FKs present.",
@@ -249,15 +204,7 @@
             "id": 8,
             "title": "Add TypeScript Types and Tenant Isolation Tests",
             "description": "Export Drizzle types to /shared/types, write tests verifying tenant isolation and cross-tenant leakage prevention.",
-            "dependencies": [
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-              7
-            ],
+            "dependencies": [1, 2, 3, 4, 5, 6, 7],
             "details": "Create index.d.ts exporting InferSelectModel for all tables. Tests: insert tenant A/B data, query tenant A must not see B data. Test FK cascade delete.",
             "status": "done",
             "testStrategy": "Jest/Vitest: 100% coverage on isolation tests, verify query scoping middleware or DB queries filter by tenant_id.",
@@ -274,9 +221,7 @@
         "details": "Scaffold React app with Vite/TS, HubSpot CLI integration. Implement hsMeta context hook to extract current company record (companyId, properties). Create basic tab layout with loading/empty states. Use Bulletproof React modules: features/, entities/, ui/. Verify HubSpot docs for latest crm.record.tab API and context shape.",
         "testStrategy": "Local HubSpot dev server renders extension in company record tab, hsMeta provides company context, basic layout renders without errors",
         "priority": "high",
-        "dependencies": [
-          "1"
-        ],
+        "dependencies": ["1"],
         "status": "done",
         "subtasks": [
           {
@@ -294,9 +239,7 @@
             "id": 2,
             "title": "Configure Project Files for Vite/TS and HubSpot",
             "description": "Create and configure hsproject.json, app.json, app-hsmeta.json with platformVersion 2025.2, scopes, and permittedUrls.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Set location: 'crm.record.tab' in app.json. Add Vite/TS config for React. Include serverless.json if needed. Ensure Bulletproof React structure: features/, entities/, ui/ folders.",
             "status": "done",
             "testStrategy": "Validate JSON schemas with CLI, hs project upload succeeds, permittedUrls allow necessary fetches.",
@@ -307,9 +250,7 @@
             "id": 3,
             "title": "Implement Extension Entry Point with hubspot.extend",
             "description": "Create main extension file using hubspot.extend<'crm.record.tab'> passing context to React Extension component.",
-            "dependencies": [
-              2
-            ],
+            "dependencies": [2],
             "details": "Import from '@hubspot/ui-extensions'. Destructure context and actions. Render <Extension context={context} />. Use TypeScript for type safety per HubSpot docs.",
             "status": "done",
             "testStrategy": "Unit test entry point renders without crashing using createRenderer('crm.record.tab').",
@@ -320,9 +261,7 @@
             "id": 4,
             "title": "Develop hsMeta Context Hook for Company Record",
             "description": "Create custom React hook to extract companyId, properties from context, using fetchCrmObjectProperties and onCrmPropertiesUpdate.",
-            "dependencies": [
-              3
-            ],
+            "dependencies": [3],
             "details": "Place in features/ or entities/. Handle loading states. Access context.portal.id, context.objectTypeId. Fetch company properties relevant to task.",
             "status": "done",
             "testStrategy": "Mock context in Vitest, verify hook returns companyId and properties, test updates trigger re-fetch.",
@@ -333,9 +272,7 @@
             "id": 5,
             "title": "Build Basic Tab Layout with HubSpot UI Components",
             "description": "Design layout using Flex, Text, Tile, LoadingSpinner from @hubspot/ui-extensions for crm.record.tab.",
-            "dependencies": [
-              4
-            ],
+            "dependencies": [4],
             "details": "Structure in ui/ folder per Bulletproof React. Integrate context hook data. Ensure responsive design matching HubSpot native look.",
             "status": "done",
             "testStrategy": "Visual regression tests for layout, component renders correctly with mock props.",
@@ -346,9 +283,7 @@
             "id": 6,
             "title": "Add Loading and Empty States to Extension",
             "description": "Implement loading spinner and empty state UI with proper messaging using HubSpot Alert and Text components.",
-            "dependencies": [
-              5
-            ],
+            "dependencies": [5],
             "details": "Conditional rendering based on context hook state. Show 'Loading company data...' and 'No data available' states. Follow TDD: tests first.",
             "status": "done",
             "testStrategy": "TDD with createRenderer: test loading state shows spinner, empty state shows message, transitions correctly.",
@@ -359,9 +294,7 @@
             "id": 7,
             "title": "Setup Vitest TDD Environment and Verify Integration",
             "description": "Configure Vitest with @hubspot/ui-extensions/testing, write tests for all components, run hs project dev and verify in HubSpot.",
-            "dependencies": [
-              6
-            ],
+            "dependencies": [6],
             "details": "Use createRenderer('crm.record.tab') for all tests. Test context access, states. Lint, build, upload, and inspect in company record tab.",
             "status": "done",
             "testStrategy": "100% test coverage for scaffold, all states pass, extension renders in local HubSpot dev server without console errors.",
@@ -372,12 +305,7 @@
             "id": 8,
             "title": "Create HubSpot developer test account and import mock data",
             "description": "Create a separate HubSpot development/test account, install the app there, and import mock CRM data for realistic company-record testing.",
-            "dependencies": [
-              1,
-              2,
-              6,
-              7
-            ],
+            "dependencies": [1, 2, 6, 7],
             "details": "Use HubSpot CLI configurable or developer test account flow. Prefer isolated developer test account for first validation. Create/import mock company and contact data so crm.record.tab can be tested against realistic target-account scenarios. Include hs test-account create and hs test-account import-data workflow or equivalent current documented HubSpot flow. Ensure at least one target account using hs_is_target_account and several company/contact fixtures covering strong evidence, <3 contacts, empty, stale, degraded, and ineligible states.",
             "status": "done",
             "testStrategy": "Verify the test account exists, the app is installed into it, mock data imports successfully, and the extension renders against real company records in the test account.",
@@ -394,10 +322,7 @@
         "details": "Setup Hono app with CORS for HubSpot origin, Drizzle integration. Create POST /api/snapshot/:companyId that returns {eligibility, reasonToContact, people: [], evidenceRefs, stateFlags}. Add auth middleware for HubSpot app tokens. Use async/await, structured logging. Verify Hono routing patterns from docs.",
         "testStrategy": "curl/postman calls return 200 with mock snapshot JSON matching contract, error handling for invalid companyId, auth required",
         "priority": "high",
-        "dependencies": [
-          "1",
-          "2"
-        ],
+        "dependencies": ["1", "2"],
         "status": "done",
         "subtasks": [
           {
@@ -415,9 +340,7 @@
             "id": 2,
             "title": "Initialize Hono app with CORS middleware for HubSpot",
             "description": "Setup base Hono app with typed Variables, CORS middleware for HubSpot origin, structured logger, and Node.js serve export.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Use new Hono<{Variables: AppVariables}>(), app.use('/api/*', cors({origin: c.env.CORS_ORIGIN})), logger() before handlers. Export serve({fetch: app.fetch}).",
             "status": "done",
             "testStrategy": "Run tests from subtask 1; verify app starts without errors, CORS headers present in responses.",
@@ -428,9 +351,7 @@
             "id": 3,
             "title": "Write TDD tests for auth middleware and 401 responses",
             "description": "Add Vitest tests for bearerAuth middleware: 401 without token, 200 with valid HubSpot app token before implementing endpoint.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Test POST /api/snapshot/:companyId requires Authorization: Bearer <token>. Mock token validation. Verify middleware chaining order.",
             "status": "done",
             "testStrategy": "expect(app.request('POST /api/snapshot/test')).toHaveStatus(401); expect(with token).toHaveStatus(200)",
@@ -441,10 +362,7 @@
             "id": 4,
             "title": "Implement bearerAuth middleware for HubSpot tokens",
             "description": "Add bearerAuth middleware to /api/* routes validating HubSpot app tokens from env or DB whitelist.",
-            "dependencies": [
-              2,
-              3
-            ],
+            "dependencies": [2, 3],
             "details": "import {bearerAuth} from 'hono/bearer-auth'; app.use('/api/*', bearerAuth({token: process.env.HUBSPOT_TOKENS.split(',')})). Set c.set('auth', true) on success.",
             "status": "done",
             "testStrategy": "Pass auth tests from subtask 3; test invalid token returns 401 JSON error.",
@@ -455,9 +373,7 @@
             "id": 5,
             "title": "Write TDD tests for snapshot endpoint responses",
             "description": "Create comprehensive tests for POST /api/snapshot/:companyId: 200 with full contract, 400 invalid ID, 404 not found, using app.request().",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Mock DB responses. Test contract: {eligibilityState, reasonToContact?, people:[], evidenceRefs:[], stateFlags:{stale,etc}}. Verify JSON structure and status codes.\n<info added on 2026-04-10T23:33:07.980Z>\nTenant isolation requirements: All snapshot endpoint tests must verify tenant-scoped data access. Implementation must: (1) extract tenant_id from auth context using tenant resolution middleware after bearerAuth validates HubSpot token, (2) scope all DB queries with WHERE tenant_id = ? filter, (3) ensure response contains only snapshots belonging to the authenticated tenant's portal. Mock DB responses must include tenant_id in filtering logic. Add test cases: tenant A requests snapshot, verify only tenant A data returned; tenant B requests same snapshot ID, verify 404 or access denied; cross-tenant query attempts rejected. Verify bearerAuth middleware (per subtask 4.4) passes tenant context to handlers before DB access.\n</info added on 2026-04-10T23:33:07.980Z>",
             "status": "done",
             "testStrategy": "Vitest: mock db query, expect(c.json(snapshotContract)).toMatchSnapshot(), error cases 400/404.",
@@ -468,9 +384,7 @@
             "id": 6,
             "title": "Integrate Drizzle DB client and implement snapshot query",
             "description": "Setup Drizzle client import, query snapshots table by companyId, map to contract with async/await.",
-            "dependencies": [
-              2
-            ],
+            "dependencies": [2],
             "details": "import db from './db'; In handler: const snapshot = await db.query.snapshots.findFirst({where: eq(snapshots.companyId, id)}); return c.json(mapToContract(snapshot)).\n<info added on 2026-04-10T23:33:18.826Z>\nTENANT ISOLATION UPDATE: Drizzle DB client must always scope queries by tenant_id. Create a tenant-scoped DB helper: getTenantDb(tenantId) that wraps all queries with WHERE tenant_id = ?. The snapshot query must be: db.query.snapshots.findFirst({ where: and(eq(snapshots.tenantId, tenantId), eq(snapshots.companyId, companyId)) }). Never query without tenant filter.\n</info added on 2026-04-10T23:33:18.826Z>",
             "status": "done",
             "testStrategy": "Mock Drizzle queries in tests; verify query params and result mapping.",
@@ -481,11 +395,7 @@
             "id": 7,
             "title": "Add error handling, implement endpoint, verify all tests",
             "description": "Create POST /api/snapshot/:companyId route with auth+CORS+DB+error handling (400 invalid ID, 500 DB error). Run full TDD suite.",
-            "dependencies": [
-              4,
-              5,
-              6
-            ],
+            "dependencies": [4, 5, 6],
             "details": "app.post('/api/snapshot/:companyId', auth, async (c)=>{try{...}catch{e=400/500}}); Use c.req.param('companyId'), structured logging c.get('logger').",
             "status": "done",
             "testStrategy": "All subtasks 1,3,5 tests pass + integration: curl -H 'Authorization: Bearer token' POST /api/snapshot/valid returns 200 contract JSON.",
@@ -502,10 +412,7 @@
         "details": "In /shared/types: Snapshot type with eligibilityState, reasonToContact?: string, people: Person[], evidence: Evidence[], states: StateFlags. Evidence {source, timestamp, confidence, content}. Person {name, title, reasonToTalk, evidenceRefs}. StateFlags {stale, degraded, lowConfidence, ineligible, restricted}. Export for FE/BE use.",
         "testStrategy": "TypeScript compiles without errors, generate mock data validating all union types, coverage for all evidence states",
         "priority": "high",
-        "dependencies": [
-          "1",
-          "2"
-        ],
+        "dependencies": ["1", "2"],
         "status": "done",
         "subtasks": [
           {
@@ -523,9 +430,7 @@
             "id": 2,
             "title": "Define ThresholdConfig and LlmProviderConfig Types",
             "description": "Implement ThresholdConfig { freshnessMaxDays: number, minConfidence: number } and LlmProviderConfig { provider: union of strings, model: string, apiKeyRef: string, endpointUrl?: string }",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Add union type for provider: 'anthropic'|'openai'|'gemini'|'openrouter'|'custom'. Make numbers precise with branded types or constraints. Config-driven, no hardcoded values.",
             "status": "done",
             "testStrategy": "Validate union literals for provider, ensure optional fields handled, numbers >0 constraints",
@@ -536,10 +441,7 @@
             "id": 3,
             "title": "Define ProviderConfig and Update StateFlags Type",
             "description": "Create ProviderConfig { name: string, enabled: boolean, apiKeyRef: string, thresholds: ThresholdConfig } and finalize StateFlags with all 8 QA states",
-            "dependencies": [
-              1,
-              2
-            ],
+            "dependencies": [1, 2],
             "details": "StateFlags: { stale, degraded, lowConfidence, ineligible, restricted, ... } as boolean flags per PRD. ProviderConfig supports multi-provider setup.",
             "status": "done",
             "testStrategy": "Type checks all StateFlags properties exist, ProviderConfig requires thresholds reference",
@@ -550,9 +452,7 @@
             "id": 4,
             "title": "Update Snapshot, Evidence, and Person Types with TenantId",
             "description": "Extend existing Snapshot, Evidence, Person types to include tenantId: string. Scope all fields to tenant context.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Snapshot adds tenantId, evidence: Evidence[], people: Person[] all tenant-scoped. Evidence adds tenantId. Person unchanged structurally but tenant-aware.",
             "status": "done",
             "testStrategy": "Verify tenantId required on Snapshot/Evidence, arrays properly typed, no breaking changes to Person",
@@ -563,9 +463,7 @@
             "id": 5,
             "title": "Implement Tenant-Aware Factory Functions",
             "description": "Create factory functions for Snapshot, Evidence, Person, StateFlags that accept tenantId parameter and enforce tenant isolation.",
-            "dependencies": [
-              4
-            ],
+            "dependencies": [4],
             "details": "Functions like createSnapshot(tenantId: string, ...), createEvidence(tenantId: string, ...). Generate fixtures for tenant A/B isolation testing.",
             "status": "done",
             "testStrategy": "Factories produce valid tenant-scoped objects, tenant A data doesn't leak to tenant B fixtures",
@@ -576,10 +474,7 @@
             "id": 6,
             "title": "Add TypeScript Type Tests for Tenant Scoping",
             "description": "Write TDD type tests verifying tenantId presence, isolation, and factory function correctness per TDD rule.",
-            "dependencies": [
-              4,
-              5
-            ],
+            "dependencies": [4, 5],
             "details": "Use TypeScript's conditional types to test tenantId required everywhere. Verify factory outputs match domain contracts with correct tenant scoping.",
             "status": "done",
             "testStrategy": "Type errors if tenantId missing, fixtures validate multi-tenant isolation, coverage for all types",
@@ -590,12 +485,7 @@
             "id": 7,
             "title": "Export All Domain Types and Run Full Compilation",
             "description": "Export complete domain model from /shared/types for FE/BE use. Verify full TypeScript compilation with all updates.",
-            "dependencies": [
-              3,
-              4,
-              5,
-              6
-            ],
+            "dependencies": [3, 4, 5, 6],
             "details": "Barrel export: export * from './domain-types'. Update any existing imports. Ensure no type errors across shared codebase.",
             "status": "done",
             "testStrategy": "tsc --noEmit succeeds, all exports resolvable, generate mock data validating union types and tenant scoping",
@@ -612,11 +502,7 @@
         "details": "Backend service: fetchHubSpotCompany(companyId) -> check hs_is_target_account boolean. Configurable via DB config table (default: true if missing). Return {eligible: boolean, reason: 'ineligible' | 'unconfigured'}. Cache results 5min. No hardcoding.",
         "testStrategy": "Unit tests: eligible=true/false/missing, integration test with mock HubSpot API, verify fallback behavior",
         "priority": "high",
-        "dependencies": [
-          "2",
-          "4",
-          "5"
-        ],
+        "dependencies": ["2", "4", "5"],
         "status": "done",
         "subtasks": [
           {
@@ -634,9 +520,7 @@
             "id": 2,
             "title": "Setup HubSpot API Client",
             "description": "Initialize @hubspot/api-client with private app access token from environment variables.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Create fetchHubSpotCompany(companyId) function to retrieve company properties including configurable gating property (default 'hs_is_target_account'). Handle API errors gracefully with try-catch. No hardcoded tokens or properties.",
             "status": "done",
             "testStrategy": "Mock API responses in tests from subtask 1 to verify client fetches properties correctly",
@@ -647,10 +531,7 @@
             "id": 3,
             "title": "Implement Eligibility Check Service",
             "description": "Build core logic to evaluate target account eligibility based on fetched property.",
-            "dependencies": [
-              1,
-              2
-            ],
+            "dependencies": [1, 2],
             "details": "Check boolean value of gating property; return {eligible: true, reason: 'eligible'} if true/missing with default true fallback; {eligible: false, reason: 'ineligible'} if false; {eligible: false, reason: 'unconfigured'} if property unusable. Fail safely per PRD.",
             "status": "done",
             "testStrategy": "Validate against test cases from subtask 1: true/false/missing/unconfigured scenarios pass",
@@ -661,10 +542,7 @@
             "id": 4,
             "title": "Add Caching Layer with 5-Minute TTL",
             "description": "Implement result caching to store eligibility outcomes for companyId with 5-minute expiration.",
-            "dependencies": [
-              1,
-              3
-            ],
+            "dependencies": [1, 3],
             "details": "Use in-memory cache (e.g., lru-cache or Redis if available) keyed by companyId. Cache {eligible, reason} on fetch. Check cache first on calls, refresh on miss/expiry. Ensure thread-safe in Hono context.",
             "status": "done",
             "testStrategy": "Test cache hit (no API call, returns cached), miss (fetches and caches), expiry after 5min from subtask 1",
@@ -675,10 +553,7 @@
             "id": 5,
             "title": "Integrate Config-Driven Property Name",
             "description": "Connect to provider_config DB table to read gating property name dynamically.",
-            "dependencies": [
-              1,
-              3
-            ],
+            "dependencies": [1, 3],
             "details": "Query DB for gating_property_name (default 'hs_is_target_account' if missing). Use Drizzle ORM. Cache config reads separately if frequent. Ensure no hardcoding; fallback to default on DB errors.",
             "status": "done",
             "testStrategy": "Tests from subtask 1 verify configurable name: default and custom property scenarios work",
@@ -689,12 +564,7 @@
             "id": 6,
             "title": "Verification and Integration Testing",
             "description": "Run full test suite, integrate into /api/snapshot endpoint, and verify end-to-end.",
-            "dependencies": [
-              2,
-              3,
-              4,
-              5
-            ],
+            "dependencies": [2, 3, 4, 5],
             "details": "Expose eligibility service in Hono backend. Test full flow: companyId -> cached eligibility. Manual verification with real HubSpot token (dev env). Update snapshot contract to include eligibility/reason. Ensure deps on tasks 2,4,5 satisfied.",
             "status": "done",
             "testStrategy": "End-to-end: mock HubSpot + DB, curl endpoint verifies {eligible, reason} in response; measure cache performance",
@@ -711,11 +581,7 @@
         "details": "DB config table: providers {name: 'exa', enabled, apiKeyEncrypted, thresholds}. Abstract ProviderAdapter interface. Exa adapter: minimal company name/domain to Exa Search API, parse recent signals. Configurable freshness (<7d), confidence (>0.7). No hardcoded secrets.",
         "testStrategy": "Toggle provider on/off via config, test Exa calls with mock/stub return signal data, verify thresholds filter results",
         "priority": "medium",
-        "dependencies": [
-          "2",
-          "4",
-          "6"
-        ],
+        "dependencies": ["2", "4", "6"],
         "status": "done",
         "subtasks": [
           {
@@ -733,9 +599,7 @@
             "id": 2,
             "title": "Implement AnthropicAdapter",
             "description": "Build Anthropic-specific LLM adapter reading tenant config and calling Anthropic API with data minimization.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Constructor takes decrypted API key, model name from tenant llm_config. Map LlmOptions to Anthropic Messages API format. Implement streaming support if available. Mock API responses for TDD.",
             "status": "done",
             "testStrategy": "Unit test with mock Anthropic responses: valid completion, rate limit, auth error. Verify no PII in requests.",
@@ -746,9 +610,7 @@
             "id": 3,
             "title": "Implement OpenAiAdapter and CustomOpenAiCompatibleAdapter",
             "description": "Create OpenAI adapter and generic OpenAI-compatible adapter for custom endpoints from tenant config.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Shared base class for OpenAI format. Custom adapter supports endpoint URL override. Handle both Chat Completions and legacy endpoints. Tenant-specific model/API key resolution.",
             "status": "done",
             "testStrategy": "Test OpenAI and custom endpoint with mock responses. Verify tenant A OpenAI vs tenant B custom works.",
@@ -759,9 +621,7 @@
             "id": 4,
             "title": "Implement GeminiAdapter and OpenRouterAdapter",
             "description": "Build adapters for Google Gemini and OpenRouter supporting tenant-specific models and routing.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Gemini: Google Generative AI SDK integration. OpenRouter: Custom headers for model routing. Both read tenant llm_config for API keys/models. Ensure consistent LlmResponse format.",
             "status": "done",
             "testStrategy": "Mock API responses testing completion, token usage, error handling. Cross-verify response normalization.",
@@ -772,12 +632,7 @@
             "id": 5,
             "title": "Develop LlmAdapterFactory",
             "description": "Create factory that resolves tenant-specific LLM adapter from llm_config table with key decryption.",
-            "dependencies": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "dependencies": [1, 2, 3, 4],
             "details": "Method: getAdapter(tenantId: string): Promise<LlmAdapter>. Query DB by tenant_id, decrypt apiKeyEncrypted, instantiate correct adapter class. Graceful fallback for missing config.",
             "status": "done",
             "testStrategy": "Test tenant A\u2192Anthropic, tenant B\u2192OpenAI, missing config\u2192fallback. Verify decryption/isolation.",
@@ -788,9 +643,7 @@
             "id": 6,
             "title": "Update Exa Signal ProviderAdapter",
             "description": "Enhance Exa adapter for per-tenant config from provider_config table with thresholds and freshness.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Read tenant-specific enabled/apiKeyEncrypted/thresholds/freshness from provider_config. Call Exa Search API with company name/domain. Parse signals filtering by configurable confidence/freshness.",
             "status": "done",
             "testStrategy": "Mock Exa API: test thresholds filter results, tenant toggles, freshness <7d. Verify no hardcoded secrets.",
@@ -801,9 +654,7 @@
             "id": 7,
             "title": "Implement Per-Tenant Config Resolution Service",
             "description": "Build service for querying/decrypting provider_config and llm_config tables by tenant_id.",
-            "dependencies": [
-              5
-            ],
+            "dependencies": [5],
             "details": "Shared ConfigResolver class: getLlmConfig(tenantId), getProviderConfig(tenantId, providerName). Handle encryption/decryption. Cache results with TTL. Support multiple providers per tenant.",
             "status": "done",
             "testStrategy": "Integration tests: tenant isolation, decryption, cache hit/miss, missing tenant fallback.",
@@ -814,14 +665,7 @@
             "id": 8,
             "title": "Add Data Minimization and Comprehensive Tests",
             "description": "Implement prompt data minimization guardrails and full TDD suite for adapters/factory.",
-            "dependencies": [
-              2,
-              3,
-              4,
-              5,
-              6,
-              7
-            ],
+            "dependencies": [2, 3, 4, 5, 6, 7],
             "details": "Prompt sanitizer strips PII/CRM dumps. Tests: multi-tenant isolation (A=Anthropic/B=OpenAI), factory resolution, Exa thresholds, missing config fallback, no PII in requests.",
             "status": "done",
             "testStrategy": "End-to-end: tenant scenarios, mock APIs, verify isolation/minimization. Coverage >90% on adapters.",
@@ -838,11 +682,7 @@
         "details": "Snapshot service: aggregate provider signals -> extract dominant signal (most recent/high-confidence) -> generate reason text. Fetch HubSpot contacts (limit 20) -> rank by relevance to signal -> select top 3 with reasonToTalk. Never fabricate. Use fixture data initially.",
         "testStrategy": "Mock provider signals generate valid reason/people, test 0/1/2/3 people cases, verify no fabrication when insufficient data",
         "priority": "medium",
-        "dependencies": [
-          "5",
-          "6",
-          "7"
-        ],
+        "dependencies": ["5", "6", "7"],
         "status": "done",
         "subtasks": [
           {
@@ -860,9 +700,7 @@
             "id": 2,
             "title": "Implement Reason Text Generation",
             "description": "Generate human-readable reason-to-contact text from the dominant signal content.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Map signal types to templated text using signal content fields. Handle edge cases like partial signal data. Return empty string if no dominant signal. Use fixture signals for initial implementation.",
             "status": "done",
             "testStrategy": "TDD with fixtures: verify text generation for different signal types, empty input returns empty, malformed signals handled gracefully.",
@@ -873,9 +711,7 @@
             "id": 3,
             "title": "Implement HubSpot Contact Fetch",
             "description": "Fetch up to 20 contacts associated with the company from HubSpot API.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Integrate HubSpot API client with companyId parameter, limit=20. Mock API responses using fixture data initially. Handle auth and errors. Return empty array on failures.",
             "status": "done",
             "testStrategy": "Mock HubSpot responses: test 0/5/20 contacts returned, error handling, auth middleware integration.",
@@ -886,10 +722,7 @@
             "id": 4,
             "title": "Implement Contact Ranking by Relevance",
             "description": "Rank fetched contacts by relevance to dominant signal using title/role match and recency.",
-            "dependencies": [
-              1,
-              3
-            ],
+            "dependencies": [1, 3],
             "details": "Define scoring function: keyword match on titles/roles to signal content (0-1 score), recency decay. Sort descending. Use fuzzy matching libraries if needed. Fixtures for contacts.",
             "status": "done",
             "testStrategy": "Unit tests: rank scenarios with title matches, recency variations, no-signal skips ranking, ties handled consistently.",
@@ -900,12 +733,7 @@
             "id": 5,
             "title": "Implement People Selection Service",
             "description": "Select top 0-3 ranked contacts and generate reasonToTalk from signal + contact context.",
-            "dependencies": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "dependencies": [1, 2, 3, 4],
             "details": "Slice top 3 from ranked list. Generate reasonToTalk by combining dominant reason text with contact-specific details (e.g., 'Talk to [role] about [signal]'). Support 0 selections gracefully.",
             "status": "done",
             "testStrategy": "Integration tests: 0/1/2/3 people cases, verify reasonToTalk format, no fabrication when <3 contacts available.",
@@ -916,13 +744,7 @@
             "id": 6,
             "title": "Snapshot Service Integration and Edge Case Verification",
             "description": "Integrate all components into snapshot service endpoint and verify all edge cases with TDD.",
-            "dependencies": [
-              1,
-              2,
-              3,
-              4,
-              5
-            ],
+            "dependencies": [1, 2, 3, 4, 5],
             "details": "Wire components into /api/snapshot/:companyId. Use fixture data throughout. Test full data flow. Ensure no fabrication: empty states for no-signal/no-contacts. Update Hono endpoint contract.\n<info added on 2026-04-10T23:33:51.449Z>\nTENANT + LLM PROVIDER UPDATE: Snapshot service integration must pass tenantId through the entire flow: tenant resolution \u2192 eligibility check \u2192 signal fetching (tenant's Exa key) \u2192 LLM reason generation (tenant's LLM provider) \u2192 contact ranking \u2192 snapshot assembly. All fixture data must include tenantId. Test multi-tenant scenario: tenant A gets Anthropic-generated reason, tenant B gets OpenAI-generated reason, both isolated.\n</info added on 2026-04-10T23:33:51.449Z>",
             "status": "done",
             "testStrategy": "End-to-end tests: no-signal empty, 0/1/2/3 people, low-confidence suppression, integration with Tasks 5-7, Postman/curl verification.",
@@ -939,12 +761,7 @@
         "details": "Trust service: evaluate evidence {freshness: timestamp <7d, confidence >0.7, sourceValid}. States: restricted->suppress, stale->flag, lowConf->flag+caution. Configurable thresholds. Backend computes final snapshot states. UI consumes pre-computed flags.",
         "testStrategy": "Unit tests cover all 8 QA states, integration verifies suppression (restricted empty), flags render correctly",
         "priority": "medium",
-        "dependencies": [
-          "5",
-          "6",
-          "7",
-          "8"
-        ],
+        "dependencies": ["5", "6", "7", "8"],
         "status": "done",
         "subtasks": [
           {
@@ -962,9 +779,7 @@
             "id": 2,
             "title": "Implement Freshness Checker",
             "description": "Build freshness evaluation logic to determine if evidence timestamp is fresh (<7 days) or stale based on configurable threshold.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Create isFresh() function comparing evidence.timestamp to current time against threshold from provider_config.days_fresh (default 7). Return {isFresh: boolean, ageDays: number}. Flag stale evidence with visible timestamp.",
             "status": "done",
             "testStrategy": "TDD: Test boundary cases (exactly 7 days, 6.9 days, 7.1 days), configurable thresholds (3 days, 14 days), timezone edge cases.",
@@ -975,9 +790,7 @@
             "id": 3,
             "title": "Implement Confidence Checker",
             "description": "Develop confidence scoring logic to classify evidence as adequate (>0.7) or low-confidence with explicit score display.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Create evaluateConfidence() function checking evidence.confidence against provider_config.min_confidence (default 0.7). Return {isAdequate: boolean, confidenceScore: number}. Low-confidence flags trigger caution UI.",
             "status": "done",
             "testStrategy": "TDD: Test thresholds (0.699\u2192low, 0.701\u2192adequate), configurable values (0.5, 0.9), null/undefined handling.",
@@ -988,9 +801,7 @@
             "id": 4,
             "title": "Implement Source Validator",
             "description": "Create source validity checker for provider response and data parseability to detect degraded sources.",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Build validateSource() function checking provider responding (HTTP 200) + data parseable (JSON schema valid). Return {isValid: boolean, degradationReason?: string}. Degraded sources get distinct flagging from low-confidence.",
             "status": "done",
             "testStrategy": "TDD: Mock provider failures (503, 404, parse errors), valid responses, schema mismatches.",
@@ -1001,12 +812,7 @@
             "id": 5,
             "title": "Implement Suppression Logic",
             "description": "Apply suppression rules: restricted\u2192empty response, stale/lowConf\u2192double warning flags, degraded\u2192system issue flag.",
-            "dependencies": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "dependencies": [1, 2, 3, 4],
             "details": "Create applySuppression() function in TrustEvaluator: if restricted\u2192return empty Snapshot (no evidence, no summary); else compute combined StateFlags and warnings array. Backend pre-computes all flags for UI.",
             "status": "done",
             "testStrategy": "TDD: Verify restricted returns truly empty objects; test stale+lowConf double warning combinations; ensure partial data never leaks from restricted.",
@@ -1017,13 +823,7 @@
             "id": 6,
             "title": "Verification for All 8 QA States",
             "description": "Write comprehensive TDD suite covering all 8 QA states with factory functions, configurable thresholds, and suppression validation.",
-            "dependencies": [
-              1,
-              2,
-              3,
-              4,
-              5
-            ],
+            "dependencies": [1, 2, 3, 4, 5],
             "details": "Use factory functions from Task 5 to generate test evidence for all combinations: fresh/adequate/valid, stale+lowConf+degraded+restricted\u00d72. Test UI flag consumption. Verify configurable thresholds override defaults.",
             "status": "done",
             "testStrategy": "100% coverage of 8 QA states matrix; integration tests verify empty responses for restricted; snapshot tests for flag combinations; threshold mutation testing.",
@@ -1040,12 +840,7 @@
         "details": "Connect frontend to /api/snapshot. Render states: eligible-strong, fewer-contacts, empty, stale(warning), degraded(error), lowConf(caution), ineligible, loading. Evidence modal shows source/timestamp/confidence. Responsive design, accessible.",
         "testStrategy": "Manual QA all 8 states with fixture data, snapshot testing for UI states, evidence modal opens/closes correctly",
         "priority": "medium",
-        "dependencies": [
-          "3",
-          "4",
-          "5",
-          "9"
-        ],
+        "dependencies": ["3", "4", "5", "9"],
         "status": "done",
         "subtasks": [
           {
@@ -1063,9 +858,7 @@
             "id": 2,
             "title": "Write TDD tests for loading state and evidence modal",
             "description": "Test LoadingSpinner renders during API fetch, evidence modal opens/closes correctly with source/timestamp/confidence data using findByTestId()",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Test modal trigger on evidence item click, Modal overlay shows DescriptionList with evidence fields. Verify keyboard accessibility (Escape closes). Test responsive modal on mobile viewport.",
             "status": "done",
             "testStrategy": "Modal open/close cycles 5x, loading spinner visible 2s minimum, all evidence fields populate",
@@ -1076,10 +869,7 @@
             "id": 3,
             "title": "Implement main state renderer component",
             "description": "Create central SnapshotStateRenderer component that maps Snapshot.eligibilityState to specific state handlers using switch or object map pattern",
-            "dependencies": [
-              1,
-              2
-            ],
+            "dependencies": [1, 2],
             "details": "Connect to /api/snapshot via existing hsMeta.companyId. Use Flex/Box layout. Handle loading/error states. Make responsive with HubSpot Tile. Ensure ARIA labels for accessibility.",
             "status": "done",
             "testStrategy": "Component renders correct child state for each snapshot state input",
@@ -1090,9 +880,7 @@
             "id": 4,
             "title": "Implement eligible states (strong + fewer-contacts)",
             "description": "Render full reason + people list (3 vs 1-2) + evidence drill-down triggers for eligible-strong and eligible-fewer-contacts",
-            "dependencies": [
-              3
-            ],
+            "dependencies": [3],
             "details": "Use DescriptionList for reason/people. Table or Flex for people cards with evidence chip/link. eligible-strong shows 3 people, fewer-contacts shows 1-2 + note. Add testId='eligible-strong'",
             "status": "done",
             "testStrategy": "3 people render in strong, 1-2 + note in fewer-contacts, evidence links present",
@@ -1103,9 +891,7 @@
             "id": 5,
             "title": "Implement warning/error states (stale, degraded, lowConf)",
             "description": "Render Alert components: stale(warning) with age indicator, degraded-source(danger/error), lowConf(caution) with confidence score",
-            "dependencies": [
-              3
-            ],
+            "dependencies": [3],
             "details": "Alert variant='warning' for stale with timestamp age text. variant='danger' for degraded. lowConf shows confidence bar + caution text. All maintain reasonToContact.",
             "status": "done",
             "testStrategy": "Correct Alert variant colors, confidence score displays accurately",
@@ -1116,9 +902,7 @@
             "id": 6,
             "title": "Implement empty/ineligible/restricted states",
             "description": "Render explicit messages: empty-no-reason 'No credible reason', ineligible 'Account not eligible', restricted completely empty",
-            "dependencies": [
-              3
-            ],
+            "dependencies": [3],
             "details": "Use Text variant='microcopy' for messages. restricted returns null/empty Box. Add appropriate icons or visual hierarchy. Ensure accessible screen reader text.",
             "status": "done",
             "testStrategy": "Explicit text matches PRD, restricted renders no content",
@@ -1129,12 +913,7 @@
             "id": 7,
             "title": "Implement evidence inspection modal + final verification",
             "description": "Build Modal with evidence details (source/timestamp/confidence) + verify all 8 states responsive/accessible + manual QA",
-            "dependencies": [
-              3,
-              4,
-              5,
-              6
-            ],
+            "dependencies": [3, 4, 5, 6],
             "details": "Modal uses PanelBody/DescriptionListItem for evidence fields. Responsive with max-width. Add close Button variant='secondary'. Final smoke test all states on mobile/desktop.",
             "status": "done",
             "testStrategy": "Manual QA checklist: all 8 states, modal flow, responsive breakpoints, accessibility audit",
@@ -1151,12 +930,7 @@
         "details": "Backend: HubSpot app auth validation, object-level access checks. Encrypt provider keys. Docker-compose: postgres, backend, frontend dev. Local HubSpot extension testing. Verify docs for all stack components (HubSpot, Hono, Drizzle).",
         "testStrategy": "Security audit: no secrets in client, restricted data blocked, docker env works end-to-end, docs verification checklist passed",
         "priority": "medium",
-        "dependencies": [
-          "1",
-          "2",
-          "3",
-          "4"
-        ],
+        "dependencies": ["1", "2", "3", "4"],
         "status": "done",
         "subtasks": [
           {
@@ -1174,9 +948,7 @@
             "id": 2,
             "title": "Enforce Database-Level Tenant Isolation",
             "description": "Update all Drizzle queries and schema to include mandatory tenant_id WHERE clauses and composite indexes",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Modify schema from Task 2: add tenant_id to snapshots, evidence, people, config tables as first column. Create composite indexes (tenant_id, created_at), (tenant_id, company_id). Wrap all queries with tenant filter helper function. Add RLS policies if using Supabase.",
             "status": "done",
             "testStrategy": "Query tests: insert tenant A data, verify tenant B cannot read. Performance test: index usage with EXPLAIN ANALYZE. Migration validation.",
@@ -1187,9 +959,7 @@
             "id": 3,
             "title": "Implement Provider Credential Encryption",
             "description": "Encrypt/decrypt tenant-specific provider API keys at rest using secure key derivation",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Use Node crypto module or libsodium. Store encrypted keys in config table. Create encryptProviderKey(tenant_id, key), decryptProviderKey(tenant_id, encryptedKey) functions. Decrypt only in memory at API call time. Never log plaintext keys.",
             "status": "done",
             "testStrategy": "Roundtrip encryption test, key derivation test, memory leak check, cross-tenant isolation (tenant A cannot decrypt tenant B keys)",
@@ -1200,9 +970,7 @@
             "id": 4,
             "title": "Configure HubSpot Private App Authentication",
             "description": "Set up HubSpot private app with PRIVATE_APP_ACCESS_TOKEN validation and portal context extraction",
-            "dependencies": [
-              1
-            ],
+            "dependencies": [1],
             "details": "Create HubSpot private app in dev account. Frontend sends token in Authorization header. Backend validates via HubSpot API /auth/v3/private-apps/validate. Extract portal_id from response. Update .env.example with token placeholder.",
             "status": "done",
             "testStrategy": "Valid/invalid token tests, portal_id extraction test, token expiry handling",
@@ -1213,9 +981,7 @@
             "id": 5,
             "title": "Finalize Docker-Compose Local Development",
             "description": "Complete docker-compose.yml with postgres, backend, frontend services and tenant-aware volumes",
-            "dependencies": [
-              2
-            ],
+            "dependencies": [2],
             "details": "Update from Task 1: services for postgres (with init scripts), backend (Hono), frontend (Vite dev). Separate volumes per service for tenant isolation. Healthchecks, depends_on. Local HubSpot extension testing via ngrok/tunnel.",
             "status": "done",
             "testStrategy": "docker-compose up end-to-end test, verify all services healthy, tenant middleware works locally",
@@ -1226,9 +992,7 @@
             "id": 6,
             "title": "Setup Test HubSpot Account with Mock Data",
             "description": "Create dedicated HubSpot dev account with multi-tenant mock data covering all 8 QA states",
-            "dependencies": [
-              4
-            ],
+            "dependencies": [4],
             "details": "Two portals: tenant A (eligible-strong, stale, etc.), tenant B (ineligible, restricted). Populate CRM with mock companies/people/evidence. Document connection instructions. Include 8 QA states from Task 9.",
             "status": "done",
             "testStrategy": "Verify data isolation between portals, API queries return correct tenant data",
@@ -1239,9 +1003,7 @@
             "id": 7,
             "title": "Configure Deployment and Vercel/HubSpot CLI",
             "description": "Set up Vercel CLI for preview/deploy and HubSpot CLI for app management with tenant config",
-            "dependencies": [
-              5
-            ],
+            "dependencies": [5],
             "details": "Add vercel.json, hubspot.config.yml. Scripts for preview deploys per tenant. Environment variable mapping for multi-tenant (DATABASE_URL, etc.). HubSpot app private install instructions.",
             "status": "done",
             "testStrategy": "Deploy preview, verify tenant isolation in production-like env, CLI commands work",
@@ -1252,11 +1014,7 @@
             "id": 8,
             "title": "Create Security Artifact Documentation",
             "description": "Document all security measures, tenant isolation, encryption, auth flows for audit and onboarding",
-            "dependencies": [
-              2,
-              3,
-              4
-            ],
+            "dependencies": [2, 3, 4],
             "details": "Create /docs/SECURITY.md covering tenant middleware, DB isolation, encryption, RLS, cross-tenant tests. Include architecture diagram, threat model, compliance checklist (GDPR, SOC2 basics). Verify all stack docs (HubSpot, Hono, Drizzle).",
             "status": "done",
             "testStrategy": "Peer review doc completeness against requirements checklist",
@@ -1267,16 +1025,7 @@
             "id": 9,
             "title": "Full Security Verification and Cross-Tenant Tests",
             "description": "Run comprehensive TDD security audit, verify no leakage, docs standards, end-to-end local dev",
-            "dependencies": [
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-              8
-            ],
+            "dependencies": [1, 2, 3, 4, 5, 6, 7, 8],
             "details": "Write tests: cross-tenant leakage (A sees B data?), encryption roundtrip, middleware rejection, Docker E2E. Security audit checklist. Verify all docs standards. Manual QA all 8 states with isolation.",
             "status": "done",
             "testStrategy": "100% test coverage on security paths, zero leakage incidents, docker-compose works, docs checklist 100% pass",
@@ -1292,9 +1041,7 @@
       "lastModified": "2026-04-15T19:55:40.828Z",
       "taskCount": 11,
       "completedCount": 11,
-      "tags": [
-        "master"
-      ]
+      "tags": ["master"]
     }
   },
   "slice-3-phase-3": {
@@ -1318,9 +1065,7 @@
         "details": "Task ID: tenant-tx. Add apps/api/src/lib/tenant-tx.ts with transaction helpers and tests proving the session variable is set and tenant scoping works under RLS.",
         "testStrategy": "Write failing tests for current_setting and cross-tenant visibility first, confirm failure, implement helpers, and rerun focused plus broad tests.",
         "priority": "high",
-        "dependencies": [
-          "1"
-        ],
+        "dependencies": ["1"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-16T16:30:05.941Z"
@@ -1344,10 +1089,7 @@
         "details": "Task ID: rls-wiring. Add the request-scoped DB middleware after tenantMiddleware in apps/api/src/index.ts, update snapshot route to use c.get('db'), and add cross-tenant regression coverage proving RLS blocks cross-tenant access.",
         "testStrategy": "Write failing route/integration tests first, confirm failure, wire the middleware and route changes, then rerun tests and regression checks.",
         "priority": "high",
-        "dependencies": [
-          "1",
-          "2"
-        ],
+        "dependencies": ["1", "2"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-16T16:38:57.438Z"
@@ -1359,10 +1101,7 @@
         "details": "Task ID: nonce-wiring. Add apps/api/src/middleware/nonce.ts, stash rawBody in hubspot-signature middleware, and reject duplicate replay attempts with 401 replay_detected while preserving tenant-scoped behavior.",
         "testStrategy": "Write failing middleware tests for duplicate and cross-tenant success cases first, confirm failure, implement wiring, and rerun focused plus broad tests.",
         "priority": "high",
-        "dependencies": [
-          "3",
-          "4"
-        ],
+        "dependencies": ["3", "4"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-16T16:41:34.513Z"
@@ -1374,9 +1113,7 @@
         "details": "Task ID: provider-contract-fix. Update the adapter interface, snapshot assembler, wrappers, all signal adapters, and tests so the contract is fetchSignals(tenantId, { companyId, companyName?, domain? }).",
         "testStrategy": "Write failing contract and call-site tests first, confirm failure, implement the interface change, then rerun affected tests and the full suite.",
         "priority": "high",
-        "dependencies": [
-          "4"
-        ],
+        "dependencies": ["4"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-16T16:53:58.804Z"
@@ -1388,10 +1125,7 @@
         "details": "Task ID: hubspot-enrichment. Implement the real adapter, add getCompanyEngagements to apps/api/src/lib/hubspot-client.ts, extend signal factory deps with db and tenantId, and cover both injected and default-construction paths with tests and cassettes.",
         "testStrategy": "Write failing adapter tests first, confirm failure, implement the adapter and client changes, then rerun cassette-backed tests and the full suite.",
         "priority": "high",
-        "dependencies": [
-          "4",
-          "6"
-        ],
+        "dependencies": ["4", "6"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-16T16:59:26.466Z"
@@ -1415,9 +1149,7 @@
         "details": "Task ID: lint-db-imports. Update biome.json so createDatabase is restricted in apps/api/src/routes and apps/api/src/services while legitimate @hap/db schema, type, eq, and sql imports remain allowed.",
         "testStrategy": "Add or run failing lint cases first, confirm the rule catches banned imports but permits allowed ones, implement the config, then rerun lint.",
         "priority": "medium",
-        "dependencies": [
-          "4"
-        ],
+        "dependencies": ["4"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-16T17:05:11.714Z"
@@ -1429,13 +1161,7 @@
         "details": "Task ID: docs-sweep. Update docs/security/SECURITY.md with the RLS and replay-nonce sections and clean stale comments or references, including any necessary CLAUDE.md cleanup from doc-path drift.",
         "testStrategy": "Review docs after implementation against the accepted architecture and acceptance criteria, then verify referenced commands and sections are accurate.",
         "priority": "medium",
-        "dependencies": [
-          "5",
-          "6",
-          "7",
-          "8",
-          "9"
-        ],
+        "dependencies": ["5", "6", "7", "8", "9"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-16T17:07:34.876Z"
@@ -1447,9 +1173,7 @@
         "details": "Task ID: security-audit. Review the completed Phase 3 changes against the intended security posture and record PASS or concrete findings for each area.",
         "testStrategy": "Use code inspection and the implemented tests plus validation commands to determine PASS/FAIL per audited area.",
         "priority": "medium",
-        "dependencies": [
-          "10"
-        ],
+        "dependencies": ["10"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-16T17:12:58.771Z"
@@ -1461,9 +1185,7 @@
         "details": "Task ID: code-review. After security audit passes, push the branch, run CodeRabbit CLI plus an independent review pass, and fix any substantive issues that come back.",
         "testStrategy": "Review tool output, reproduce real findings where needed, fix them under TDD, and rerun the affected validation commands.",
         "priority": "medium",
-        "dependencies": [
-          "11"
-        ],
+        "dependencies": ["11"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-16T17:20:02.791Z"
@@ -1500,9 +1222,7 @@
         "details": "Completed slice. The repo now includes the settings extension surface, tenant-scoped settings APIs, encrypted secret handling, actionable unconfigured guidance, and the supporting security/docs updates described in .claude/tasks/2026-04-16-slice-4-settings-configuration.md.",
         "testStrategy": "Preserve coverage for settings reads/writes, write-only secret behavior, tenant isolation, and the install-to-configure flow.",
         "priority": "high",
-        "dependencies": [
-          "13"
-        ],
+        "dependencies": ["13"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-17T18:20:00.000Z"
@@ -1514,9 +1234,7 @@
         "details": "Completed slice. The repo now carries the Slice 5 production-contract docs, profile-driven HubSpot app config, deployment/runbook material, and pilot-readiness guidance referenced by docs/slice-5-preflight-notes.md and docs/security/slice-5-audit.md.",
         "testStrategy": "Keep profile/config tests, OAuth origin hardening coverage, and deploy/runbook docs aligned with the shipped environment contract.",
         "priority": "high",
-        "dependencies": [
-          "14"
-        ],
+        "dependencies": ["14"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-17T18:20:00.000Z"
@@ -1528,9 +1246,7 @@
         "details": "Completed slice. The tenant lifecycle model, runtime guards, reinstall semantics, offboarding runbook, and Slice 6 security notes are present in the repo per .claude/tasks/2026-04-17-slice-6-install-lifecycle-offboarding.md and docs/runbooks/tenant-offboarding.md.",
         "testStrategy": "Retain tenant lifecycle tests, runtime-offboarding guards, and reinstall verification as future lifecycle work lands.",
         "priority": "high",
-        "dependencies": [
-          "15"
-        ],
+        "dependencies": ["15"],
         "status": "done",
         "subtasks": [],
         "updatedAt": "2026-04-17T18:20:00.000Z"
@@ -1542,9 +1258,7 @@
         "details": "Active PR: #10 (feature/slice-7-lifecycle-webhook-receiver -> main). Adds POST /webhooks/hubspot/lifecycle, exports verifyHubSpotSignatureV3, mounts the route in apps/api/src/index.ts, and proves the behavior with 5 route tests plus 1 index-wiring test. This is transport-only; subscription bootstrap and journal/pull automation remain follow-ups.",
         "testStrategy": "With Postgres up, keep pnpm typecheck and pnpm test green (71 files / 630 tests on the branch) and preserve the lifecycle route, signature, and tenant mutation assertions.",
         "priority": "high",
-        "dependencies": [
-          "16"
-        ],
+        "dependencies": ["16"],
         "status": "in-progress",
         "subtasks": [],
         "updatedAt": "2026-04-17T18:20:00.000Z"
@@ -1556,9 +1270,7 @@
         "details": "Active PR: #9 (feature/slice-8-extension-api-origin-profile -> main). Adds resolveApiBaseUrl(), the __HAP_API_ORIGIN__ Vite define, and 12 tests that pin resolver precedence, config-contract behavior, and built-bundle determinism. This ships the build-time mechanism but still needs the wrapper/upload path to feed API_ORIGIN into the build.",
         "testStrategy": "Keep pnpm typecheck and pnpm test green (73 files / 636 tests on the branch) and preserve resolver, Vite config, and real build assertions.",
         "priority": "high",
-        "dependencies": [
-          "15"
-        ],
+        "dependencies": ["15"],
         "status": "in-progress",
         "subtasks": [],
         "updatedAt": "2026-04-17T18:20:00.000Z"
@@ -1570,9 +1282,7 @@
         "details": "Active PR: #8 (feature/slice-9-hubspot-build-wrapper -> feature/slice-8-extension-api-origin-profile). Adds build-with-profile.ts, build-with-profile-cli.ts, 19 tests, and the build:with-profile package script. This slice depends on Slice 8 and should merge after PR #9 lands.",
         "testStrategy": "Keep pnpm typecheck and pnpm test green (75 files / 655 tests on the branch) and preserve both the unit contract and the end-to-end wrapper-driven Vite build assertion.",
         "priority": "high",
-        "dependencies": [
-          "18"
-        ],
+        "dependencies": ["18"],
         "status": "in-progress",
         "subtasks": [],
         "updatedAt": "2026-04-17T18:20:00.000Z"
@@ -1584,10 +1294,7 @@
         "details": "Active PR: #11 (feature/slice-10-upload-profile-wiring -> feature/slice-9-hubspot-build-wrapper). Wires the real HubSpot upload path to the profile-aware origin contract by threading API_ORIGIN through scripts/hs-project-upload.ts and the programmatic bundler, with import-safe bundler library/CLI split, targeted tests, and e2e upload verification. This slice depends on Slice 9 and should merge after PRs #9 and #8 land.",
         "testStrategy": "Keep pnpm typecheck and pnpm test green (77 files / 679 tests on the branch), preserve upload-runner argv/profile handoff, define-contract tests, and the stubbed-upload e2e verification of bundle output.",
         "priority": "high",
-        "dependencies": [
-          "18",
-          "19"
-        ],
+        "dependencies": ["18", "19"],
         "status": "in-progress",
         "subtasks": [],
         "updatedAt": "2026-04-18T10:35:00.000Z"
@@ -1596,15 +1303,13 @@
         "id": "21",
         "title": "Slice 11 - Lifecycle Subscription Bootstrap and Journal Automation",
         "description": "Complete the documented primary lifecycle automation path by creating HubSpot lifecycle subscriptions and reconciling event ingestion beyond the runtime fallback path.",
-        "details": "Queued follow-up. docs/slice-6-preflight-notes.md and .claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md still point at client-credentials lifecycle subscription management and journal/cursor handling as the primary automation path. PR #10 adds the receiver transport only; this follow-up should decide whether to ship a narrow subscription bootstrap helper first or continue into the fuller journal-ingestion/control-plane plan.",
+        "details": "Queued follow-up. docs/slice-6-preflight-notes.md and .claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md still point at client-credentials lifecycle subscription management and journal/cursor handling as the primary automation path. PR #10 adds the receiver transport only; this follow-up should decide whether to ship a narrow subscription bootstrap helper first or continue into the fuller journal-ingestion/control-plane plan.\n\nImplementation note (2026-04-18): scope narrowed to subscription bootstrap only (axis B). Journal/cursor ingestion (axis C) deferred. Receiver transport (axis A) shipped in Slice 7. Slice 6 fallback (D) preserved unchanged. See .claude/tasks/2026-04-18-slice-11-lifecycle-subscription-bootstrap.md.",
         "testStrategy": "Re-verify current HubSpot docs, write failing tests around subscription/journal auth and idempotent lifecycle application, and preserve Slice 6 fallback behavior as the safety net.",
         "priority": "medium",
-        "dependencies": [
-          "17"
-        ],
-        "status": "pending",
+        "dependencies": ["17"],
+        "status": "in_progress",
         "subtasks": [],
-        "updatedAt": "2026-04-17T18:20:00.000Z"
+        "updatedAt": "2026-04-18T12:00:00.000Z"
       }
     ],
     "metadata": {

--- a/PLANNING_INDEX.md
+++ b/PLANNING_INDEX.md
@@ -48,15 +48,19 @@ Important:
 - `docs/phase-6-doc-alignment.md`
 - `docs/slice-5-preflight-notes.md`
 - `docs/slice-6-preflight-notes.md`
+- `docs/slice-11-preflight-notes.md`
 - `docs/runbooks/tenant-offboarding.md`
+- `docs/runbooks/lifecycle-subscription-bootstrap.md`
 - `docs/security/slice-5-audit.md`
 - `docs/security/slice-6-audit.md`
+- `docs/security/slice-11-audit.md`
 - `.claude/tasks/2026-04-16-slice-3-phase-3-rls-card-bundling.md`
 - `.claude/tasks/2026-04-16-slice-4-settings-configuration.md`
 - `.claude/tasks/2026-04-17-slice-5-production-marketplace-readiness.md`
 - `.claude/tasks/2026-04-17-slice-6-install-lifecycle-offboarding.md`
 - `.claude/tasks/2026-04-17-slice-7-lifecycle-journal-ingestion.md`
 - `.claude/tasks/2026-04-17-slice-10-upload-profile-wiring.md`
+- `.claude/tasks/2026-04-18-slice-11-lifecycle-subscription-bootstrap.md`
 - `docs/superpowers/plans/2026-04-14-slice-1-core-domain.md`
 - `docs/superpowers/plans/2026-04-15-slice-2-live-integrations.md`
 - `docs/superpowers/plans/2026-04-15-slice-3-oauth-public-app.md`
@@ -92,24 +96,31 @@ If someone is joining active implementation now, read in this order:
 ## 5. Best current source documents in ChatPRD
 
 ### Implementation Plan
+
 https://app.chatprd.ai/chat/9a823a82-230a-4d69-99f2-8f8ab0ad85bf?doc=7321e14b-ada3-4265-a4e9-d1cda84dfe55&vers=e4f12945-0e88-4975-bd8f-faa2edc0ce54
 
 ### AI Coding Rules & Standards
+
 https://app.chatprd.ai/chat/8f94764f-40d2-4ec7-af32-6acddc224c80?doc=7d454b45-7ac2-4c28-83d6-76570c9b245e
 
 ### Product Brief for AI Development
+
 https://app.chatprd.ai/chat/a6cc6c7f-f81a-44cd-a58f-d0a103a62ae8?doc=b39ce5e7-480e-44f1-9fe8-88bc591308f4
 
 ### Repo Draft & Execution Checklist
+
 https://app.chatprd.ai/chat/b3484579-353d-439d-9126-da35d7955fde?doc=d1591ae5-b3cd-4595-8238-a6005502d785&vers=464aa340-0564-4bf8-a397-7ac60b838948
 
 ### Security / Permission Gate
+
 https://app.chatprd.ai/chat/fec5394b-cfd7-48ba-96e9-2356656ef0d0?doc=ed0efb92-7e4e-4716-8674-f9013e8f01e8&vers=327f5454-212c-46c7-8c05-d27dc2100ab7
 
 ### Spec for AI Prototyping
+
 https://app.chatprd.ai/chat/2cdfb7f1-cd53-4fc1-8b99-383cbd2a06c4?doc=deacf6b3-ef2f-4930-a4fa-0d48019cb2d4&vers=0fef3cf0-b259-4d87-a733-5bbacfc1e1cb
 
 ### QA & Verification Plan
+
 https://app.chatprd.ai/chat/1ebac952-f6d6-461b-8c4b-982e49146e8b?doc=7aed1d8b-2b0d-4b37-bb52-9bfdedec013a&vers=ef0be73a-faa2-44bb-a8f9-235af86a894b
 
 ---

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "lifecycle:bootstrap": "tsx scripts/lifecycle-bootstrap.ts"
   },
   "dependencies": {
     "@hap/config": "workspace:*",

--- a/apps/api/scripts/lifecycle-bootstrap.ts
+++ b/apps/api/scripts/lifecycle-bootstrap.ts
@@ -1,0 +1,48 @@
+/**
+ * Slice 11 Task 4 — CLI shim for lifecycle subscription bootstrap.
+ *
+ * Invokes `ensureLifecycleSubscriptions` directly (no HTTP). Intended for
+ * operators running via `pnpm --filter @hap/api lifecycle:bootstrap`.
+ *
+ * Exit codes:
+ *   0 — success; JSON report printed to stdout.
+ *   1 — unexpected / generic error; `{ error: "internal_error" }` on stderr.
+ *   2 — misconfiguration (missing `LIFECYCLE_TARGET_URL`).
+ *   3 — `SubscriptionBootstrapError`; redacted shape on stderr.
+ *
+ * Never prints bearer tokens, raw error messages, or response bodies.
+ */
+
+import {
+  ensureLifecycleSubscriptions,
+  SubscriptionBootstrapError,
+} from "../src/lib/hubspot-subscription-bootstrap";
+
+async function main(): Promise<void> {
+  const targetUrl = process.env.LIFECYCLE_TARGET_URL;
+  if (!targetUrl || targetUrl.length === 0) {
+    process.stderr.write("lifecycle-bootstrap: LIFECYCLE_TARGET_URL is required\n");
+    process.exit(2);
+  }
+
+  try {
+    const report = await ensureLifecycleSubscriptions({ targetUrl });
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(0);
+  } catch (err) {
+    if (err instanceof SubscriptionBootstrapError) {
+      const payload = {
+        error: "upstream_failure",
+        stage: err.stage,
+        status: err.status,
+        eventTypeId: err.eventTypeId,
+      };
+      process.stderr.write(`${JSON.stringify(payload)}\n`);
+      process.exit(3);
+    }
+    process.stderr.write(`${JSON.stringify({ error: "internal_error" })}\n`);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { authMiddleware } from "./middleware/auth";
 import { type CorrelationVariables, correlationMiddleware } from "./middleware/correlation";
 import { nonceMiddleware } from "./middleware/nonce";
 import { type TenantVariables, tenantMiddleware } from "./middleware/tenant";
+import { createLifecycleBootstrapRoute } from "./routes/admin/lifecycle-bootstrap";
 import { lifecycleWebhookRoutes } from "./routes/lifecycle";
 import { createOAuthRoutes } from "./routes/oauth";
 import { settingsRoutes } from "./routes/settings";
@@ -123,6 +124,11 @@ app.route(
 // so they skip auth/tenant/nonce middleware. Authenticity is proven by the
 // route's internal v3 signature check (see routes/lifecycle.ts).
 app.route("/webhooks/hubspot/lifecycle", lifecycleWebhookRoutes({ db: getDb() }));
+
+// Operator-only lifecycle subscription bootstrap — mounted OUTSIDE `/api/*`
+// and the tenant middleware because it is gated on a static internal token
+// rather than a HubSpot-signed request. Mirrors the webhook mount posture.
+app.route("/admin/lifecycle", createLifecycleBootstrapRoute());
 
 // Composed middleware chain for /api/* routes: auth -> tenant -> route.
 app.use("/api/*", authMiddleware());

--- a/apps/api/src/lib/__tests__/hubspot-app-auth.test.ts
+++ b/apps/api/src/lib/__tests__/hubspot-app-auth.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Slice 11 Task 2 — HubSpot app-level auth client (client-credentials flow).
+ *
+ * Covers `../hubspot-app-auth.ts`:
+ *   - Required env validation (HUBSPOT_APP_CLIENT_ID, HUBSPOT_APP_CLIENT_SECRET,
+ *     HUBSPOT_APP_ID) — missing any one throws a clear error that NEVER
+ *     includes the suspected secret value.
+ *   - Successful token fetch — form-urlencoded body with grant_type,
+ *     client_id, client_secret, and space-separated scopes; Content-Type
+ *     header set.
+ *   - Error path — non-2xx token-endpoint response throws with a clean
+ *     message that strips any response body content (secrets-paranoid).
+ *   - Cache — second call inside TTL does NOT re-fetch; second call AFTER
+ *     `expires_in - 60s` elapsed does re-fetch.
+ *
+ * Zero network access — every test injects a fake `fetch`. Time is
+ * controlled via an injected `nowMs`. Env is injected per-test so module
+ * state never leaks across cases.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetAppAuthCache,
+  AppAuthError,
+  getAppAccessToken,
+  HUBSPOT_APP_AUTH_SCOPES,
+  HUBSPOT_APP_TOKEN_URL,
+} from "../hubspot-app-auth";
+
+const BASE_ENV: NodeJS.ProcessEnv = {
+  HUBSPOT_APP_ID: "1234567",
+  HUBSPOT_APP_CLIENT_ID: "client-id-xxx",
+  HUBSPOT_APP_CLIENT_SECRET: "client-secret-yyy",
+};
+
+function successResponse(body: {
+  access_token: string;
+  expires_in: number;
+  token_type?: string;
+}): Response {
+  return new Response(JSON.stringify({ token_type: "bearer", ...body }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  __resetAppAuthCache();
+});
+
+describe("getAppAccessToken — env validation", () => {
+  it("throws when HUBSPOT_APP_CLIENT_ID is missing", async () => {
+    const env = { ...BASE_ENV };
+    delete env.HUBSPOT_APP_CLIENT_ID;
+    const fetchImpl = vi.fn();
+    await expect(
+      getAppAccessToken({
+        env,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/HUBSPOT_APP_CLIENT_ID/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("throws when HUBSPOT_APP_CLIENT_SECRET is missing", async () => {
+    const env = { ...BASE_ENV };
+    delete env.HUBSPOT_APP_CLIENT_SECRET;
+    const fetchImpl = vi.fn();
+    await expect(
+      getAppAccessToken({
+        env,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/HUBSPOT_APP_CLIENT_SECRET/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("throws when HUBSPOT_APP_ID is missing", async () => {
+    const env = { ...BASE_ENV };
+    delete env.HUBSPOT_APP_ID;
+    const fetchImpl = vi.fn();
+    await expect(
+      getAppAccessToken({
+        env,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/HUBSPOT_APP_ID/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("missing-env error message never includes the suspected secret value", async () => {
+    const env = { ...BASE_ENV };
+    delete env.HUBSPOT_APP_CLIENT_SECRET;
+    const fetchImpl = vi.fn();
+    await expect(
+      getAppAccessToken({
+        env,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.not.stringContaining("client-secret-yyy"),
+      }) as unknown as Error,
+    );
+  });
+});
+
+describe("getAppAccessToken — successful fetch", () => {
+  it("POSTs x-www-form-urlencoded with grant_type, client_id, client_secret, scopes", async () => {
+    const fetchImpl = vi.fn(async () =>
+      successResponse({ access_token: "TOKEN-1", expires_in: 1800 }),
+    );
+    const token = await getAppAccessToken({
+      env: BASE_ENV,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      nowMs: () => 1_000_000,
+    });
+    expect(token).toBe("TOKEN-1");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const [url, init] = call;
+    expect(url).toBe(HUBSPOT_APP_TOKEN_URL);
+    expect(init.method).toBe("POST");
+    const headers = new Headers(init.headers);
+    expect(headers.get("content-type")).toMatch(/application\/x-www-form-urlencoded/);
+
+    const body = init.body as string;
+    const params = new URLSearchParams(body);
+    expect(params.get("grant_type")).toBe("client_credentials");
+    expect(params.get("client_id")).toBe("client-id-xxx");
+    expect(params.get("client_secret")).toBe("client-secret-yyy");
+    expect(params.get("scope")).toBe(HUBSPOT_APP_AUTH_SCOPES);
+    expect(HUBSPOT_APP_AUTH_SCOPES).toBe(
+      "developer.webhooks_journal.subscriptions.read developer.webhooks_journal.subscriptions.write",
+    );
+  });
+});
+
+describe("getAppAccessToken — error path", () => {
+  it("throws AppAuthError on non-2xx and does NOT include the response body in the message", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            message: "bad credentials — secret was client-secret-yyy",
+            correlationId: "abc-123",
+          }),
+          { status: 401, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const err = await getAppAccessToken({
+      env: BASE_ENV,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    }).catch((e: unknown) => e as Error);
+
+    expect(err).toBeInstanceOf(AppAuthError);
+    expect((err as Error).message).not.toContain("client-secret-yyy");
+    expect((err as Error).message).toMatch(/401/);
+  });
+
+  it("throws AppAuthError when fetch itself rejects (network error) without leaking secret", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNRESET while posting client_secret=client-secret-yyy");
+    });
+    const err = await getAppAccessToken({
+      env: BASE_ENV,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    }).catch((e: unknown) => e as Error);
+
+    expect(err).toBeInstanceOf(AppAuthError);
+    expect((err as Error).message).not.toContain("client-secret-yyy");
+  });
+});
+
+describe("getAppAccessToken — cache behavior", () => {
+  it("returns cached token on second call within effective TTL (fetch called once)", async () => {
+    const fetchImpl = vi.fn(async () =>
+      successResponse({ access_token: "TOKEN-A", expires_in: 1800 }),
+    );
+    const t0 = 1_000_000;
+    const first = await getAppAccessToken({
+      env: BASE_ENV,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      nowMs: () => t0,
+    });
+    // 1000s later — well inside (1800 - 60)s effective window.
+    const second = await getAppAccessToken({
+      env: BASE_ENV,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      nowMs: () => t0 + 1_000_000,
+    });
+    expect(first).toBe("TOKEN-A");
+    expect(second).toBe("TOKEN-A");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after (expires_in - 60)s effective expiry elapses", async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      return successResponse({
+        access_token: call === 1 ? "TOKEN-1" : "TOKEN-2",
+        expires_in: 1800,
+      });
+    });
+    const t0 = 1_000_000;
+    const first = await getAppAccessToken({
+      env: BASE_ENV,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      nowMs: () => t0,
+    });
+    // Jump to just past the effective expiry: (1800 - 60) * 1000 ms = 1_740_000 ms.
+    const second = await getAppAccessToken({
+      env: BASE_ENV,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      nowMs: () => t0 + 1_740_001,
+    });
+    expect(first).toBe("TOKEN-1");
+    expect(second).toBe("TOKEN-2");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("trusts expires_in from the response (short TTL expires sooner)", async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      return successResponse({
+        access_token: call === 1 ? "SHORT-1" : "SHORT-2",
+        expires_in: 120, // 2 minutes — effective window is 60s.
+      });
+    });
+    const t0 = 5_000_000;
+    await getAppAccessToken({
+      env: BASE_ENV,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      nowMs: () => t0,
+    });
+    // 61s later — past the (120 - 60)s effective window.
+    const second = await getAppAccessToken({
+      env: BASE_ENV,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      nowMs: () => t0 + 61_000,
+    });
+    expect(second).toBe("SHORT-2");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts
+++ b/apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Slice 11 Task 3 — idempotent ensure/diff of HubSpot app lifecycle subscriptions.
+ *
+ * Covers `../hubspot-subscription-bootstrap.ts`:
+ *   - all-missing -> creates both install + uninstall
+ *   - partial-present -> only creates the missing one
+ *   - both-present -> no creates
+ *   - list error (non-2xx) -> typed error, no creates attempted
+ *   - create error (non-2xx) -> typed error identifying which eventTypeId failed
+ *   - secrets posture -> errors must not contain the bearer token
+ *
+ * Zero network access: every test injects fetchImpl + getToken.
+ */
+
+import { describe, expect, it } from "vitest";
+import { HUBSPOT_LIFECYCLE_EVENT_IDS } from "../../routes/lifecycle";
+import {
+  ensureLifecycleSubscriptions,
+  HUBSPOT_SUBSCRIPTIONS_URL,
+  SubscriptionBootstrapError,
+} from "../hubspot-subscription-bootstrap";
+
+const INSTALL = HUBSPOT_LIFECYCLE_EVENT_IDS.APP_INSTALL;
+const UNINSTALL = HUBSPOT_LIFECYCLE_EVENT_IDS.APP_UNINSTALL;
+
+const TOKEN = "bearer-token-shhh-secret";
+const TARGET_URL = "https://example.com/api/lifecycle";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function makeFetch(responses: Response[]): {
+  fetchImpl: typeof fetch;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  let i = 0;
+  const fetchImpl = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: RequestInit,
+  ): Promise<Response> => {
+    calls.push({ url: String(input), init });
+    const response = responses[i++];
+    if (!response) throw new Error(`unexpected fetch call index ${i - 1}`);
+    return response;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function getToken(): Promise<string> {
+  return Promise.resolve(TOKEN);
+}
+
+describe("ensureLifecycleSubscriptions — URL contract", () => {
+  it("exports the locked webhooks-journal subscriptions URL", () => {
+    expect(HUBSPOT_SUBSCRIPTIONS_URL).toBe(
+      "https://api.hubapi.com/webhooks-journal/subscriptions/2026-03",
+    );
+  });
+});
+
+describe("ensureLifecycleSubscriptions — all missing", () => {
+  it("creates both install and uninstall subscriptions", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      jsonResponse({ results: [] }),
+      jsonResponse({
+        id: "sub-install-1",
+        subscriptionType: "APP_LIFECYCLE_EVENT",
+        eventTypeId: INSTALL,
+      }),
+      jsonResponse({
+        id: "sub-uninstall-2",
+        subscriptionType: "APP_LIFECYCLE_EVENT",
+        eventTypeId: UNINSTALL,
+      }),
+    ]);
+
+    const report = await ensureLifecycleSubscriptions({
+      targetUrl: TARGET_URL,
+      fetchImpl,
+      getToken,
+    });
+
+    expect(report.targetUrl).toBe(TARGET_URL);
+    expect(report.alreadyPresent).toEqual([]);
+    expect(report.created).toEqual([
+      { eventTypeId: INSTALL, subscriptionId: "sub-install-1" },
+      { eventTypeId: UNINSTALL, subscriptionId: "sub-uninstall-2" },
+    ]);
+
+    expect(calls).toHaveLength(3);
+    const listCall = calls[0]!;
+    const createInstall = calls[1]!;
+    const createUninstall = calls[2]!;
+    expect(listCall.url).toBe(HUBSPOT_SUBSCRIPTIONS_URL);
+    expect(listCall.init?.method ?? "GET").toBe("GET");
+    expect((listCall.init?.headers as Record<string, string> | undefined)?.Authorization).toBe(
+      `Bearer ${TOKEN}`,
+    );
+
+    // First create call is install
+    expect(createInstall.url).toBe(HUBSPOT_SUBSCRIPTIONS_URL);
+    expect(createInstall.init?.method).toBe("POST");
+    const headers1 = createInstall.init?.headers as Record<string, string>;
+    expect(headers1.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(headers1["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(String(createInstall.init?.body))).toEqual({
+      subscriptionType: "APP_LIFECYCLE_EVENT",
+      eventTypeId: INSTALL,
+    });
+
+    // Second create is uninstall
+    expect(JSON.parse(String(createUninstall.init?.body))).toEqual({
+      subscriptionType: "APP_LIFECYCLE_EVENT",
+      eventTypeId: UNINSTALL,
+    });
+  });
+});
+
+describe("ensureLifecycleSubscriptions — partial present", () => {
+  it("creates only the missing subscription and reports the existing one", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      jsonResponse({
+        results: [
+          {
+            id: "existing-install",
+            subscriptionType: "APP_LIFECYCLE_EVENT",
+            eventTypeId: INSTALL,
+          },
+        ],
+      }),
+      jsonResponse({
+        id: "new-uninstall",
+        subscriptionType: "APP_LIFECYCLE_EVENT",
+        eventTypeId: UNINSTALL,
+      }),
+    ]);
+
+    const report = await ensureLifecycleSubscriptions({
+      targetUrl: TARGET_URL,
+      fetchImpl,
+      getToken,
+    });
+
+    expect(report.alreadyPresent).toEqual([
+      { eventTypeId: INSTALL, subscriptionId: "existing-install" },
+    ]);
+    expect(report.created).toEqual([{ eventTypeId: UNINSTALL, subscriptionId: "new-uninstall" }]);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("ignores unrelated subscription entries and only creates missing lifecycle events", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      jsonResponse({
+        results: [
+          {
+            id: "noise-1",
+            subscriptionType: "OBJECT_CREATION",
+            eventTypeId: "other-thing",
+          },
+          {
+            id: "existing-uninstall",
+            subscriptionType: "APP_LIFECYCLE_EVENT",
+            eventTypeId: UNINSTALL,
+          },
+        ],
+      }),
+      jsonResponse({
+        id: "new-install",
+        subscriptionType: "APP_LIFECYCLE_EVENT",
+        eventTypeId: INSTALL,
+      }),
+    ]);
+
+    const report = await ensureLifecycleSubscriptions({
+      targetUrl: TARGET_URL,
+      fetchImpl,
+      getToken,
+    });
+
+    expect(report.created).toEqual([{ eventTypeId: INSTALL, subscriptionId: "new-install" }]);
+    expect(report.alreadyPresent).toEqual([
+      { eventTypeId: UNINSTALL, subscriptionId: "existing-uninstall" },
+    ]);
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe("ensureLifecycleSubscriptions — both present", () => {
+  it("makes no create calls and returns both in alreadyPresent sorted by eventTypeId", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      jsonResponse({
+        results: [
+          {
+            id: "u-id",
+            subscriptionType: "APP_LIFECYCLE_EVENT",
+            eventTypeId: UNINSTALL,
+          },
+          {
+            id: "i-id",
+            subscriptionType: "APP_LIFECYCLE_EVENT",
+            eventTypeId: INSTALL,
+          },
+        ],
+      }),
+    ]);
+
+    const report = await ensureLifecycleSubscriptions({
+      targetUrl: TARGET_URL,
+      fetchImpl,
+      getToken,
+    });
+
+    expect(report.created).toEqual([]);
+    expect(report.alreadyPresent).toEqual([
+      { eventTypeId: INSTALL, subscriptionId: "i-id" },
+      { eventTypeId: UNINSTALL, subscriptionId: "u-id" },
+    ]);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("ensureLifecycleSubscriptions — error paths", () => {
+  it("throws a typed error when the list call returns non-2xx and does not attempt creates", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      new Response("unauthorized", {
+        status: 401,
+        headers: { "content-type": "text/plain" },
+      }),
+    ]);
+
+    const err = await ensureLifecycleSubscriptions({
+      targetUrl: TARGET_URL,
+      fetchImpl,
+      getToken,
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(SubscriptionBootstrapError);
+    const typed = err as SubscriptionBootstrapError;
+    expect(typed.stage).toBe("list");
+    expect(typed.status).toBe(401);
+    expect(typed.message).not.toContain(TOKEN);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("throws a typed error with the failing eventTypeId when a create call returns non-2xx", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      jsonResponse({ results: [] }),
+      new Response("bad request", {
+        status: 400,
+        headers: { "content-type": "text/plain" },
+      }),
+    ]);
+
+    const err = await ensureLifecycleSubscriptions({
+      targetUrl: TARGET_URL,
+      fetchImpl,
+      getToken,
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(SubscriptionBootstrapError);
+    const typed = err as SubscriptionBootstrapError;
+    expect(typed.stage).toBe("create");
+    expect(typed.status).toBe(400);
+    expect(typed.eventTypeId).toBe(INSTALL);
+    expect(typed.message).not.toContain(TOKEN);
+    // list + first (failing) create only — second create NOT attempted
+    expect(calls).toHaveLength(2);
+  });
+
+  it("error messages never contain the bearer token even on unexpected JSON shapes", async () => {
+    const { fetchImpl } = makeFetch([
+      new Response(JSON.stringify({ error: "nope", token: TOKEN }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+
+    const err = await ensureLifecycleSubscriptions({
+      targetUrl: TARGET_URL,
+      fetchImpl,
+      getToken,
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(SubscriptionBootstrapError);
+    expect((err as Error).message).not.toContain(TOKEN);
+  });
+});

--- a/apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts
+++ b/apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts
@@ -224,6 +224,73 @@ describe("ensureLifecycleSubscriptions — both present", () => {
     ]);
     expect(calls).toHaveLength(1);
   });
+
+  it("normalizes numeric subscription ids from the list response to strings", async () => {
+    // Per docs/slice-11-preflight-notes.md §2, HubSpot's webhooks-journal
+    // subscriptions API returns `id` as a number (e.g. `"id": 60001005`).
+    // The list filter must accept numeric ids and coerce them to strings,
+    // otherwise existing subscriptions are silently skipped and we would
+    // duplicate-create them.
+    const { fetchImpl, calls } = makeFetch([
+      jsonResponse({
+        results: [
+          {
+            id: 60001005,
+            subscriptionType: "APP_LIFECYCLE_EVENT",
+            eventTypeId: INSTALL,
+          },
+          {
+            id: 60001006,
+            subscriptionType: "APP_LIFECYCLE_EVENT",
+            eventTypeId: UNINSTALL,
+          },
+        ],
+      }),
+    ]);
+
+    const report = await ensureLifecycleSubscriptions({
+      targetUrl: TARGET_URL,
+      fetchImpl,
+      getToken,
+    });
+
+    expect(report.created).toEqual([]);
+    expect(report.alreadyPresent).toEqual([
+      { eventTypeId: INSTALL, subscriptionId: "60001005" },
+      { eventTypeId: UNINSTALL, subscriptionId: "60001006" },
+    ]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("normalizes numeric subscription ids from the create response to strings", async () => {
+    // Same numeric-id shape must be honored on create responses.
+    const { fetchImpl, calls } = makeFetch([
+      jsonResponse({ results: [] }),
+      jsonResponse({
+        id: 60001111,
+        subscriptionType: "APP_LIFECYCLE_EVENT",
+        eventTypeId: INSTALL,
+      }),
+      jsonResponse({
+        id: 60002222,
+        subscriptionType: "APP_LIFECYCLE_EVENT",
+        eventTypeId: UNINSTALL,
+      }),
+    ]);
+
+    const report = await ensureLifecycleSubscriptions({
+      targetUrl: TARGET_URL,
+      fetchImpl,
+      getToken,
+    });
+
+    expect(report.created).toEqual([
+      { eventTypeId: INSTALL, subscriptionId: "60001111" },
+      { eventTypeId: UNINSTALL, subscriptionId: "60002222" },
+    ]);
+    expect(report.alreadyPresent).toEqual([]);
+    expect(calls).toHaveLength(3);
+  });
 });
 
 describe("ensureLifecycleSubscriptions — error paths", () => {

--- a/apps/api/src/lib/hubspot-app-auth.ts
+++ b/apps/api/src/lib/hubspot-app-auth.ts
@@ -1,0 +1,168 @@
+/**
+ * Slice 11 Task 2 — HubSpot app-level auth client (client-credentials flow).
+ *
+ * Provides a single export — {@link getAppAccessToken} — that returns a
+ * bearer token scoped to the HubSpot webhooks-journal subscriptions API.
+ *
+ * Behavior locked by `docs/slice-11-preflight-notes.md`:
+ *   - POST https://api.hubapi.com/oauth/v1/token,
+ *     Content-Type: application/x-www-form-urlencoded,
+ *     form fields: grant_type=client_credentials, client_id, client_secret,
+ *     scope=<space-separated read + write scopes>.
+ *   - Response `{ access_token, expires_in, token_type }` is cached in-memory.
+ *     Cache TTL trusts `expires_in` from the response and subtracts 60s skew.
+ *   - `HUBSPOT_APP_ID` is required (for log correlation) but is NOT sent to
+ *     the token endpoint.
+ *
+ * Secrets posture:
+ *   - `HUBSPOT_APP_CLIENT_SECRET` and the returned bearer token MUST NOT
+ *     appear in logs, thrown error messages, or response bodies re-thrown
+ *     to callers.
+ *   - Missing-env errors name the variable but never its value.
+ *   - Non-2xx responses surface status code + HubSpot correlationId only.
+ */
+
+export const HUBSPOT_APP_TOKEN_URL = "https://api.hubapi.com/oauth/v1/token";
+
+export const HUBSPOT_APP_AUTH_SCOPES =
+  "developer.webhooks_journal.subscriptions.read developer.webhooks_journal.subscriptions.write";
+
+const SKEW_MS = 60_000;
+
+export class AppAuthError extends Error {
+  readonly status?: number;
+  readonly correlationId?: string;
+  constructor(message: string, opts?: { status?: number; correlationId?: string }) {
+    super(message);
+    this.name = "AppAuthError";
+    this.status = opts?.status;
+    this.correlationId = opts?.correlationId;
+  }
+}
+
+type CacheEntry = {
+  clientId: string;
+  token: string;
+  expiresAtMs: number;
+};
+
+// Module-scoped single-slot cache. The app-auth identity is app-global, so
+// one slot is enough. We still key on clientId so a clientId change in the
+// environment forces a re-fetch rather than returning a stale token for the
+// previous app identity.
+let cache: CacheEntry | null = null;
+
+/** Test-only: clear the module-scoped cache. Not exported from the package index. */
+export function __resetAppAuthCache(): void {
+  cache = null;
+}
+
+export type GetAppAccessTokenOptions = {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  nowMs?: () => number;
+};
+
+function requireEnv(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new AppAuthError(`missing required env var: ${name}`);
+  }
+  return value;
+}
+
+type HubSpotTokenResponseBody = {
+  access_token?: unknown;
+  expires_in?: unknown;
+  token_type?: unknown;
+};
+
+async function safeReadCorrelationId(response: Response): Promise<string | undefined> {
+  try {
+    const body = (await response.clone().json()) as { correlationId?: unknown };
+    if (typeof body.correlationId === "string") return body.correlationId;
+  } catch {
+    // Non-JSON body — ignore. We will not echo the body itself.
+  }
+  return undefined;
+}
+
+/**
+ * Fetch (or return cached) an app-level bearer token for the HubSpot
+ * client-credentials flow.
+ *
+ * The returned token is suitable for the webhooks-journal subscriptions
+ * management API (`/webhooks-journal/subscriptions/2026-03`).
+ *
+ * @throws {AppAuthError} when required env is missing, when the token
+ *   endpoint returns non-2xx, or when the underlying fetch rejects. Error
+ *   messages NEVER include the client secret or the bearer token.
+ */
+export async function getAppAccessToken(options: GetAppAccessTokenOptions = {}): Promise<string> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const nowMs = options.nowMs ?? Date.now;
+
+  // Validate env eagerly so a cached token can never mask a subsequent
+  // mis-configuration.
+  const clientId = requireEnv(env, "HUBSPOT_APP_CLIENT_ID");
+  const clientSecret = requireEnv(env, "HUBSPOT_APP_CLIENT_SECRET");
+  requireEnv(env, "HUBSPOT_APP_ID");
+
+  const now = nowMs();
+  if (cache && cache.clientId === clientId && cache.expiresAtMs > now) {
+    return cache.token;
+  }
+
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: clientId,
+    client_secret: clientSecret,
+    scope: HUBSPOT_APP_AUTH_SCOPES,
+  });
+
+  let response: Response;
+  try {
+    response = await fetchImpl(HUBSPOT_APP_TOKEN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+  } catch {
+    // Intentionally drop the underlying error message — it may echo back
+    // request bodies (some runtimes include the POST body in connection
+    // error strings). Preserve only the fact that the network call failed.
+    throw new AppAuthError("hubspot token endpoint network error");
+  }
+
+  if (!response.ok) {
+    const correlationId = await safeReadCorrelationId(response);
+    throw new AppAuthError(`hubspot token endpoint returned ${response.status}`, {
+      status: response.status,
+      correlationId,
+    });
+  }
+
+  let parsed: HubSpotTokenResponseBody;
+  try {
+    parsed = (await response.json()) as HubSpotTokenResponseBody;
+  } catch {
+    throw new AppAuthError("hubspot token endpoint returned non-json body");
+  }
+  const accessToken = parsed.access_token;
+  const expiresIn = parsed.expires_in;
+  if (typeof accessToken !== "string" || accessToken.length === 0) {
+    throw new AppAuthError("hubspot token endpoint response missing access_token");
+  }
+  if (typeof expiresIn !== "number" || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new AppAuthError("hubspot token endpoint response missing valid expires_in");
+  }
+
+  const effectiveLifetimeMs = Math.max(expiresIn * 1000 - SKEW_MS, 0);
+  cache = {
+    clientId,
+    token: accessToken,
+    expiresAtMs: now + effectiveLifetimeMs,
+  };
+  return accessToken;
+}

--- a/apps/api/src/lib/hubspot-subscription-bootstrap.ts
+++ b/apps/api/src/lib/hubspot-subscription-bootstrap.ts
@@ -1,0 +1,227 @@
+/**
+ * Slice 11 Task 3 — idempotent ensure/diff of HubSpot app lifecycle
+ * subscriptions on the webhooks-journal API.
+ *
+ * Behavior locked by `docs/slice-11-preflight-notes.md`:
+ *   - GET  https://api.hubapi.com/webhooks-journal/subscriptions/2026-03
+ *     returns `{ results: [{ id, subscriptionType, eventTypeId, ... }] }`.
+ *   - POST https://api.hubapi.com/webhooks-journal/subscriptions/2026-03
+ *     with body `{ subscriptionType: "APP_LIFECYCLE_EVENT", eventTypeId }`.
+ *   - The subscription API is app-scoped. Target URL is NOT transmitted on
+ *     the wire (it is configured on the app itself). We still echo the
+ *     caller's `targetUrl` back in the returned report for observability.
+ *
+ * Secrets posture:
+ *   - Bearer token is obtained from `getAppAccessToken()` and only placed
+ *     on outbound `Authorization` headers.
+ *   - Thrown error messages MUST NOT contain the bearer token or any
+ *     response body. Only HTTP status + the eventTypeId that failed.
+ */
+
+import { HUBSPOT_LIFECYCLE_EVENT_IDS } from "../routes/lifecycle";
+import { getAppAccessToken } from "./hubspot-app-auth";
+
+export const HUBSPOT_SUBSCRIPTIONS_URL =
+  "https://api.hubapi.com/webhooks-journal/subscriptions/2026-03";
+
+const LIFECYCLE_SUBSCRIPTION_TYPE = "APP_LIFECYCLE_EVENT";
+
+const REQUIRED_EVENT_TYPE_IDS: readonly string[] = [
+  HUBSPOT_LIFECYCLE_EVENT_IDS.APP_INSTALL,
+  HUBSPOT_LIFECYCLE_EVENT_IDS.APP_UNINSTALL,
+];
+
+export type SubscriptionEntry = {
+  eventTypeId: string;
+  subscriptionId: string;
+};
+
+export type EnsureLifecycleSubscriptionsReport = {
+  targetUrl: string;
+  created: SubscriptionEntry[];
+  alreadyPresent: SubscriptionEntry[];
+};
+
+export type EnsureLifecycleSubscriptionsOptions = {
+  targetUrl: string;
+  fetchImpl?: typeof fetch;
+  getToken?: () => Promise<string>;
+};
+
+export class SubscriptionBootstrapError extends Error {
+  readonly stage: "list" | "create";
+  readonly status?: number;
+  readonly eventTypeId?: string;
+  constructor(
+    message: string,
+    opts: { stage: "list" | "create"; status?: number; eventTypeId?: string },
+  ) {
+    super(message);
+    this.name = "SubscriptionBootstrapError";
+    this.stage = opts.stage;
+    this.status = opts.status;
+    this.eventTypeId = opts.eventTypeId;
+  }
+}
+
+type ListResultItem = {
+  id?: unknown;
+  subscriptionType?: unknown;
+  eventTypeId?: unknown;
+};
+
+type ListResponseBody = {
+  results?: unknown;
+};
+
+type CreateResponseBody = {
+  id?: unknown;
+  subscriptionType?: unknown;
+  eventTypeId?: unknown;
+};
+
+function byEventTypeId(a: SubscriptionEntry, b: SubscriptionEntry): number {
+  if (a.eventTypeId < b.eventTypeId) return -1;
+  if (a.eventTypeId > b.eventTypeId) return 1;
+  return 0;
+}
+
+async function listLifecycleSubscriptions(
+  fetchImpl: typeof fetch,
+  token: string,
+): Promise<Map<string, string>> {
+  let response: Response;
+  try {
+    response = await fetchImpl(HUBSPOT_SUBSCRIPTIONS_URL, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    });
+  } catch (_cause) {
+    throw new SubscriptionBootstrapError("failed to reach HubSpot subscriptions list endpoint", {
+      stage: "list",
+    });
+  }
+
+  if (!response.ok) {
+    throw new SubscriptionBootstrapError(
+      `HubSpot subscriptions list returned non-2xx status ${response.status}`,
+      { stage: "list", status: response.status },
+    );
+  }
+
+  let body: ListResponseBody;
+  try {
+    body = (await response.json()) as ListResponseBody;
+  } catch (_cause) {
+    throw new SubscriptionBootstrapError("HubSpot subscriptions list returned invalid JSON", {
+      stage: "list",
+      status: response.status,
+    });
+  }
+
+  const existing = new Map<string, string>();
+  const results = Array.isArray(body.results) ? body.results : [];
+  for (const raw of results) {
+    const item = raw as ListResultItem;
+    if (
+      typeof item.id === "string" &&
+      typeof item.eventTypeId === "string" &&
+      item.subscriptionType === LIFECYCLE_SUBSCRIPTION_TYPE &&
+      REQUIRED_EVENT_TYPE_IDS.includes(item.eventTypeId)
+    ) {
+      // First write wins; duplicates should not happen but we don't overwrite.
+      if (!existing.has(item.eventTypeId)) {
+        existing.set(item.eventTypeId, item.id);
+      }
+    }
+  }
+  return existing;
+}
+
+async function createLifecycleSubscription(
+  fetchImpl: typeof fetch,
+  token: string,
+  eventTypeId: string,
+): Promise<string> {
+  let response: Response;
+  try {
+    response = await fetchImpl(HUBSPOT_SUBSCRIPTIONS_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        subscriptionType: LIFECYCLE_SUBSCRIPTION_TYPE,
+        eventTypeId,
+      }),
+    });
+  } catch (_cause) {
+    throw new SubscriptionBootstrapError(
+      `failed to reach HubSpot subscriptions create endpoint for eventTypeId ${eventTypeId}`,
+      { stage: "create", eventTypeId },
+    );
+  }
+
+  if (!response.ok) {
+    throw new SubscriptionBootstrapError(
+      `HubSpot subscriptions create returned non-2xx status ${response.status} for eventTypeId ${eventTypeId}`,
+      { stage: "create", status: response.status, eventTypeId },
+    );
+  }
+
+  let body: CreateResponseBody;
+  try {
+    body = (await response.json()) as CreateResponseBody;
+  } catch (_cause) {
+    throw new SubscriptionBootstrapError(
+      `HubSpot subscriptions create returned invalid JSON for eventTypeId ${eventTypeId}`,
+      { stage: "create", status: response.status, eventTypeId },
+    );
+  }
+
+  if (typeof body.id !== "string" || body.id.length === 0) {
+    throw new SubscriptionBootstrapError(
+      `HubSpot subscriptions create response missing id for eventTypeId ${eventTypeId}`,
+      { stage: "create", status: response.status, eventTypeId },
+    );
+  }
+
+  return body.id;
+}
+
+export async function ensureLifecycleSubscriptions(
+  options: EnsureLifecycleSubscriptionsOptions,
+): Promise<EnsureLifecycleSubscriptionsReport> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const getToken = options.getToken ?? (() => getAppAccessToken());
+
+  const token = await getToken();
+  const existing = await listLifecycleSubscriptions(fetchImpl, token);
+
+  const alreadyPresent: SubscriptionEntry[] = [];
+  const created: SubscriptionEntry[] = [];
+
+  for (const eventTypeId of REQUIRED_EVENT_TYPE_IDS) {
+    const existingId = existing.get(eventTypeId);
+    if (typeof existingId === "string") {
+      alreadyPresent.push({ eventTypeId, subscriptionId: existingId });
+      continue;
+    }
+    const subscriptionId = await createLifecycleSubscription(fetchImpl, token, eventTypeId);
+    created.push({ eventTypeId, subscriptionId });
+  }
+
+  alreadyPresent.sort(byEventTypeId);
+  created.sort(byEventTypeId);
+
+  return {
+    targetUrl: options.targetUrl,
+    created,
+    alreadyPresent,
+  };
+}

--- a/apps/api/src/lib/hubspot-subscription-bootstrap.ts
+++ b/apps/api/src/lib/hubspot-subscription-bootstrap.ts
@@ -86,6 +86,19 @@ function byEventTypeId(a: SubscriptionEntry, b: SubscriptionEntry): number {
   return 0;
 }
 
+/**
+ * HubSpot's webhooks-journal subscriptions API returns `id` as a NUMBER in
+ * practice (see `docs/slice-11-preflight-notes.md` §2 sample payload with
+ * `"id": 60001005`). Accept both string and finite number; normalize to
+ * string. Returns null for anything else (including empty strings and
+ * non-finite numbers like NaN / Infinity).
+ */
+function coerceSubscriptionId(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
 async function listLifecycleSubscriptions(
   fetchImpl: typeof fetch,
   token: string,
@@ -126,15 +139,16 @@ async function listLifecycleSubscriptions(
   const results = Array.isArray(body.results) ? body.results : [];
   for (const raw of results) {
     const item = raw as ListResultItem;
+    const id = coerceSubscriptionId(item.id);
     if (
-      typeof item.id === "string" &&
+      id !== null &&
       typeof item.eventTypeId === "string" &&
       item.subscriptionType === LIFECYCLE_SUBSCRIPTION_TYPE &&
       REQUIRED_EVENT_TYPE_IDS.includes(item.eventTypeId)
     ) {
       // First write wins; duplicates should not happen but we don't overwrite.
       if (!existing.has(item.eventTypeId)) {
-        existing.set(item.eventTypeId, item.id);
+        existing.set(item.eventTypeId, id);
       }
     }
   }
@@ -184,14 +198,15 @@ async function createLifecycleSubscription(
     );
   }
 
-  if (typeof body.id !== "string" || body.id.length === 0) {
+  const id = coerceSubscriptionId(body.id);
+  if (id === null) {
     throw new SubscriptionBootstrapError(
       `HubSpot subscriptions create response missing id for eventTypeId ${eventTypeId}`,
       { stage: "create", status: response.status, eventTypeId },
     );
   }
 
-  return body.id;
+  return id;
 }
 
 export async function ensureLifecycleSubscriptions(

--- a/apps/api/src/routes/admin/__tests__/lifecycle-bootstrap.test.ts
+++ b/apps/api/src/routes/admin/__tests__/lifecycle-bootstrap.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for POST /admin/lifecycle/bootstrap — guarded admin endpoint that
+ * invokes `ensureLifecycleSubscriptions` via a DI-friendly factory.
+ *
+ * Security contract:
+ *   - Auth is a shared `X-Internal-Bootstrap-Token` header compared against
+ *     `INTERNAL_BOOTSTRAP_TOKEN` using length-safe constant-time comparison.
+ *   - Responses never leak the internal token, bearer, body, or raw error.
+ */
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type EnsureLifecycleSubscriptionsOptions,
+  type EnsureLifecycleSubscriptionsReport,
+  SubscriptionBootstrapError,
+} from "../../../lib/hubspot-subscription-bootstrap";
+import { createLifecycleBootstrapRoute } from "../lifecycle-bootstrap";
+
+const VALID_TOKEN = "internal-bootstrap-token-0123456789";
+const TARGET_URL = "https://example.com/webhooks/hubspot/lifecycle";
+
+function mount(
+  deps: {
+    ensure?: (
+      opts: EnsureLifecycleSubscriptionsOptions,
+    ) => Promise<EnsureLifecycleSubscriptionsReport>;
+    env?: Record<string, string | undefined>;
+  } = {},
+) {
+  const app = new Hono();
+  app.route("/admin/lifecycle", createLifecycleBootstrapRoute(deps));
+  return app;
+}
+
+function goodReport(): EnsureLifecycleSubscriptionsReport {
+  return {
+    targetUrl: TARGET_URL,
+    created: [{ eventTypeId: "4-1909196", subscriptionId: "sub-install-1" }],
+    alreadyPresent: [{ eventTypeId: "4-1916193", subscriptionId: "sub-uninstall-1" }],
+  };
+}
+
+describe("POST /admin/lifecycle/bootstrap", () => {
+  it("returns 401 when X-Internal-Bootstrap-Token is missing", async () => {
+    const ensure =
+      vi.fn<
+        (opts: EnsureLifecycleSubscriptionsOptions) => Promise<EnsureLifecycleSubscriptionsReport>
+      >();
+    const app = mount({
+      ensure,
+      env: {
+        INTERNAL_BOOTSTRAP_TOKEN: VALID_TOKEN,
+        LIFECYCLE_TARGET_URL: TARGET_URL,
+      },
+    });
+
+    const res = await app.request("/admin/lifecycle/bootstrap", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "missing_internal_token" });
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when token has the same length but wrong value", async () => {
+    const ensure =
+      vi.fn<
+        (opts: EnsureLifecycleSubscriptionsOptions) => Promise<EnsureLifecycleSubscriptionsReport>
+      >();
+    const wrong = VALID_TOKEN.split("").reverse().join("");
+    expect(wrong.length).toBe(VALID_TOKEN.length);
+
+    const app = mount({
+      ensure,
+      env: {
+        INTERNAL_BOOTSTRAP_TOKEN: VALID_TOKEN,
+        LIFECYCLE_TARGET_URL: TARGET_URL,
+      },
+    });
+
+    const res = await app.request("/admin/lifecycle/bootstrap", {
+      method: "POST",
+      headers: { "X-Internal-Bootstrap-Token": wrong },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "invalid_internal_token" });
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when token has a different length than the configured token", async () => {
+    const ensure =
+      vi.fn<
+        (opts: EnsureLifecycleSubscriptionsOptions) => Promise<EnsureLifecycleSubscriptionsReport>
+      >();
+    const app = mount({
+      ensure,
+      env: {
+        INTERNAL_BOOTSTRAP_TOKEN: VALID_TOKEN,
+        LIFECYCLE_TARGET_URL: TARGET_URL,
+      },
+    });
+
+    const res = await app.request("/admin/lifecycle/bootstrap", {
+      method: "POST",
+      headers: { "X-Internal-Bootstrap-Token": "short" },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "invalid_internal_token" });
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when INTERNAL_BOOTSTRAP_TOKEN env is missing (misconfigured)", async () => {
+    const ensure =
+      vi.fn<
+        (opts: EnsureLifecycleSubscriptionsOptions) => Promise<EnsureLifecycleSubscriptionsReport>
+      >();
+    const app = mount({
+      ensure,
+      env: {
+        INTERNAL_BOOTSTRAP_TOKEN: undefined,
+        LIFECYCLE_TARGET_URL: TARGET_URL,
+      },
+    });
+
+    const res = await app.request("/admin/lifecycle/bootstrap", {
+      method: "POST",
+      headers: { "X-Internal-Bootstrap-Token": VALID_TOKEN },
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "bootstrap_not_configured" });
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when LIFECYCLE_TARGET_URL env is missing", async () => {
+    const ensure =
+      vi.fn<
+        (opts: EnsureLifecycleSubscriptionsOptions) => Promise<EnsureLifecycleSubscriptionsReport>
+      >();
+    const app = mount({
+      ensure,
+      env: {
+        INTERNAL_BOOTSTRAP_TOKEN: VALID_TOKEN,
+        LIFECYCLE_TARGET_URL: undefined,
+      },
+    });
+
+    const res = await app.request("/admin/lifecycle/bootstrap", {
+      method: "POST",
+      headers: { "X-Internal-Bootstrap-Token": VALID_TOKEN },
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "bootstrap_not_configured" });
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with the report when token is valid and ensure succeeds", async () => {
+    const report = goodReport();
+    const ensure =
+      vi.fn<
+        (opts: EnsureLifecycleSubscriptionsOptions) => Promise<EnsureLifecycleSubscriptionsReport>
+      >();
+    ensure.mockResolvedValue(report);
+    const app = mount({
+      ensure,
+      env: {
+        INTERNAL_BOOTSTRAP_TOKEN: VALID_TOKEN,
+        LIFECYCLE_TARGET_URL: TARGET_URL,
+      },
+    });
+
+    const res = await app.request("/admin/lifecycle/bootstrap", {
+      method: "POST",
+      headers: { "X-Internal-Bootstrap-Token": VALID_TOKEN },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(report);
+    expect(ensure).toHaveBeenCalledTimes(1);
+    const firstCall = ensure.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    expect(firstCall?.[0]).toMatchObject({ targetUrl: TARGET_URL });
+  });
+
+  it("returns 502 with redacted shape when ensure throws SubscriptionBootstrapError", async () => {
+    const err = new SubscriptionBootstrapError("redacted-internal-detail", {
+      stage: "create",
+      status: 502,
+      eventTypeId: "4-1909196",
+    });
+    const ensure = vi.fn(async () => {
+      throw err;
+    });
+    const app = mount({
+      ensure,
+      env: {
+        INTERNAL_BOOTSTRAP_TOKEN: VALID_TOKEN,
+        LIFECYCLE_TARGET_URL: TARGET_URL,
+      },
+    });
+
+    const res = await app.request("/admin/lifecycle/bootstrap", {
+      method: "POST",
+      headers: { "X-Internal-Bootstrap-Token": VALID_TOKEN },
+    });
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: "upstream_failure",
+      stage: "create",
+      status: 502,
+      eventTypeId: "4-1909196",
+    });
+    // Must not leak the error message, bearer tokens, or internal token.
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain("redacted-internal-detail");
+    expect(serialized).not.toContain(VALID_TOKEN);
+  });
+
+  it("returns 500 with opaque error when ensure throws a generic Error", async () => {
+    const ensure = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const app = mount({
+      ensure,
+      env: {
+        INTERNAL_BOOTSTRAP_TOKEN: VALID_TOKEN,
+        LIFECYCLE_TARGET_URL: TARGET_URL,
+      },
+    });
+
+    const res = await app.request("/admin/lifecycle/bootstrap", {
+      method: "POST",
+      headers: { "X-Internal-Bootstrap-Token": VALID_TOKEN },
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "internal_error" });
+    expect(JSON.stringify(body)).not.toContain("boom");
+  });
+});

--- a/apps/api/src/routes/admin/lifecycle-bootstrap.ts
+++ b/apps/api/src/routes/admin/lifecycle-bootstrap.ts
@@ -1,0 +1,104 @@
+/**
+ * Slice 11 Task 4 — guarded admin bootstrap route.
+ *
+ * POST /admin/lifecycle/bootstrap
+ *   Mounted OUTSIDE /api/* and the tenant middleware because it is an
+ *   operator-only endpoint whose auth is a shared static token, not a HubSpot
+ *   signed request. This mirrors the `/webhooks/hubspot/lifecycle` mount
+ *   posture.
+ *
+ * Auth:
+ *   - Header `X-Internal-Bootstrap-Token` compared against
+ *     `INTERNAL_BOOTSTRAP_TOKEN` using length-safe `timingSafeEqual`.
+ *   - Missing env  -> 503 `bootstrap_not_configured` (never 500).
+ *   - Missing header -> 401 `missing_internal_token`.
+ *   - Wrong header -> 403 `invalid_internal_token` (same code for wrong
+ *     length or wrong content — no length oracle).
+ *
+ * Success:
+ *   - 200 JSON = `EnsureLifecycleSubscriptionsReport` verbatim.
+ *
+ * Failure:
+ *   - `SubscriptionBootstrapError` -> 502 with `{ error, stage, status,
+ *     eventTypeId }` only. Never leaks bearer, raw body, or internal token.
+ *   - Any other Error -> 500 `internal_error` with no message propagation.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import { Hono } from "hono";
+import {
+  ensureLifecycleSubscriptions as defaultEnsure,
+  type EnsureLifecycleSubscriptionsOptions,
+  type EnsureLifecycleSubscriptionsReport,
+  SubscriptionBootstrapError,
+} from "../../lib/hubspot-subscription-bootstrap";
+
+const INTERNAL_TOKEN_HEADER = "x-internal-bootstrap-token";
+
+export type LifecycleBootstrapDeps = {
+  ensure?: (
+    opts: EnsureLifecycleSubscriptionsOptions,
+  ) => Promise<EnsureLifecycleSubscriptionsReport>;
+  env?: Record<string, string | undefined>;
+};
+
+/**
+ * Length-safe constant-time string compare. Mirrors the pattern in
+ * `apps/api/src/middleware/hubspot-signature.ts`: `timingSafeEqual` throws on
+ * unequal `Buffer.byteLength`, so we gate on a length check and still burn a
+ * compare against a padded buffer to keep timing roughly flat.
+ */
+function safeEquals(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.byteLength !== bBuf.byteLength) {
+    const padded = Buffer.alloc(aBuf.byteLength);
+    timingSafeEqual(aBuf, padded);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+export function createLifecycleBootstrapRoute(deps: LifecycleBootstrapDeps = {}) {
+  const ensure = deps.ensure ?? defaultEnsure;
+  const env = deps.env ?? process.env;
+
+  const app = new Hono();
+
+  app.post("/bootstrap", async (c) => {
+    const expectedToken = env.INTERNAL_BOOTSTRAP_TOKEN;
+    const targetUrl = env.LIFECYCLE_TARGET_URL;
+
+    if (!expectedToken || expectedToken.length === 0 || !targetUrl || targetUrl.length === 0) {
+      return c.json({ error: "bootstrap_not_configured" }, 503);
+    }
+
+    const provided = c.req.header(INTERNAL_TOKEN_HEADER);
+    if (!provided || provided.length === 0) {
+      return c.json({ error: "missing_internal_token" }, 401);
+    }
+    if (!safeEquals(provided, expectedToken)) {
+      return c.json({ error: "invalid_internal_token" }, 403);
+    }
+
+    try {
+      const report = await ensure({ targetUrl });
+      return c.json(report, 200);
+    } catch (err) {
+      if (err instanceof SubscriptionBootstrapError) {
+        return c.json(
+          {
+            error: "upstream_failure",
+            stage: err.stage,
+            status: err.status,
+            eventTypeId: err.eventTypeId,
+          },
+          502,
+        );
+      }
+      return c.json({ error: "internal_error" }, 500);
+    }
+  });
+
+  return app;
+}

--- a/biome.json
+++ b/biome.json
@@ -36,6 +36,7 @@
       "!**/coverage",
       "!**/.next",
       "!**/drizzle",
+      "!**/.bundle-artifacts",
       "!.worktrees",
       "!.taskmaster"
     ]

--- a/docs/runbooks/lifecycle-subscription-bootstrap.md
+++ b/docs/runbooks/lifecycle-subscription-bootstrap.md
@@ -82,8 +82,8 @@ not tenant-level, operation.
 {
   "targetUrl": "https://api.example.com/webhooks/hubspot/lifecycle",
   "created": [
-    { "eventTypeId": "4-1909196", "subscriptionId": 60001005 },
-    { "eventTypeId": "4-1916193", "subscriptionId": 60001006 }
+    { "eventTypeId": "4-1909196", "subscriptionId": "60001005" },
+    { "eventTypeId": "4-1916193", "subscriptionId": "60001006" }
   ],
   "alreadyPresent": []
 }
@@ -96,8 +96,8 @@ On an already-subscribed app:
   "targetUrl": "https://api.example.com/webhooks/hubspot/lifecycle",
   "created": [],
   "alreadyPresent": [
-    { "eventTypeId": "4-1909196", "subscriptionId": 60001005 },
-    { "eventTypeId": "4-1916193", "subscriptionId": 60001006 }
+    { "eventTypeId": "4-1909196", "subscriptionId": "60001005" },
+    { "eventTypeId": "4-1916193", "subscriptionId": "60001006" }
   ]
 }
 ```
@@ -188,8 +188,8 @@ Operational consequence:
 
 | Symptom                                                           | Likely cause                                                    | Next step                                                                                                                                                                                |
 | ----------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `401 { error: "unauthorized" }` from the admin route              | `X-Internal-Bootstrap-Token` header missing                     | Add the header.                                                                                                                                                                          |
-| `403 { error: "forbidden" }` from the admin route                 | Header present but wrong value                                  | Check the env var vs the header value. Do NOT echo either in logs.                                                                                                                       |
+| `401 { error: "missing_internal_token" }` from the admin route    | `X-Internal-Bootstrap-Token` header missing                     | Add the header.                                                                                                                                                                          |
+| `403 { error: "invalid_internal_token" }` from the admin route    | Header present but wrong value                                  | Check the env var vs the header value. Do NOT echo either in logs.                                                                                                                       |
 | `503 { error: "bootstrap_not_configured" }`                       | Server-side `INTERNAL_BOOTSTRAP_TOKEN` env is unset             | Set the env var in the deploy environment and restart.                                                                                                                                   |
 | `502 { error: "upstream_failure", stage: "token" }`               | Token fetch against `/oauth/v1/token` failed                    | Check `HUBSPOT_APP_CLIENT_ID` / `HUBSPOT_APP_CLIENT_SECRET` / network egress. Never echo the secret.                                                                                     |
 | `502 { error: "upstream_failure", stage: "list" }`                | GET subscriptions failed                                        | Check scopes (`developer.webhooks_journal.subscriptions.read`) and the HubSpot `correlationId` in the error.                                                                             |

--- a/docs/runbooks/lifecycle-subscription-bootstrap.md
+++ b/docs/runbooks/lifecycle-subscription-bootstrap.md
@@ -1,0 +1,208 @@
+# Lifecycle Subscription Bootstrap Runbook
+
+Date: 2026-04-18
+
+## 1. Purpose
+
+This runbook bootstraps the HubSpot `APP_LIFECYCLE_EVENT` subscriptions so the
+Slice 7 webhook receiver (`POST /webhooks/hubspot/lifecycle`) actually receives
+install and uninstall events for the installed portals.
+
+Without this bootstrap, the receiver is live but never called, and the system
+is relying solely on the Slice 6 oauth-refresh-failure fallback as the signal
+for tenant offboarding. That is a marketplace-submission blocker: HubSpot
+requires the app to subscribe to `APP_LIFECYCLE_EVENT` and prove install and
+uninstall handling.
+
+Cross-links:
+
+- `docs/runbooks/tenant-offboarding.md` — Slice 6 fallback
+- `.claude/tasks/2026-04-18-slice-11-lifecycle-subscription-bootstrap.md` — plan
+- `docs/slice-11-preflight-notes.md` — contract + source docs
+- `docs/security/slice-11-audit.md` — security audit
+
+## 2. Config
+
+Exactly five env vars feed the bootstrap. See
+`docs/slice-11-preflight-notes.md` §7 for the locked contract.
+
+| Env var                     | Required | Purpose                                                                                                                                                                        |
+| --------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `HUBSPOT_APP_ID`            | required | Numeric app id. Used for log correlation only. NOT sent to the token endpoint.                                                                                                 |
+| `HUBSPOT_APP_CLIENT_ID`     | required | App client id for the client-credentials flow.                                                                                                                                 |
+| `HUBSPOT_APP_CLIENT_SECRET` | required | App client secret. Never log. Never echo.                                                                                                                                      |
+| `LIFECYCLE_TARGET_URL`      | required | Public HTTPS URL of the Slice 7 receiver. NOT sent in the HubSpot subscription body (see §8). Kept as a passthrough field in the JSON report for operator visual verification. |
+| `INTERNAL_BOOTSTRAP_TOKEN`  | required | Shared secret for the admin route guard. 32+ bytes from a CSPRNG. Per-env, never reused. Never log.                                                                            |
+
+Credential owners:
+
+- `HUBSPOT_APP_*`: owned by the HubSpot developer-account admin. Lives in the
+  developer UI under the app's Auth tab.
+- `LIFECYCLE_TARGET_URL`: owned by the deploy-environment config. MUST match
+  what the app's `app-hsmeta.json` webhooks feature component (or
+  developer-UI webhooks settings) points at.
+- `INTERNAL_BOOTSTRAP_TOKEN`: owned by the deploy-environment operator.
+  Generated per environment (dev, preview, prod) and not shared across envs.
+
+## 3. First-run
+
+Two equivalent entry points. Pick the one that matches the environment.
+
+### 3.1 Script (preferred for CI and dev)
+
+```
+pnpm --filter @hap/api lifecycle:bootstrap
+```
+
+Reads env directly, calls `ensureLifecycleSubscriptions`, prints the JSON
+report to stdout.
+
+Exit codes:
+
+- `0` — success (any report, including one where both subscriptions were
+  already present)
+- `2` — missing env (one of the five vars above is unset)
+- `3` — upstream HubSpot failure (token fetch, list, or create call failed)
+- `1` — any other unexpected internal error
+
+### 3.2 HTTP (preferred for prod after first deploy)
+
+```
+curl -X POST \
+  -H "X-Internal-Bootstrap-Token: $INTERNAL_BOOTSTRAP_TOKEN" \
+  https://<api-host>/admin/lifecycle/bootstrap
+```
+
+Mounted outside `/api/*` and outside tenant middleware — this is an app-level,
+not tenant-level, operation.
+
+### 3.3 Expected report shape
+
+```json
+{
+  "targetUrl": "https://api.example.com/webhooks/hubspot/lifecycle",
+  "created": [
+    { "eventTypeId": "4-1909196", "subscriptionId": 60001005 },
+    { "eventTypeId": "4-1916193", "subscriptionId": 60001006 }
+  ],
+  "alreadyPresent": []
+}
+```
+
+On an already-subscribed app:
+
+```json
+{
+  "targetUrl": "https://api.example.com/webhooks/hubspot/lifecycle",
+  "created": [],
+  "alreadyPresent": [
+    { "eventTypeId": "4-1909196", "subscriptionId": 60001005 },
+    { "eventTypeId": "4-1916193", "subscriptionId": 60001006 }
+  ]
+}
+```
+
+### 3.4 Mandatory visual check
+
+The operator MUST visually confirm that the returned `targetUrl` matches what
+is configured in the app's `app-hsmeta.json` webhooks feature component (or
+the developer-UI "Webhooks target URL" field). HubSpot's subscription API is
+app-scoped and does NOT expose a per-subscription target URL, so the
+bootstrap cannot assert this programmatically — see §8.
+
+## 4. Idempotency
+
+Re-running the bootstrap on an already-subscribed app is safe. The diff is on
+`(subscriptionType, eventTypeId)` only. If both `APP_LIFECYCLE_EVENT` /
+`4-1909196` and `APP_LIFECYCLE_EVENT` / `4-1916193` already exist for the
+app, the report returns `created: []` and `alreadyPresent` contains both
+subscription rows.
+
+CI can safely call the bootstrap on every production deploy as a guardrail —
+it is a no-op when nothing needs to change.
+
+## 5. Rotation — `HUBSPOT_APP_CLIENT_SECRET`
+
+1. Rotate the client secret in the HubSpot developer UI (Auth → rotate).
+2. Update the new value in the deploy-environment secret store.
+3. Restart the API process so the new env is picked up. The in-memory token
+   cache in `apps/api/src/lib/hubspot-app-auth.ts` is process-local and is
+   discarded on restart.
+4. Re-run the bootstrap (script or HTTP). It will acquire a fresh
+   client-credentials token using the new secret and return `alreadyPresent`
+   for both event types.
+
+The old client secret is invalidated on the HubSpot side immediately. Any
+bootstrap run that races the rotation will either use the old secret (may
+401 on the token endpoint) or the new secret (succeeds). Neither path can
+corrupt subscription state — it either succeeds or fails cleanly.
+
+## 6. Rotation — `INTERNAL_BOOTSTRAP_TOKEN`
+
+1. Generate a new 32+ byte random value (for example
+   `openssl rand -base64 48`) in the deploy-environment secret store.
+2. Restart the API so the new env is picked up.
+3. Update the operator's local `curl` env to use the new token.
+4. No code change required.
+
+There is no grace period for the old token — the admin route compares the
+presented token against the current env value with constant-time equality.
+Keep rotation coordinated so a bootstrap is not mid-flight.
+
+## 7. Rollback
+
+Leaving the subscriptions in place is safe. The Slice 7 receiver treats
+unknown events as no-ops, and the existing install/uninstall handling is the
+expected behavior. No rollback action is required for normal code rollback.
+
+If the subscriptions must be explicitly torn down (for example during
+developer-account cleanup), do it manually, out of band:
+
+- Via the HubSpot developer UI, delete the two APP_LIFECYCLE_EVENT
+  subscriptions from the app.
+- Or, as an operator-only one-off:
+  `DELETE https://api.hubapi.com/webhooks-journal/subscriptions/2026-03/{subscriptionId}`
+  for each of the two subscription ids returned in the last bootstrap report.
+
+The shipped code path does NOT wrap the delete call. Slice 11 only creates
+subscriptions.
+
+## 8. `LIFECYCLE_TARGET_URL` and the subscription API
+
+HubSpot's `APP_LIFECYCLE_EVENT` subscription API is app-scoped. The
+subscription record itself does NOT carry a `targetUrl` or `portalId`;
+HubSpot delivers events to the single target URL configured on the app in
+`app-hsmeta.json` (or the developer-UI webhooks settings).
+
+Operational consequence:
+
+- The bootstrap service cannot programmatically detect a drifted target URL.
+- `LIFECYCLE_TARGET_URL` is a passthrough field in the JSON report so the
+  operator can visually compare it to the app's webhooks config.
+- If the operator sees `targetUrl` in the report diverge from what the app
+  is actually configured to deliver to, fix the app webhooks config in
+  HubSpot (not the bootstrap env) — the env is a label, the app config is
+  the source of truth.
+
+## 9. Troubleshooting
+
+| Symptom                                                           | Likely cause                                                    | Next step                                                                                                                                                                                |
+| ----------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `401 { error: "unauthorized" }` from the admin route              | `X-Internal-Bootstrap-Token` header missing                     | Add the header.                                                                                                                                                                          |
+| `403 { error: "forbidden" }` from the admin route                 | Header present but wrong value                                  | Check the env var vs the header value. Do NOT echo either in logs.                                                                                                                       |
+| `503 { error: "bootstrap_not_configured" }`                       | Server-side `INTERNAL_BOOTSTRAP_TOKEN` env is unset             | Set the env var in the deploy environment and restart.                                                                                                                                   |
+| `502 { error: "upstream_failure", stage: "token" }`               | Token fetch against `/oauth/v1/token` failed                    | Check `HUBSPOT_APP_CLIENT_ID` / `HUBSPOT_APP_CLIENT_SECRET` / network egress. Never echo the secret.                                                                                     |
+| `502 { error: "upstream_failure", stage: "list" }`                | GET subscriptions failed                                        | Check scopes (`developer.webhooks_journal.subscriptions.read`) and the HubSpot `correlationId` in the error.                                                                             |
+| `502 { error: "upstream_failure", stage: "create", eventTypeId }` | POST create-subscription failed for one event type              | Check write scope (`developer.webhooks_journal.subscriptions.write`). If `429`, wait out `Retry-After` and re-run — the bootstrap is idempotent. HubSpot rate limit is 50 req/s per app. |
+| Bootstrap reports success but receiver never fires                | App's webhooks target URL does not match `LIFECYCLE_TARGET_URL` | Fix the target URL in `app-hsmeta.json` / developer-UI webhooks settings (see §8).                                                                                                       |
+
+## 10. Security notes
+
+- `HUBSPOT_APP_CLIENT_SECRET`, the client-credentials bearer token, and
+  `INTERNAL_BOOTSTRAP_TOKEN` MUST NOT appear in logs, error payloads, or
+  test snapshots. The bootstrap and app-auth client are designed to surface
+  only `correlationId`, status, stage, and (for creates) `eventTypeId`.
+- The admin route is mounted OUTSIDE `/api/*` and outside tenant middleware.
+  It is intentionally app-scoped, not tenant-scoped — subscriptions are a
+  property of the HubSpot app, not of any one installed portal.
+- Full security review in `docs/security/slice-11-audit.md`.

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -661,3 +661,57 @@ problem rather than an opaque failure.
 - `docs/slice-6-preflight-notes.md`
 - `docs/runbooks/tenant-offboarding.md`
 - `docs/security/slice-6-audit.md`
+
+## 21. Slice 11 Lifecycle Subscription Bootstrap
+
+Slice 11 adds a narrow, app-scoped bootstrap that registers the HubSpot
+`APP_LIFECYCLE_EVENT` subscriptions required by the Slice 7 receiver
+(`POST /webhooks/hubspot/lifecycle`). Without it, the receiver is live but
+never called, and the system relies solely on the Slice 6 oauth-failure
+fallback.
+
+### 21.1 Scope boundary
+
+The bootstrap is **app-level**, not tenant-level. HubSpot's subscription API
+is app-scoped; one subscription covers every installed portal. No code path
+reads or writes `tenant_id`; no RLS policy is affected.
+
+### 21.2 New surface
+
+- Route: `POST /admin/lifecycle/bootstrap`, mounted OUTSIDE `/api/*` and
+  OUTSIDE tenant middleware.
+- Guard: `X-Internal-Bootstrap-Token` compared constant-time against
+  `INTERNAL_BOOTSTRAP_TOKEN` env using the repo's existing length-safe
+  `timingSafeEqual` pattern.
+- Script: `pnpm --filter @hap/api lifecycle:bootstrap` for CI / local use.
+- In-memory app-token cache in `apps/api/src/lib/hubspot-app-auth.ts`
+  (process-local, TTL = `expires_in - 60s`, never persisted).
+
+### 21.3 New env vars
+
+- `HUBSPOT_APP_ID` — log correlation only.
+- `HUBSPOT_APP_CLIENT_ID` — client-credentials flow.
+- `HUBSPOT_APP_CLIENT_SECRET` — client-credentials flow. Never log.
+- `LIFECYCLE_TARGET_URL` — public HTTPS URL of the Slice 7 receiver. NOT
+  sent in the subscription body (the API is app-scoped); kept as a
+  passthrough in the JSON report for operator visual verification against
+  `app-hsmeta.json`.
+- `INTERNAL_BOOTSTRAP_TOKEN` — admin-route shared secret. Per-env, 32+ byte
+  CSPRNG, never reused across envs.
+
+### 21.4 Preserved invariants
+
+- `apps/api/src/routes/lifecycle.ts` (Slice 7 receiver) is unchanged. HMAC
+  v3 verification and event-id mapping are unchanged.
+- `apps/api/src/lib/tenant-lifecycle.ts` (Slice 6 service) is unchanged. The
+  oauth-refresh-failure soft-deactivate fallback still fires at runtime, so
+  a missed bootstrap cannot leave a revoked install active.
+- No change to `/api/*` auth, tenant resolution, RLS, encryption envelope,
+  or replay nonce.
+
+### 21.5 Supporting docs
+
+- `.claude/tasks/2026-04-18-slice-11-lifecycle-subscription-bootstrap.md`
+- `docs/slice-11-preflight-notes.md`
+- `docs/runbooks/lifecycle-subscription-bootstrap.md`
+- `docs/security/slice-11-audit.md`

--- a/docs/security/slice-11-audit.md
+++ b/docs/security/slice-11-audit.md
@@ -55,8 +55,8 @@ change itself: no tenant-scoped file in the repo is modified.
     is missing the token. This is intentionally distinct from 401/403
     so a missing-env misconfiguration is not conflated with a bad
     client-side header.
-  - `401 { error: "unauthorized" }` when the header is missing.
-  - `403 { error: "forbidden" }` when the header is present but wrong.
+  - `401 { error: "missing_internal_token" }` when the header is missing.
+  - `403 { error: "invalid_internal_token" }` when the header is present but wrong.
   - `200` with the typed JSON report on success.
   - `502 { error: "upstream_failure", stage, ... }` when HubSpot's
     token / list / create call fails. The stage is safe to surface.

--- a/docs/security/slice-11-audit.md
+++ b/docs/security/slice-11-audit.md
@@ -1,0 +1,232 @@
+# Slice 11 Security Audit — Lifecycle Subscription Bootstrap
+
+Date: 2026-04-18
+Scope: Slice 11 subscription-bootstrap surface only (axis B). Axis A (Slice 7
+receiver) and axis D (Slice 6 fallback) are preserved unchanged. Axis C
+(journal/cursor ingestion) is explicitly out of scope.
+
+Sources:
+
+- Plan: `.claude/tasks/2026-04-18-slice-11-lifecycle-subscription-bootstrap.md`
+- Preflight: `docs/slice-11-preflight-notes.md`
+- Code under review:
+  - `apps/api/src/lib/hubspot-app-auth.ts`
+  - `apps/api/src/lib/hubspot-subscription-bootstrap.ts`
+  - `apps/api/src/routes/admin/lifecycle-bootstrap.ts`
+  - `apps/api/scripts/lifecycle-bootstrap.ts`
+- Unchanged (read-only reference):
+  - `apps/api/src/routes/lifecycle.ts` (Slice 7 receiver)
+  - `apps/api/src/lib/tenant-lifecycle.ts` (Slice 6 service)
+  - `apps/api/src/middleware/hubspot-signature.ts` (constant-time pattern)
+
+Verdict: PASS.
+
+## 1. Scope boundaries — explicitly app-level, not tenant-level
+
+The bootstrap operates at the HubSpot **app** level, not the tenant level.
+HubSpot's `APP_LIFECYCLE_EVENT` subscription API is app-scoped by design: a
+single subscription covers install and uninstall events for every portal that
+installs the app. Consequently:
+
+- No code path in Slice 11 reads or writes `tenant_id`.
+- No RLS policy is affected. No tenant-scoped table is touched.
+- There is no cross-tenant surface added by this slice — there is no
+  per-tenant row the bootstrap could leak across boundaries in the first
+  place.
+- The admin route is mounted OUTSIDE `/api/*` and OUTSIDE
+  `tenantMiddleware`. This is deliberate, not an oversight — wrapping an
+  app-level operation in tenant middleware would be semantically wrong and
+  would require a synthetic tenantId that has no real-world meaning.
+
+This non-regression of tenant isolation is asserted by the shape of the
+change itself: no tenant-scoped file in the repo is modified.
+
+## 2. Admin route exposure
+
+- Path: `POST /admin/lifecycle/bootstrap`
+- Mounted: OUTSIDE `/api/*`, OUTSIDE tenant middleware.
+- Guard: `X-Internal-Bootstrap-Token` header, compared against
+  `INTERNAL_BOOTSTRAP_TOKEN` env with a length-safe **constant-time**
+  comparison following the `timingSafeEqual` pattern already used in
+  `apps/api/src/middleware/hubspot-signature.ts`.
+- No anonymous access path. No fallback unauthenticated trigger.
+- Response status contract:
+  - `503 { error: "bootstrap_not_configured" }` when the server-side env
+    is missing the token. This is intentionally distinct from 401/403
+    so a missing-env misconfiguration is not conflated with a bad
+    client-side header.
+  - `401 { error: "unauthorized" }` when the header is missing.
+  - `403 { error: "forbidden" }` when the header is present but wrong.
+  - `200` with the typed JSON report on success.
+  - `502 { error: "upstream_failure", stage, ... }` when HubSpot's
+    token / list / create call fails. The stage is safe to surface.
+
+The route does NOT echo the presented token in any log, error message, or
+response. The constant-time check avoids leaking token length via timing for
+the equal-length branch; the unequal-length branch's timing reveals only the
+attacker-supplied length, which the attacker already knows.
+
+## 3. Secret handling
+
+### 3.1 `HUBSPOT_APP_CLIENT_SECRET`
+
+- Read from env by `hubspot-app-auth.ts`.
+- Sent only as the `client_secret` form field on
+  `POST https://api.hubapi.com/oauth/v1/token` over TLS.
+- Never logged. `AppAuthError` carries `stage` and `status` but NOT the
+  request body.
+- Never echoed in responses.
+
+### 3.2 `INTERNAL_BOOTSTRAP_TOKEN`
+
+- Read from env by the admin route handler only.
+- Compared constant-time. Never logged. Never echoed.
+- Missing-env returns 503 with a generic message that does not indicate
+  whether the client header is correct (the client check never runs if the
+  server has no token configured).
+
+### 3.3 HubSpot client-credentials bearer token
+
+- Acquired via client-credentials on `/oauth/v1/token`.
+- Kept in an in-memory module cache in `hubspot-app-auth.ts`.
+- Cache TTL is `response.expires_in - 60s` as a skew buffer; the code
+  trusts `expires_in` rather than hardcoding a lifetime.
+- Never logged. Never returned to clients. Never included in any error
+  payload. `SubscriptionBootstrapError` carries `stage`, optional `status`,
+  and (for creates) `eventTypeId` — not the bearer value.
+- Process restart invalidates the cache; there is no persistent token
+  storage.
+
+### 3.4 `HUBSPOT_APP_ID` and `LIFECYCLE_TARGET_URL`
+
+Safe to log. Used for correlation and operator-visible reporting.
+
+## 4. Slice 6 fallback preservation
+
+`apps/api/src/lib/tenant-lifecycle.ts` is UNCHANGED by Slice 11. The
+oauth-refresh-failure soft-deactivate path still fires at runtime when a
+tenant's refresh token is revoked:
+
+- `tenants.is_active = false`
+- `deactivation_reason = oauth_refresh_failed`
+- tenant OAuth credentials removed
+- snapshot route returns `401 tenant_access_revoked`
+
+Security consequence: even if the subscription bootstrap is missed, delayed,
+or misconfigured for a given environment, a revoked install cannot leave the
+tenant active. The runtime fallback catches it on the next HubSpot-backed
+request.
+
+A `git diff --stat origin/main -- apps/api/src/routes/lifecycle.ts apps/api/src/lib/tenant-lifecycle.ts`
+must return zero changed files; this is part of the validator's acceptance
+criteria.
+
+## 5. Preserved invariants
+
+- `apps/api/src/routes/lifecycle.ts` (Slice 7 receiver) is unchanged.
+- HMAC v3 verification (`verifyHubSpotSignatureV3`) is unchanged.
+- Event-id mapping (`HUBSPOT_LIFECYCLE_EVENT_IDS` — `4-1909196` app install,
+  `4-1916193` app uninstall) is unchanged. The bootstrap service IMPORTS
+  these ids from the receiver module rather than re-declaring them, keeping
+  receiver and bootstrap in lockstep.
+- Signed-request nonce, RLS policies, tenant middleware, encryption envelope,
+  and every other Slice 1–10 security surface are untouched.
+
+## 6. Attack surface delta
+
+- +1 HTTP route: `POST /admin/lifecycle/bootstrap` (token-guarded).
+- +1 module cache: in-memory HubSpot app-token cache (process-local,
+  discarded on restart, never persisted).
+- +1 script entrypoint: `pnpm --filter @hap/api lifecycle:bootstrap`.
+  Reads env directly; no network surface beyond the token endpoint and the
+  subscriptions API.
+- 0 new public-anonymous surfaces.
+- 0 new cross-tenant surfaces.
+- 0 new data-at-rest.
+- 0 new cookies or sessions.
+- 0 changes to `/api/*` auth, tenant resolution, RLS, or encryption.
+
+## 7. Residual risks and mitigations
+
+### R1 — Operator forgets to run the bootstrap in a new environment
+
+Receiver is live, but HubSpot delivers no events to it. Install and uninstall
+drift in tenant state until the Slice 6 oauth-failure backstop triggers on
+the next HubSpot-backed request.
+
+Mitigation:
+
+- Runbook §3 documents the first-run step per environment.
+- CI can safely invoke the script on every prod deploy as an idempotent
+  guardrail (runbook §4).
+
+### R2 — Weak or reused `INTERNAL_BOOTSTRAP_TOKEN`
+
+An attacker who recovers a weak or env-reused token can trigger bootstraps.
+Worst case: subscriptions are re-upserted to their existing app-scoped
+state. There is no data exfiltration path.
+
+Mitigation:
+
+- Runbook §2 and §6 require a per-environment 32+ byte CSPRNG value.
+- The operation itself is idempotent and creates no side effects beyond
+  (re-)registering the two app-scoped subscriptions, so impact is bounded.
+
+### R3 — HubSpot rate limit (50 req/s per app) during retry storms
+
+Sequential creates under a retry loop could hit the limit.
+
+Mitigation:
+
+- Bootstrap runs are infrequent (first-run + deploy guardrail).
+- Creates are sequential, not parallel.
+- Errors are surfaced per `eventTypeId` so the operator can retry only the
+  failed one after the rate-limit window (runbook §9).
+
+### R4 — Drifted `LIFECYCLE_TARGET_URL` vs `app-hsmeta.json` webhooks config
+
+HubSpot's subscription API does not carry a per-subscription target URL, so
+the bootstrap cannot detect drift programmatically.
+
+Mitigation:
+
+- `LIFECYCLE_TARGET_URL` is passed through into the JSON report.
+- Runbook §3.4 makes the visual comparison against the app's webhooks
+  config a mandatory first-run step.
+- A drifted target URL produces no security leak — the receiver endpoint
+  still requires valid HMAC v3 verification against `HUBSPOT_CLIENT_SECRET`
+  and a known portal, so a misrouted HubSpot event cannot be spoofed into
+  tenant state changes.
+
+### R5 — Log surface of `correlationId`
+
+HubSpot's error payloads include a `correlationId`. The bootstrap surfaces
+it for operator debugging. This is safe: `correlationId` is a HubSpot-side
+request marker, not a secret, and HubSpot docs designate it as the field to
+quote when filing support tickets.
+
+## 8. Compliance check against project rules
+
+- Tenant isolation: N/A (app-level operation by design) — explicitly called
+  out above so this is not mistaken for a regression.
+- No silent CRM writes: the bootstrap writes only to HubSpot's
+  subscriptions API (app-scope), not to any CRM object or tenant data.
+- Config-driven: all behavior is driven by the five env vars in the locked
+  contract (preflight §7). No hardcoded secrets, thresholds, or URLs beyond
+  documented HubSpot API paths.
+- No log leakage: verified above in §3.
+
+## 9. Verdict
+
+Slice 11 introduces a narrow, auditable, app-scope bootstrap surface with a
+token-guarded admin route, constant-time comparison, strict no-log posture
+on secrets, and zero regression of tenant isolation, RLS, encryption, HMAC
+verification, or the Slice 6 oauth-failure fallback.
+
+Approved for merge subject to:
+
+- All three targeted test suites green
+  (`hubspot-app-auth.test.ts`, `hubspot-subscription-bootstrap.test.ts`,
+  `lifecycle-bootstrap.test.ts`).
+- `git diff --stat origin/main -- apps/api/src/routes/lifecycle.ts apps/api/src/lib/tenant-lifecycle.ts` returns zero files.
+- Workspace `pnpm typecheck`, `pnpm lint`, `pnpm test` green.

--- a/docs/slice-11-preflight-notes.md
+++ b/docs/slice-11-preflight-notes.md
@@ -1,0 +1,332 @@
+# Slice 11 Preflight Notes
+
+Date: 2026-04-18
+
+Purpose: lock the HubSpot lifecycle-subscription-bootstrap contract before any
+Slice 11 implementation begins. Re-verifies the endpoints, auth model,
+idempotency semantics, and config surface the bootstrap service will consume.
+
+Sources (verified 2026-04-18):
+
+- Webhooks journal management APIs (version label `2026-03`):
+  `https://developers.hubspot.com/docs/api-reference/latest/webhooks-journal/subscriptions/guide`
+- Webhooks journal overview + auth/scopes:
+  `https://developers.hubspot.com/docs/api-reference/latest/webhooks-journal/guide`
+- Authentication overview (client-credentials section):
+  `https://developers.hubspot.com/docs/apps/developer-platform/build-apps/authentication/overview`
+- Slice 6 preflight (lifecycle event ids, hybrid-model posture):
+  `docs/slice-6-preflight-notes.md`
+- Live receiver (read-only reference):
+  `apps/api/src/routes/lifecycle.ts`
+
+## 1. Critical finding — the plan's endpoint and body shape must be corrected
+
+The Slice 11 plan (`.claude/tasks/2026-04-18-slice-11-lifecycle-subscription-bootstrap.md`)
+implicitly assumes the subscription-management API lives at
+`/webhooks/v4/subscriptions` and that a subscription carries a `targetUrl`.
+**Neither assumption matches the current (2026-03) docs.** The shipped
+receiver route comment in `apps/api/src/routes/lifecycle.ts` also mentions
+`POST /webhooks/v4/subscriptions`, which is stale.
+
+Correct values, per docs:
+
+- Base URL: `https://api.hubapi.com`
+- Management API path prefix: `/webhooks-journal/subscriptions/2026-03`
+  (the `2026-03` segment is the docs-versioned path, not a query param).
+- **A subscription does NOT carry a `targetUrl`.** Subscriptions are
+  app-global; HubSpot delivers events to the webhook target URL configured
+  in the app itself (via `app-hsmeta.json` webhooks config or the developer
+  UI). Slice 11's `LIFECYCLE_TARGET_URL` env is therefore consumed by the
+  app-config / receiver-mount side, **not** sent in the subscription body.
+- **APP_LIFECYCLE_EVENT subscriptions do NOT carry `portalId`** — they are
+  app-scope. Only `OBJECT` / `ASSOCIATION` / `LIST_MEMBERSHIP` subscription
+  types take a `portalId` (those are install-scoped).
+
+These two corrections drop the "mismatched target URL" diff case from the
+bootstrap service entirely — there is no per-subscription target URL to
+diff against. The service only needs to diff on `(subscriptionType,
+eventTypeId)`.
+
+## 2. Subscription management endpoints
+
+All require a **client-credentials** access token in `Authorization: Bearer <token>`.
+
+| Action                                  | Method   | Path                                                         | Success      |
+| --------------------------------------- | -------- | ------------------------------------------------------------ | ------------ |
+| List all subscriptions (for the app)    | `GET`    | `/webhooks-journal/subscriptions/2026-03`                    | `200` + body |
+| Create or update a subscription         | `POST`   | `/webhooks-journal/subscriptions/2026-03`                    | `200`/`201`  |
+| Delete a subscription by id             | `DELETE` | `/webhooks-journal/subscriptions/2026-03/{subscriptionId}`   | `204`        |
+| Delete all subscriptions for one portal | `DELETE` | `/webhooks-journal/subscriptions/2026-03/portals/{portalId}` | `204`        |
+
+Required scopes on the client-credentials token:
+
+- `developer.webhooks_journal.subscriptions.read` — for `GET`
+- `developer.webhooks_journal.subscriptions.write` — for `POST` / `DELETE`
+
+Rate limit: **50 req/s per app** on the subscriptions API.
+
+Auth header shape (same for all three):
+
+```
+Authorization: Bearer <client-credentials access token>
+Content-Type: application/json   (POST only)
+```
+
+### Body shape — APP_LIFECYCLE_EVENT
+
+Per HubSpot's "Create an app install or uninstall event subscription" section:
+
+```json
+{
+  "subscriptionType": "APP_LIFECYCLE_EVENT",
+  "eventTypeId": "4-1909196",
+  "properties": ["string"]
+}
+```
+
+There is no `targetUrl`, no `portalId`, no `actions` array for this
+subscription type. Slice 11's bootstrap creates **two** such subscriptions —
+one per event type id.
+
+### List response shape (relevant fields)
+
+```json
+{
+  "results": [
+    {
+      "id": 60001005,
+      "appId": 936515,
+      "subscriptionType": "APP_LIFECYCLE_EVENT",
+      "eventTypeId": "4-1909196",
+      "createdAt": "2025-07-10T18:30:38.062Z",
+      "updatedAt": "2025-07-10T18:30:38.062Z"
+    }
+  ]
+}
+```
+
+For Slice 11's diff, match on `subscriptionType === "APP_LIFECYCLE_EVENT"`
+AND `eventTypeId` in `{"4-1909196", "4-1916193"}`.
+
+## 3. Client-credentials flow (app-level auth)
+
+- Endpoint: `POST https://api.hubapi.com/oauth/v1/token`
+- Content-Type: `application/x-www-form-urlencoded`
+- Required form fields:
+  - `grant_type=client_credentials`
+  - `client_id=<HUBSPOT_APP_CLIENT_ID>`
+  - `client_secret=<HUBSPOT_APP_CLIENT_SECRET>`
+  - `scope=developer.webhooks_journal.subscriptions.read developer.webhooks_journal.subscriptions.write`
+    (space-separated; omit `read`/`write` the bootstrap does not use; Slice 11
+    bootstrap needs both read and write)
+- Response shape (standard OAuth2):
+
+  ```json
+  {
+    "access_token": "CO...",
+    "expires_in": 1800,
+    "token_type": "bearer"
+  }
+  ```
+
+- Token lifetime: HubSpot's docs describe these as "short-term expiry windows
+  that must be refreshed after a certain amount of time" without pinning a
+  single number. Community/reference material typically cites 30 minutes
+  (1800s) for client-credentials tokens, but the authoritative value is
+  whatever comes back in `expires_in` on each fetch. **The app-auth client
+  MUST trust `expires_in` from the response and NOT hardcode a constant.**
+  A safe in-memory cache TTL is `expires_in - 60s` as a skew buffer.
+- No refresh-token flow: client-credentials tokens are re-fetched on expiry
+  by re-POSTing to the token endpoint with the same credentials.
+
+Note: `HUBSPOT_APP_ID` is NOT sent to `/oauth/v1/token` — only `client_id` and
+`client_secret`. `HUBSPOT_APP_ID` is still useful (logging, correlating to
+the app's numeric id in HubSpot, constructing admin UI links) but is not a
+required auth input. The plan's config contract correctly lists it.
+
+## 4. Idempotency semantics — "Create or update a subscription"
+
+The HubSpot endpoint is explicitly titled **"Create or update a subscription"**
+in the 2026-03 docs, and the subscriptions API guide repeatedly uses that
+phrasing. HubSpot does not document a `409 Conflict` path for duplicate
+subscription creation; it documents a single POST that either creates or
+updates.
+
+Confirmed behavior from the docs:
+
+- Success codes are `200 OK` and `204 No Content`; there is no
+  `409 Conflict` in the documented error-code list.
+- The response payload includes an `id`; re-posting an equivalent subscription
+  returns a subscription row (HubSpot treats the endpoint as upsert rather
+  than strict-create).
+
+**Implication for the bootstrap diff-and-create strategy:** the service can
+be implemented as either:
+
+1. **Diff-first (preferred for Slice 11):** `GET` the list, compare against
+   the desired set of two `(APP_LIFECYCLE_EVENT, eventTypeId)` pairs, and
+   only `POST` the missing ones. Report `alreadyPresent` for matches. This
+   is idempotent by construction and gives a clean operator-facing report.
+2. **Upsert-unconditional:** `POST` both subscriptions every run, trust
+   HubSpot's upsert. This is also idempotent but produces a less useful
+   report (no "alreadyPresent" signal).
+
+Slice 11 should use **diff-first**. Reasoning: the plan's acceptance
+criteria explicitly require the typed report `{ created, alreadyPresent }`,
+and the diff-first path is what produces that without a second GET after
+each POST.
+
+No `409` handling branch is required. The bootstrap should still surface
+non-2xx responses as errors with the HubSpot `correlationId` (see §6).
+
+## 5. APP_LIFECYCLE_EVENT + event-id cross-check
+
+Confirmed current (2026-03 docs, 2026-04-14 last-modified):
+
+- `subscriptionType`: `APP_LIFECYCLE_EVENT` ✓
+- `4-1909196` → App install event ✓
+- `4-1916193` → App uninstall event ✓
+
+These match `apps/api/src/routes/lifecycle.ts` line 42-45:
+
+```ts
+export const HUBSPOT_LIFECYCLE_EVENT_IDS = {
+  APP_INSTALL: "4-1909196",
+  APP_UNINSTALL: "4-1916193",
+} as const;
+```
+
+The bootstrap service MUST reuse the ids from `HUBSPOT_LIFECYCLE_EVENT_IDS`
+rather than re-declaring them, to keep the receiver and bootstrap in lockstep.
+
+Journal event payload reference (for cross-check only; journal ingestion is
+deferred out of Slice 11):
+
+```json
+{
+  "type": "app_lifecycle_event",
+  "action": "APP_INSTALL",
+  "portalId": 123456,
+  "eventTypeId": "4-1909196",
+  "properties": { "hs_app_id": 1234567, "hs_app_install_level": "PORTAL", ... }
+}
+```
+
+## 6. Error handling the bootstrap should surface
+
+Per the webhooks-journal overview:
+
+- `400` invalid request body
+- `401` missing/invalid token — auth-client should re-fetch once and retry
+- `403` missing scopes — surface as "insufficient scopes" with the correlationId
+- `429` rate-limited — respect `Retry-After`; bootstrap runs are infrequent
+  so a simple single retry is acceptable
+- `5xx` upstream error — surface as `502` from the admin route
+
+Error payload shape:
+
+```json
+{
+  "status": "error",
+  "message": "...",
+  "correlationId": "...",
+  "category": "VALIDATION_ERROR"
+}
+```
+
+`correlationId` is safe to log. `message` is safe to log. The bearer token
+and `client_secret` are NOT safe to log.
+
+## 7. Locked config contract
+
+Exactly five env vars feed Slice 11. Nothing else.
+
+| Env var                     | Required | Purpose                                                                                                                                                                                                 | Consumer                                        | Example shape (redacted)                             |
+| --------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------- |
+| `HUBSPOT_APP_ID`            | required | Numeric app id. Not sent to `/oauth/v1/token` — used for log correlation and error messages only.                                                                                                       | app-auth client (logging), bootstrap service    | `1234567`                                            |
+| `HUBSPOT_APP_CLIENT_ID`     | required | App client id for client-credentials flow. Form field `client_id`.                                                                                                                                      | app-auth client only                            | `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`               |
+| `HUBSPOT_APP_CLIENT_SECRET` | required | App client secret for client-credentials flow. Form field `client_secret`. **NEVER log.**                                                                                                               | app-auth client only                            | `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`               |
+| `LIFECYCLE_TARGET_URL`      | required | Public HTTPS URL of the Slice 7 receiver. **NOT sent in the subscription body** (see §1). Used by the operator runbook + `app-hsmeta.json` webhooks config + consistency check in the bootstrap report. | bootstrap service (report), runbook, app-hsmeta | `https://api.example.com/webhooks/hubspot/lifecycle` |
+| `INTERNAL_BOOTSTRAP_TOKEN`  | required | Shared secret for the admin route guard. Compared with length-safe constant-time equality. **NEVER log.**                                                                                               | admin route only                                | 32+ byte random string                               |
+
+**Handling rules (security audit consumes these):**
+
+- `HUBSPOT_APP_CLIENT_SECRET`, `INTERNAL_BOOTSTRAP_TOKEN`, and any bearer
+  token from `/oauth/v1/token` MUST NOT appear in logs, error payloads, or
+  test snapshots.
+- Missing-env failures must name the missing env var but never print its
+  suspected value.
+- `HUBSPOT_APP_ID` and `LIFECYCLE_TARGET_URL` ARE safe to log.
+
+## 8. Consistency-check caveat for `LIFECYCLE_TARGET_URL`
+
+Because HubSpot does not accept a per-subscription `targetUrl` on
+APP_LIFECYCLE_EVENT subscriptions, the bootstrap service CANNOT assert
+via the subscriptions API that HubSpot will deliver to the expected URL.
+The target URL is owned by the app's webhooks config (e.g.,
+`app-hsmeta.json`'s webhooks feature component, or the developer UI
+"Webhooks target URL" field).
+
+Recommendation for Slice 11:
+
+- The bootstrap report SHOULD include `targetUrl` it was configured with
+  as a passthrough field in the JSON output, so the operator runbook can
+  visually compare it to what's set in the HubSpot developer UI / app
+  config.
+- The bootstrap service does NOT fail on mismatched URLs — it cannot see
+  them. The plan's "mismatched target URL" diff case should be REMOVED
+  from the acceptance criteria for the bootstrap service. It remains a
+  valid runbook check, not a programmatic check.
+
+This is the single largest plan adjustment needed before the
+`builder-subscription-bootstrap` task starts.
+
+## 9. Explicit non-goals (confirming Slice 11 scope boundary)
+
+Out of scope, per the Slice 11 plan and confirmed here:
+
+- **Journal polling / cursor checkpointing** (`GET /webhooks-journal/journal/2026-03/*`).
+  The receiver in `apps/api/src/routes/lifecycle.ts` handles webhook
+  delivery directly; journal ingestion is deferred to a later slice.
+- **`DELETE /appinstalls/v3/external-install`** (app uninstall by API).
+  Remains operator-only; Slice 11 does not wrap it.
+- **Delete-all-subscriptions-for-portal**
+  (`DELETE /webhooks-journal/subscriptions/2026-03/portals/{portalId}`).
+  Not used — Slice 11 only creates APP_LIFECYCLE_EVENT subscriptions at the
+  app level. Tenant offboarding is already handled by Slice 6.
+- **Subscription filters** (`/webhooks-journal/subscriptions/2026-03/filters`).
+  Not applicable to APP_LIFECYCLE_EVENT subscriptions.
+- **Slice 6 oauth-failure fallback** preserved unchanged —
+  `apps/api/src/lib/tenant-lifecycle.ts` is read-only for Slice 11.
+
+## 10. Downstream builder checklist
+
+This section is the contract `builder-app-auth`, `builder-subscription-bootstrap`,
+and `builder-admin-route` consume.
+
+- **Token endpoint:** `POST https://api.hubapi.com/oauth/v1/token`, form-urlencoded,
+  grant `client_credentials`, scopes `developer.webhooks_journal.subscriptions.read developer.webhooks_journal.subscriptions.write`.
+- **Cache TTL:** trust `expires_in` from the response; expire the cache
+  `expires_in - 60s` after fetch.
+- **List subscriptions:** `GET https://api.hubapi.com/webhooks-journal/subscriptions/2026-03`
+  with `Authorization: Bearer <token>`.
+- **Create subscription:** `POST https://api.hubapi.com/webhooks-journal/subscriptions/2026-03`
+  with `Authorization: Bearer <token>`, `Content-Type: application/json`,
+  body `{ "subscriptionType": "APP_LIFECYCLE_EVENT", "eventTypeId": "<id>" }`
+  (omit `properties` unless we later need specific event properties).
+- **Delete subscription:** `DELETE https://api.hubapi.com/webhooks-journal/subscriptions/2026-03/{subscriptionId}`
+  with `Authorization: Bearer <token>`. Slice 11 does not call this in the
+  primary path, but the app-auth client should support it for future use.
+- **Diff key:** `(subscriptionType === "APP_LIFECYCLE_EVENT", eventTypeId)`.
+  No target-URL comparison.
+- **Desired set:** exactly two entries — one with `eventTypeId === "4-1909196"`,
+  one with `eventTypeId === "4-1916193"`. Both pulled from
+  `HUBSPOT_LIFECYCLE_EVENT_IDS` in `apps/api/src/routes/lifecycle.ts`.
+- **Idempotency:** diff-first — create only the missing ones. Re-runs with
+  both present return `{ created: [], alreadyPresent: ["4-1909196", "4-1916193"] }`.
+- **Admin route guard:** `X-Internal-Bootstrap-Token` compared with
+  length-safe constant-time equality against `INTERNAL_BOOTSTRAP_TOKEN`.
+  401 if header missing, 403 if present-but-wrong, 200 on success, 502 on
+  upstream HubSpot failure.
+- **Mount point:** `POST /admin/lifecycle/bootstrap`, OUTSIDE `/api/*`,
+  outside tenant middleware.


### PR DESCRIPTION
## Summary

Slice 11 closes the app-level bootstrap gap between Slice 7's shipped lifecycle webhook receiver and actual HubSpot event delivery. Without an `APP_LIFECYCLE_EVENT` subscription registered against the app, HubSpot never calls the receiver and the system relies solely on the Slice 6 oauth-failure fallback as the install/uninstall signal — exactly the posture Slice 7 was meant to exit.

This slice ships axis **B (subscription bootstrap)** only. Journal/cursor ingestion (axis C) is deferred. Receiver transport (axis A, Slice 7) is unchanged. Slice 6 fallback (D) is preserved.

## Root cause

After Slice 7, an operator had to manually toggle the `APP_LIFECYCLE_EVENT` subscription in the HubSpot developer UI for every environment (dev/preview/prod). That is error-prone, undiffable, and blocks marketplace submission posture. The receiver was effectively plumbing with no faucet.

## What changed

New code (behind a small operator-only surface):

- `apps/api/src/lib/hubspot-app-auth.ts` — client-credentials token client. In-memory TTL cache keyed on `clientId`, refresh at `expires_in − 60s` skew. Never logs secrets; errors strip response bodies that may echo the POSTed secret.
- `apps/api/src/lib/hubspot-subscription-bootstrap.ts` — idempotent ensure service. Diffs on `(subscriptionType, eventTypeId)` only and creates only the missing pair (`4-1909196` install, `4-1916193` uninstall). Event-ids are imported from `apps/api/src/routes/lifecycle.ts` (the Slice 7 receiver) rather than re-declared, so the two stay locked in step.
- `apps/api/src/routes/admin/lifecycle-bootstrap.ts` — `POST /admin/lifecycle/bootstrap` mounted **outside `/api/*`** and outside tenant middleware. Guarded by `X-Internal-Bootstrap-Token` with a length-safe, constant-time comparison (`timingSafeEqual` + `byteLength` guard, matching `apps/api/src/middleware/hubspot-signature.ts`'s `safeEquals`). Returns `401 missing_internal_token`, `403 invalid_internal_token`, `503 bootstrap_not_configured`, `200 <report>`, `502 upstream_failure`, or `500 internal_error` — the 500 branch never propagates the thrown message.
- `apps/api/scripts/lifecycle-bootstrap.ts` + `pnpm --filter @hap/api lifecycle:bootstrap` — a CLI shim calling the same service directly (no HTTP). Exit codes: 0 success, 2 missing env, 3 upstream failure, 1 internal error.

Docs & tracking:

- `docs/slice-11-preflight-notes.md` — verified HubSpot Webhooks Journal 2026-03 subscription management endpoints, client-credentials flow, scopes, idempotency.
- `docs/runbooks/lifecycle-subscription-bootstrap.md` — operator runbook (first-run, secret rotation, rollback, visual `LIFECYCLE_TARGET_URL` vs `app-hsmeta.json` check).
- `docs/security/slice-11-audit.md` + `docs/security/SECURITY.md` §21 — audit covering app-level (not tenant-level) scope, admin route exposure, secret handling, Slice 6 fallback preservation, attack-surface delta, residual risks.
- `PLANNING_INDEX.md` — registers the plan, preflight, runbook, and audit.
- `.taskmaster/tasks/tasks.json` — Slice 11 entry → `in_progress` with the axis-B scope note. (Large line delta is JSON re-serialization churn; the semantic change is limited to that single entry.)
- `biome.json` — adds `!**/.bundle-artifacts` so test-generated card/settings bundles don't pollute workspace lint after a test run.

### Plan correction caught in preflight

The original plan assumed HubSpot's subscription API carried a per-subscription `targetUrl`. Preflight against 2026-03 docs proved it doesn't — the API is app-scoped and the webhook target URL lives on the app itself via `app-hsmeta.json` / the developer-UI webhooks config. The plan was patched in-flight. Diff is on `(subscriptionType, eventTypeId)` only. `LIFECYCLE_TARGET_URL` is kept as a JSON-report passthrough and a runbook-level visual check.

### Review-driven fix (included in this PR)

`9bcf59f` fixes a correctness bug caught by both CodeRabbit and an independent reviewer: HubSpot's webhooks-journal subscriptions API returns `id` as a **number** in practice (see preflight §2 sample `"id": 60001005`), but the initial implementation filtered on `typeof id === "string"`. Before the fix, the list filter would silently drop real existing subscriptions and the bootstrap would re-`POST` them as duplicates, and the create path would throw on a successful 2xx response. A helper `coerceSubscriptionId()` now accepts both `string` and finite `number`, normalizes to string, and rejects empty/NaN/Infinity. Two new tests (one for the list path, one for the create path) cover the numeric-id shape.

## Verification

All from the workspace root inside the worktree (fresh, this PR's HEAD):

- `pnpm install --frozen-lockfile` — exit 0
- `pnpm test` — exit 0, **81 files / 713 tests** (baseline was 78 / 685 on `origin/main`; +3 files / +28 tests for Slice 11)
- Targeted suites combined — exit 0, 3 files / 28 tests (`hubspot-app-auth.test.ts` 10, `hubspot-subscription-bootstrap.test.ts` 10, `routes/admin/lifecycle-bootstrap.test.ts` 8)
- `pnpm typecheck` — exit 0
- `pnpm lint` — exit 0 (3 non-blocking `noNonNullAssertion` warnings in test code, allowed by biome config)
- `git diff --stat origin/main -- apps/api/src/routes/lifecycle.ts apps/api/src/lib/tenant-lifecycle.ts` — empty

## Scope / non-goals

**In scope (axis B):** subscription bootstrap for `APP_LIFECYCLE_EVENT` at the app level.

**Explicitly NOT in this PR:**

- No journal polling, cursor checkpointing, or reconciliation sweep (axis C, deferred).
- No changes to `apps/api/src/routes/lifecycle.ts` — Slice 7 receiver is untouched.
- No changes to `apps/api/src/lib/tenant-lifecycle.ts` — Slice 6 soft-deactivate/reactivate fallback is preserved.
- No tenant-scoped surface — subscriptions are a property of the HubSpot app itself, not any one installed portal. No RLS impact.
- No new migrations, no new tables, no `packages/db/` changes.
- No widened public surface. The only new route is `POST /admin/lifecycle/bootstrap`, shared-secret-gated and mounted outside both `/api/*` and the tenant middleware.
- `apps/hubspot-extension/.bundle-artifacts/` is an intentional untracked test output and is NOT part of this PR.

## Remaining risks / follow-ups

- **R1.** Operator forgets to run bootstrap after deploying to a new environment → receiver is mounted but sees no deliveries → tenant state drifts until the Slice 6 oauth-failure backstop fires. Mitigation: runbook + CI-step recommendation. Optional follow-up: wire the script into deploy automation.
- **R2.** `INTERNAL_BOOTSTRAP_TOKEN` must be per-env, ≥32 bytes from a CSPRNG. Runbook calls this out.
- **R3.** HubSpot subscription API rate limit is 50 req/s per app; sequential create order keeps us well clear.
- **R4.** `LIFECYCLE_TARGET_URL` visual-check drift (env ↔ `app-hsmeta.json`). Non-exploitable — the Slice 7 receiver still gates on HMAC v3 + known-portal tenant resolution; a misrouted HubSpot delivery cannot spoof tenant state.
- **R5. Follow-up opportunity (not blocking):** journal polling / cursor reconciliation (axis C) if webhook-first + oauth-failure backstop ever proves insufficient. Queue as a later slice.

## Commits in this PR

- `9255b18` feat(api): add lifecycle subscription bootstrap flow
- `9bcf59f` fix(api): accept numeric HubSpot subscription ids on list + create

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates HubSpot `APP_LIFECYCLE_EVENT` subscription setup so the Slice 7 lifecycle webhook receives install/uninstall events. Adds an idempotent bootstrap service with a guarded admin endpoint and a CLI; the receiver and Slice 6 fallback are unchanged.

- **New Features**
  - HubSpot app auth client (client-credentials) with in-memory TTL cache; errors never leak secrets.
  - Idempotent ensure for install (`4-1909196`) and uninstall (`4-1916193`) subscriptions; diffs by `(subscriptionType, eventTypeId)`; app-scoped API (no per-subscription target URL).
  - Admin route `POST /admin/lifecycle/bootstrap` outside `/api/*`, protected by `X-Internal-Bootstrap-Token` using a constant-time check.
  - CLI `pnpm --filter @hap/api lifecycle:bootstrap` invoking the same service with structured exit codes.

- **Bug Fixes**
  - Accept numeric HubSpot subscription `id`s and normalize to strings to prevent duplicate creates and false errors; tests cover list and create paths.
  - Docs: updated runbook and security audit to match implemented shapes (string `subscriptionId`; 401 `missing_internal_token`, 403 `invalid_internal_token`).

<sup>Written for commit 683b48f14253bdbca51aff92cf741d4145a5cfd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary: Slice 11 – Lifecycle Subscription Bootstrap

## High-level overview
- Purpose: Register HubSpot APP_LIFECYCLE_EVENT subscriptions so the existing Slice 7 webhook receiver receives install/uninstall deliveries.
- Scope: Axis B only (app-level subscription bootstrap). Receiver (Axis A) and Slice 6 fallback (Axis D) unchanged. Axis C (journal/cursor ingestion) deferred.
- Key invariants preserved: no changes to /api/* middleware, tenant resolution, Slice 7 receiver behavior, or Slice 6 offboarding fallback.

---

## Bullet-pointed Changes (release-note style)
- New app-level OAuth client-credentials implementation with in-memory TTL cache and safe error handling
  - File: apps/api/src/lib/hubspot-app-auth.ts
  - TTL refresh: expires_in − 60s
  - Secrets never logged; non-2xx errors expose only status/correlationId
- Idempotent subscription bootstrap service (creates missing install/uninstall subscriptions only)
  - File: apps/api/src/lib/hubspot-subscription-bootstrap.ts
  - Diff key: (subscriptionType, eventTypeId)
  - Fixed eventTypeId values: install 4-1909196, uninstall 4-1916193
  - Normalizes numeric subscription IDs → strings
- Operator-only admin HTTP route (guarded) to trigger bootstrap
  - File: apps/api/src/routes/admin/lifecycle-bootstrap.ts
  - Route: POST /admin/lifecycle/bootstrap mounted outside /api/*
  - Guard: X-Internal-Bootstrap-Token validated with length-gated constant-time comparison
  - Responses:
    - 401 missing header
    - 403 invalid token
    - 503 misconfigured (missing INTERNAL_BOOTSTRAP_TOKEN or LIFECYCLE_TARGET_URL)
    - 200 success — returns EnsureLifecycleSubscriptionsReport
    - 502 upstream failure — returns { error: "upstream_failure", stage, status, eventTypeId }
    - 500 internal error — returns { error: "internal_error" }
- CLI shim for local/CI bootstrap (same service, defined exit codes)
  - File: apps/api/scripts/lifecycle-bootstrap.ts
  - Exit codes: 0 success, 2 missing env, 3 upstream failure, 1 internal error
- Tests and verification
  - New tests added; overall test count: 81 files / 713 tests
  - Test files:
    - apps/api/src/lib/__tests__/hubspot-app-auth.test.ts
    - apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts
    - apps/api/src/routes/admin/__tests__/lifecycle-bootstrap.test.ts
  - pnpm install/test/typecheck/lint passed
- Docs & tracking
  - Added preflight notes, runbook, security audit, task plan, PLANNING_INDEX update, and SECURITY.md §21
  - Package script: apps/api/package.json -> lifecycle:bootstrap

---

## Data flow diagrams (Mermaid)

Subscription bootstrap workflow:

```mermaid
graph TD
  Operator["Operator / CI"] -->|POST /admin/lifecycle/bootstrap + X-Internal-Bootstrap-Token| AdminRoute["Admin Route"]
  Operator -->|pnpm lifecycle:bootstrap + LIFECYCLE_TARGET_URL| CLI["CLI Script"]
  AdminRoute --> AuthCheck{"Header present?\n& safeEquals"}
  AuthCheck -->|fail| AuthFail["401/403"]
  AuthCheck -->|ok| Ensure["ensureLifecycleSubscriptions({ targetUrl })"]
  CLI -->|env check| EnvCheck{"LIFECYCLE_TARGET_URL present?"}
  EnvCheck -->|fail| CLIFail["Exit 2"]
  EnvCheck -->|ok| Ensure
  Ensure --> Token["getAppAccessToken()"]
  Token -->|cached or fetch| HubSpotAuth["HubSpot Token Endpoint"]
  Ensure --> List["GET /webhooks-journal/subscriptions"]
  List --> HubSpotAPI["HubSpot API: list existing"]
  Ensure --> Diff["Diff on (subscriptionType, eventTypeId)"]
  Diff -->|missing| Create["POST /webhooks-journal/subscriptions (create missing)"]
  Create --> HubSpotAPICreate["HubSpot API: create subscription"]
  HubSpotAPICreate --> Report["EnsureLifecycleSubscriptionsReport"]
  AdminRoute --> Response["200/502/500 per outcome"]
  CLI --> CLIResponse["Exit 0/3/1 + stdout/stderr"]
```

Token caching & lifecycle:

```mermaid
sequenceDiagram
  participant Caller as ensureLifecycleSubscriptions
  participant Cache as In-Memory Cache
  participant Hub as HubSpot Auth
  Caller->>Cache: getAppAccessToken(clientId)
  alt cache hit (before expires_in-60s)
    Cache-->>Caller: bearer token
  else cache miss/expired
    Cache->>Hub: POST client_credentials (client_id, client_secret, scope)
    Hub-->>Cache: { access_token, expires_in }
    Cache-->>Caller: bearer token (cached until now + expires_in - 60s)
  end
  Caller->>Hub: GET/POST subscriptions (Authorization: Bearer)
  Hub-->>Caller: list/create responses
```

Subscription diff & idempotency:

```mermaid
graph LR
  Required["Required events:\ninstall 4-1909196\nuninstall 4-1916193"] --> GET["GET current subscriptions"]
  GET --> Filter["Filter: subscriptionType == APP_LIFECYCLE_EVENT"]
  Filter --> Compare["Compare by eventTypeId"]
  Compare -->|both exist| Present["Return alreadyPresent[]"]
  Compare -->|missing| CreateMissing["Create missing POST(s)"]
  CreateMissing --> ReturnReport["Return created[] + alreadyPresent[]"]
```

---

## Testing (data-driven, traceable)
- Tests assert:
  - Env var validation and non-leakage for auth
  - Token caching TTL and deterministic expiry using injected nowMs
  - Idempotency scenarios: none exist / one exists / both exist
  - Numeric subscription ID normalization (list and create responses)
  - Admin route authentication and exact HTTP response shapes for 401/403/503/200/502/500
  - Upstream failure paths return only non-sensitive metadata (stage/status/eventTypeId)
- Test files and line counts confirmed in repo:
  - hubspot-app-auth.test.ts (248 lines)
  - hubspot-subscription-bootstrap.test.ts (370 lines)
  - lifecycle-bootstrap.test.ts (247 lines)

---

## Security summary (concise)
- Admin route protected by INTERNAL_BOOTSTRAP_TOKEN; validated with timing-safe comparison to avoid timing attacks.
- No secrets or bearer tokens are logged or returned in errors. Tests assert no secret leakage.
- In-memory token cache with conservative TTL (expires_in − 60s) to avoid expiry race conditions; cache reset helper present for tests.
- Admin route mounted outside /api/* and tenant middleware to keep operator-only surface isolated.

---

## Preflight corrections / bugfixes
- Corrected API contract: subscriptions are app-scoped and do not include per-subscription targetUrl → diff on (subscriptionType, eventTypeId).
- Coerced numeric subscription ids to strings for consistent downstream handling; tests added to cover this.

---

## How to validate & trace changes (operator/dev checklist)
- Run:
  - pnpm install
  - pnpm test
  - pnpm typecheck
  - pnpm lint
- Manual operator flow:
  - Set env: INTERNAL_BOOTSTRAP_TOKEN, HUBSPOT_APP_CLIENT_ID, HUBSPOT_APP_CLIENT_SECRET, HUBSPOT_APP_ID, LIFECYCLE_TARGET_URL
  - From CI/local: pnpm --filter @hap/api lifecycle:bootstrap → stdout: EnsureLifecycleSubscriptionsReport
  - Or call: POST /admin/lifecycle/bootstrap with X-Internal-Bootstrap-Token → 200 + identical report
- Traceability: correlate report.targetUrl to app-hsmeta.json / developer UI webhook target to verify operator intent; check security audit & runbook for expected response shapes and rotation guidance.

---

## Files of interest (quick list)
- Implementation:
  - apps/api/src/lib/hubspot-app-auth.ts
  - apps/api/src/lib/hubspot-subscription-bootstrap.ts
  - apps/api/src/routes/admin/lifecycle-bootstrap.ts
  - apps/api/scripts/lifecycle-bootstrap.ts
- Tests:
  - apps/api/src/lib/__tests__/hubspot-app-auth.test.ts
  - apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts
  - apps/api/src/routes/admin/__tests__/lifecycle-bootstrap.test.ts
- Docs:
  - docs/slice-11-preflight-notes.md
  - docs/runbooks/lifecycle-subscription-bootstrap.md
  - docs/security/slice-11-audit.md
  - docs/security/SECURITY.md §21
- Package script:
  - apps/api/package.json -> lifecycle:bootstrap

---

## Conclusion (one-line)
Implements safe, idempotent app-level bootstrap for HubSpot lifecycle subscriptions with operator-only entrypoints, conservative token caching, strict no-secret-leak policies, full test coverage, and operator runbook + security audit for traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->