### PR TITLE
settings: UX polish + surface redesign + provider connection testing (Issue A + B)

### DIFF
--- a/.claude/tasks/settings-product-followup.md
+++ b/.claude/tasks/settings-product-followup.md
@@ -1,0 +1,1057 @@
+# Plan: Settings & product follow-up (post-issue-#17)
+
+## Task Description
+
+Issue #17 (HubSpot settings extension rendering failure) landed on
+`codex/issue-17-settings-crash` at commit `c49e239`. The lane proved the
+settings surface renders; Romeo then flagged a cluster of product/UX issues
+that were previously invisible because the page couldn't load. This plan
+scopes that backlog.
+
+Requested items:
+
+1. rename card title `Account Signal` → `Account Planning`
+2. fold the separate "News" provider into the Exa surface (the adapter
+   already uses Exa; only the settings UI still treats News as its own
+   provider with its own key input)
+3. redesign the HubSpot enrichment block around tenant-specific OAuth scopes
+   instead of a fake API-key input
+4. research and recommend the best additional HubSpot scopes for stronger
+   enrichment (deals, owners, engagements, schemas, etc.)
+5. redesign the LLM settings surface so a provider dropdown drives the model
+   options and the raw endpoint URL is hidden (except for `custom`)
+6. ship a curated model catalog covering: major premium models, OpenRouter
+   top models, DeepSeek, MiniMax, and 3 open-source/free options
+7. confirm API keys are encrypted at rest, masked in the UI, and never
+   re-exposed after save
+8. add tooltips for "Freshness max days" and "Minimum confidence"
+9. display minimum confidence as a percent (`0.65 → 65%`) instead of the raw
+   decimal
+
+Issue #19 (lifecycle subscription delivery) remains explicitly out of scope.
+
+## Objective
+
+Deliver two shippable, independently verifiable issues:
+
+- **Issue A (`settings-ux-polish`)** — immediate UX cleanup with no wire or
+  schema changes. Card rename, tooltips, percent display, small text fixes.
+  No HubSpot re-auth required.
+- **Issue B (`settings-surface-redesign`)** — settings surface refactor
+  covering: drop the separate News provider (still Exa-backed at adapter
+  level), remove the fake HubSpot-enrichment API-key input, redesign LLM
+  settings with provider→model cascade and curated catalog, key masking &
+  clear flow. Wire-contract + validator + DB-settings changes; no HubSpot
+  scope change, no re-auth required.
+
+A third larger lane is explicitly deferred and tracked as a separate issue:
+
+- **Issue C (`hubspot-enrichment-scope-expansion`) — deferred.** Expand
+  OAuth scopes and enrichment adapter to read deals, owners, engagements,
+  schemas. Marketplace-listing change + forced re-install/re-auth for
+  existing tenants. Must not ride with A or B.
+
+## Prerequisite Gate
+
+Before any implementation work starts in this worktree, merge or rebase in
+the verified `#17` fix branch so the settings surface remains live during
+development:
+
+- source branch: `codex/issue-17-settings-crash`
+- required commit: `c49e239`
+
+This worktree currently points at `e8adc0b` and does **not** yet contain
+`c49e239`. Do not start Issue A or B on the pre-#17 base, or portal
+verification will regress back to the old broken settings surface and muddy
+every later result.
+
+## Problem Statement
+
+- The card is labeled `Account Signal` in the record tab, but the rest of
+  the product now calls this surface "Account Planning". Inconsistent brand.
+- The settings page shows **three** signal providers — Exa, News, HubSpot
+  enrichment — but News is really just Exa's news vertical (`category:
+"news"` against `api.exa.ai/search`), driven by the same API key. Users
+  are asked for a "News API key" that will never be used as a distinct
+  credential, which is actively misleading.
+- The HubSpot-enrichment block has an API-key `Input` with `type="password"`
+  that does nothing: the factory branch for `hubspot-enrichment` constructs
+  a `HubSpotClient` from the tenant's OAuth tokens and ignores
+  `config.apiKeyRef` entirely. The input is cosmetic and misleading.
+- LLM settings expose an `endpointUrl` text box unconditionally, a free-text
+  "Model" input, and no curated model catalog. Users can select `openai` +
+  `gemini-2.5-pro` + `https://wrong.example` and the form will accept it.
+  The wire contract allows `custom` for OpenAI-compatible endpoints — that
+  is the only case where the endpoint field should be visible.
+- Minimum confidence is shown as a raw decimal (`0.65`) with no tooltip.
+  Non-technical operators type `65` and lock themselves out of snapshots.
+- Freshness/confidence have no in-surface explanation; there is no tooltip
+  component in play.
+- Current scopes (`oauth`, `crm.objects.companies.read`,
+  `crm.objects.contacts.read`) give HubSpot enrichment very little to read.
+  Stronger enrichment needs additional scopes, which requires a marketplace
+  listing update and forced re-auth for every existing tenant.
+
+## Solution Approach
+
+Slice the work into three lanes and ship A + B. Gate C on explicit operator
+approval because it forces re-install on production tenants.
+
+**Issue A — settings-ux-polish (small, no wire change):**
+
+- `apps/hubspot-project/src/app/cards/card-hsmeta.json`: rename
+  `config.name` from `Account Signal` to `Account Planning`.
+- `apps/hubspot-extension/src/settings/settings-page.tsx`: attach HubSpot
+  `tooltip` prop to `NumberInput` for Freshness max days and Minimum
+  confidence. Use `@hubspot/ui-extensions` `NumberInput` `tooltip` prop
+  (confirm via Context7 `/hubspot/ui-extensions` docs at execution time).
+- Add explicit percent formatting for Minimum confidence: on read, multiply
+  by 100 and append `%` suffix; on write, divide by 100 back into the
+  decimal wire format. Keep the wire contract a 0..1 decimal — do NOT
+  change the validator bounds or DB field.
+- Copy review pass on all settings labels ("Account Planning" language,
+  honest descriptions for each provider).
+- Add a small regression test that asserts the wire payload for `0.65` is
+  still `0.65` after round-tripping through the percent-formatted input.
+
+**Issue B — settings-surface-redesign (moderate, wire change):**
+
+Four atomic sub-changes that must land together because they share the
+same wire contract and validator file:
+
+_B1 — Drop separate News provider from wire + UI:_
+
+- Remove `news` from `SettingsSignalProviders` / `SettingsSignalProviderUpdates`
+  in `packages/config/src/domain-types.ts`.
+- Remove `news` from `packages/validators/src/settings.ts` (both
+  `settingsResponseSchema` and `settingsUpdateSchema`).
+- Remove the "Enable News" toggle and "News API key" input from
+  `settings-page.tsx`.
+- Keep the `NewsAdapter` code path intact. Change the adapter factory:
+  the Exa provider config now drives the `news` adapter too (both use the
+  same API key). In `apps/api/src/adapters/signal/factory.ts`, construct
+  `NewsAdapter` from the `exa` provider config rather than a separate
+  `news` row when the `exa` provider is enabled.
+- DB migration: fold any existing `provider_config` row with
+  `provider_name='news'` into the Exa row's `settings` JSONB (e.g.
+  `settings.newsEnabled=true`) or drop it outright if no tenant depends on
+  it. Preflight: inspect production; if no `news` rows exist, the
+  migration is a schema cleanup only. If rows exist, merge then delete.
+- Update `apps/api/src/lib/settings-service.ts` to stop reading/writing
+  the `news` slot. Consumers of `SettingsSignalProviders.news` elsewhere:
+  grep and fix.
+
+_B2 — Remove fake HubSpot-enrichment API key input:_
+
+- Drop `hubspotEnrichmentApiKey` / `hubspotEnrichment.apiKey` from the
+  draft state and the rendered form in `settings-page.tsx`.
+- Keep the `hubspotEnrichment.enabled` toggle (that is honest).
+- Add copy: "HubSpot enrichment uses your OAuth connection. No API key
+  required."
+- Remove the `apiKey` branch from `hubspotEnrichment` in
+  `settingsUpdateSchema`. Add an explicit Zod `.strict()` (or equivalent)
+  so future wire drift fails validation.
+- Backend: ensure `updateSettings` rejects `hubspotEnrichment.apiKey` with
+  a 400 rather than silently ignoring it.
+
+_B3 — LLM settings redesign + curated catalog:_
+
+- Provider dropdown (unchanged options: none, OpenAI, Anthropic, Gemini,
+  OpenRouter, Custom) drives a second dropdown: **Model**.
+- Model dropdown is populated from a curated catalog per provider. Catalog
+  lives in `packages/config/src/llm-catalog.ts` (new file) keyed by
+  provider. The catalog is the source of truth for valid model IDs in the
+  UI; the backend still accepts any string so a customer on a fast-moving
+  provider (OpenAI, Anthropic) isn't locked out if Anthropic ships a new
+  model before we update the catalog. The catalog offers a final
+  `Other (type manually)` option that reveals a free-text `Input`.
+- Endpoint URL field is hidden unless `provider === "custom"`.
+- API key field stays masked (`type="password"`). When `hasApiKey: true`
+  is returned by the API, display "Stored key on file" and add a "Clear
+  key" button which sends `clearApiKey: true` in the update payload
+  (already supported by the wire contract).
+- Curated catalog (initial content, to be confirmed via Context7 at
+  implementation time):
+  - **OpenAI:** `gpt-5`, `gpt-4.1`, `gpt-4o`, `gpt-4o-mini`,
+    `o3`, `o4-mini`
+  - **Anthropic:** `claude-sonnet-4.5`, `claude-opus-4.5`,
+    `claude-haiku-4.5`
+  - **Gemini:** `gemini-2.5-pro`, `gemini-2.5-flash`,
+    `gemini-2.5-flash-lite`
+  - **OpenRouter (curated top):** `anthropic/claude-sonnet-4.5`,
+    `openai/gpt-5`, `google/gemini-2.5-pro`,
+    `deepseek/deepseek-v3.2`, `deepseek/deepseek-r1`,
+    `minimax/minimax-m2`, `qwen/qwen-3-235b-instruct`,
+    `meta-llama/llama-3.3-70b-instruct:free`,
+    `mistralai/mixtral-8x22b-instruct:free`,
+    `nousresearch/hermes-4-405b:free`
+  - **DeepSeek (direct, `provider=openrouter`):** `deepseek-v3.2`,
+    `deepseek-r1`
+  - **MiniMax (direct, `provider=openrouter`):** `minimax-m2`,
+    `minimax-abab-7-chat`
+  - **Open-source / free (via OpenRouter):**
+    `meta-llama/llama-3.3-70b-instruct:free`,
+    `mistralai/mixtral-8x22b-instruct:free`,
+    `nousresearch/hermes-4-405b:free`
+  - All model IDs MUST be re-verified against live docs at build time
+    (OpenAI models, Anthropic models, Gemini models, OpenRouter catalog)
+    via Context7 `/openai`, `/anthropics/claude-docs`, `/google-gemini`,
+    `/openrouter` resolves-to-latest. Do not freeze the list on the
+    contents above if docs disagree. Record the verification snapshot in
+    the commit message.
+- Catalog schema:
+  ```ts
+  export type LlmCatalogEntry = {
+    value: string; // wire value (model id)
+    label: string; // UI label
+    tier?: "premium" | "standard" | "free";
+  };
+  export const LLM_CATALOG: Record<LlmProviderType, LlmCatalogEntry[]>;
+  ```
+- Add a regression test that locks the shape of `LLM_CATALOG` (provider
+  keys, non-empty arrays, no duplicate `value` within a provider).
+
+_B4 — Provider connection testing (`Test connection` flow):_
+
+Operators currently find out their LLM or Exa credentials are wrong via
+a silently empty snapshot. The redesign must ship an explicit
+verification path so invalid credentials fail loud at save time, not
+hours later in production.
+
+- New backend endpoint: `POST /settings/test-connection`. Tenant-scoped.
+  Zod-validated body is a discriminated union:
+  ```ts
+  type TestConnectionBody =
+    | {
+        target: "llm";
+        provider: LlmProviderType;
+        model: string;
+        // Exactly one of the following:
+        apiKey?: string; // draft (unsaved) key
+        useSavedKey?: true; // resolve ciphertext from provider_config
+        endpointUrl?: string; // required when provider === "custom"
+      }
+    | {
+        target: "exa";
+        apiKey?: string;
+        useSavedKey?: true;
+      };
+  ```
+  Response is a narrow status:
+  ```ts
+  type TestConnectionResponse =
+    | { ok: true; latencyMs: number; providerEcho?: { model?: string } }
+    | {
+        ok: false;
+        code:
+          | "auth"
+          | "model"
+          | "endpoint"
+          | "network"
+          | "rate_limit"
+          | "unknown";
+        message: string;
+      };
+  ```
+- Per-provider test logic owned by a new backend service
+  (`apps/api/src/lib/settings-connection-test.ts`):
+  - **OpenAI:** cheapest check is `GET /v1/models` (auth-only, no billed
+    tokens); verify the selected `model` id appears in the list.
+  - **Anthropic:** `POST /v1/messages` with `max_tokens: 1` and a
+    single-char prompt using the selected model id.
+  - **Gemini:** `GET /v1beta/models/{model}` or a 1-token
+    `generateContent` — whichever is cheaper at implementation time;
+    confirm via Context7 `/google-gemini` at build time.
+  - **OpenRouter:** `GET /api/v1/models` + filter by model slug for
+    existence; optionally a 1-token completion to confirm the key has
+    that model enabled.
+  - **Custom (OpenAI-compatible):** `GET {endpointUrl}/models` with the
+    draft/saved key, validate response is JSON and contains the model
+    id.
+  - **Exa:** `POST https://api.exa.ai/search` with `query: "test"`,
+    `numResults: 1`.
+- Saved-key path: server loads ciphertext from `provider_config` for the
+  current tenant, decrypts in-process, passes to the vendor call, and
+  discards. The plaintext key MUST NOT leave the process memory, MUST
+  NOT be written to logs, and MUST NOT appear in error responses.
+- Draft-key path: request-body key is used for the vendor call, then
+  discarded. Never stored. Never echoed.
+- Frontend: one `Test connection` button per target (LLM block, Exa
+  block). Button uses draft key if the password input has any value,
+  otherwise sends `useSavedKey: true`. Disabled when neither a draft
+  key nor a stored key is present. Inline status component renders
+  success (green check + latency) or failure (red + error code + short
+  human message from the response). Never auto-fires on keystroke.
+- Rate limiting: per-tenant token-bucket, e.g. 5 tests/min, to prevent
+  the test path from becoming a free-tier DoS vector.
+- SSRF guard: when `provider === "custom"` or `target === "exa"` is
+  ever parameterized with user-supplied URLs, the backend must reject
+  loopback / link-local / private-range / cloud-metadata hosts; HTTPS
+  only.
+- No vendor error body is returned verbatim to the client. The backend
+  maps vendor errors to the narrow `code` union and a short sanitized
+  `message`. Vendor HTTP status is logged server-side (no key leakage)
+  for observability.
+- Failing-first tests (backend): route rejects missing discriminator
+  (400), route rejects both `apiKey` and `useSavedKey` set together
+  (400), service maps a 401 from the vendor mock to `{ ok: false, code:
+"auth" }`, service never logs the key (assert against a captured
+  logger spy), cross-tenant isolation (tenant A cannot test tenant B's
+  saved key).
+- Failing-first tests (frontend): button disabled when no key and no
+  stored key; clicking with draft key sends `apiKey` (never
+  `useSavedKey`); clicking with stored key sends `useSavedKey: true`
+  (never the masked placeholder); success state renders latency;
+  failure state renders the error code.
+
+**Issue C — hubspot-enrichment-scope-expansion (DEFERRED):**
+
+Research-backed scope recommendation (must be re-verified against
+`https://developers.hubspot.com/docs/guides/apps/authentication/scopes` at
+implementation time):
+
+| Scope                        | Why                                             |
+| ---------------------------- | ----------------------------------------------- |
+| `crm.objects.deals.read`     | Open pipeline deals are a top reason-to-contact |
+| `crm.objects.owners.read`    | Account owner context / reason-to-talk routing  |
+| `crm.schemas.companies.read` | Property metadata for safe field reads          |
+| `crm.schemas.contacts.read`  | Ditto for contacts                              |
+| `crm.objects.notes.read`     | Recent human context on the account             |
+| `sales-email-read`           | Historical outbound context (evaluate vs v3)    |
+| `tickets`                    | Support-driven reasons (evaluate demand)        |
+| `crm.lists.read`             | Segmentation, target-account lists              |
+
+The engagement-oriented reads (notes/tasks/meetings/emails/calls) use the
+v3 Engagements API, which in 2026 is gated under
+`crm.objects.*_engagements.read`-style scopes — verify current names via
+Context7 before committing to the list. Add `optionalScopes` entries where
+the UX can degrade gracefully; require only what the critical path needs.
+
+Issue C must:
+
+- Update `apps/hubspot-project/src/app/app-hsmeta.json` `requiredScopes` /
+  `optionalScopes`.
+- Extend `HubSpotClient` with the new reads.
+- Extend `HubSpotEnrichmentAdapter` to emit richer evidence (deals,
+  owners, engagements).
+- Coordinate marketplace listing update + migration path (document the
+  forced re-install for every tenant).
+- NEVER ride with Issue A or B.
+
+## Relevant Files
+
+Use these files to complete the task (Issues A + B only):
+
+- `apps/hubspot-project/src/app/cards/card-hsmeta.json` — card rename
+  (Issue A).
+- `apps/hubspot-extension/src/settings/settings-page.tsx` — main UI
+  surface. All A + B UI changes land here. Currently renders three
+  toggles + three password inputs + LLM block with free-text model and
+  unconditional endpoint URL.
+- `apps/hubspot-extension/src/settings/use-settings.ts` — read/save hook;
+  wire-format change (percent, dropped news, dropped enrichment key) must
+  flow through here.
+- `apps/hubspot-extension/src/settings/api-fetcher.ts` — JSON fetch
+  shapes; re-align with new wire contract.
+- `packages/config/src/domain-types.ts` — wire contract for
+  `SettingsSignalProviders`, `SettingsUpdate.llm`. Drop `news`, drop
+  enrichment `apiKey`.
+- `packages/validators/src/settings.ts` — Zod schemas mirroring the wire
+  contract. Drop `news`, drop enrichment `apiKey`, add strict object
+  mode.
+- `apps/api/src/lib/settings-service.ts` — read/write path. Drop news
+  slot. Reject enrichment `apiKey`.
+- `apps/api/src/routes/settings.ts` — stable; only runs the new
+  validators.
+- `apps/api/src/adapters/signal/factory.ts` — rewire `news` branch to
+  build from the Exa provider config + exa API key. Keep the adapter.
+- `apps/api/src/adapters/signal/news.ts` — adapter itself unchanged.
+- `packages/db/src/schema/provider-config.ts` — no schema column change.
+  Data migration for any existing `provider_name='news'` row.
+- `packages/db/drizzle/<next-migration>.sql` — new migration file for the
+  news-row cleanup (see New Files).
+- Tests:
+  - `apps/hubspot-extension/src/settings/settings-entry.test.tsx`
+  - `apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx`
+  - `apps/hubspot-extension/src/settings/__tests__/use-settings.test.tsx`
+  - `apps/api/src/routes/__tests__/settings.test.ts`
+  - `apps/api/src/lib/__tests__/settings-service.test.ts`
+  - `apps/api/src/adapters/signal/__tests__/factory.test.ts`
+
+B4 (connection testing) adds:
+
+- `apps/api/src/routes/settings-test-connection.ts` — narrow route.
+- `apps/api/src/lib/settings-connection-test.ts` — per-provider + Exa
+  test service.
+- `packages/validators/src/settings.ts` — extend with
+  `testConnectionBodySchema` + `testConnectionResponseSchema`.
+- `packages/config/src/domain-types.ts` — extend with
+  `TestConnectionBody` + `TestConnectionResponse` wire types.
+- `apps/hubspot-extension/src/settings/connection-test-status.tsx` —
+  tiny inline status component (success/failure rendering).
+- `apps/hubspot-extension/src/settings/use-settings.ts` — add
+  `testConnection()` helper that wraps the fetch.
+
+### New Files
+
+- `packages/config/src/llm-catalog.ts` — curated model catalog keyed by
+  `LlmProviderType`.
+- `packages/config/src/__tests__/llm-catalog.test.ts` — locks the catalog
+  shape.
+- `packages/db/drizzle/<timestamp>_drop-news-provider.sql` — data
+  migration to merge/delete any `provider_name='news'` rows.
+- `apps/hubspot-extension/src/settings/percent-format.ts` — small helper
+  - unit tests for the percent ↔ decimal conversion.
+- `apps/api/src/routes/settings-test-connection.ts` + test — B4 route.
+- `apps/api/src/routes/__tests__/settings-test-connection.test.ts` — B4
+  route integration tests (draft key, saved key, cross-tenant, SSRF
+  guard, rate limit, sanitized errors).
+- `apps/api/src/lib/settings-connection-test.ts` + test — B4 service.
+- `apps/api/src/lib/__tests__/settings-connection-test.test.ts` —
+  per-provider unit tests with mocked vendor fetches.
+- `apps/hubspot-extension/src/settings/connection-test-status.tsx` +
+  test — B4 inline status component.
+- `apps/hubspot-extension/src/settings/__tests__/connection-test-status.test.tsx`
+  — button-disabled, draft-vs-saved dispatch, success/failure render.
+
+## Implementation Phases
+
+### Phase 1: Foundation
+
+- Merge `codex/issue-17-settings-crash` (`c49e239`) into this branch
+  before delegating any implementation tasks. Treat this as a hard gate,
+  not an optional note.
+- Verify current `@hubspot/ui-extensions` `NumberInput` / `Select` APIs
+  support tooltips + provider-dropdown layout via Context7
+  (`/hubspot/ui-extensions`, resolve-latest). Lock any API surprises
+  here, not mid-implementation.
+- Re-verify the curated model catalog against live docs:
+  OpenAI, Anthropic, Gemini, OpenRouter. Record the verification
+  snapshot in the PR body.
+- Confirm (via DB inspection in local + staging if available) whether
+  any tenant has a `provider_name='news'` row. Drives whether the
+  migration is delete-only or merge-then-delete.
+
+### Phase 2: Core Implementation
+
+- Land Issue A on its own branch (`codex/settings-ux-polish`). Ship and
+  verify in portal before starting Issue B.
+- Start Issue B on a new branch (`codex/settings-surface-redesign`).
+  Order inside B:
+  B2 first (remove fake enrichment key — smallest wire delta),
+  B3 next (LLM redesign + catalog),
+  B1 (drop news — largest wire + DB delta),
+  B4 last (connection testing — depends on the finalized wire +
+  settings-page so the button wiring has a stable surface).
+- Every sub-change follows red → green TDD discipline per
+  `AI_CODING_RULES_AND_STANDARDS.md`.
+
+### Phase 3: Integration & Polish
+
+- Full portal smoke: save/reload settings, confirm masked keys, confirm
+  percent display, confirm model dropdown switches, confirm endpoint URL
+  appears only under `custom`.
+- Confirm zero snapshot regressions (`snapshot-assembler` + adapter
+  tests still green).
+- Ship Issue A PR first, then Issue B.
+
+## Team Orchestration
+
+- You operate as the team lead and orchestrate the team to execute the plan.
+- You're responsible for deploying the right team members with the right context to execute the plan.
+- IMPORTANT: You NEVER operate directly on the codebase. You use `Task` and `Task*` tools to deploy team members to the building, validating, testing, deploying, and other tasks.
+  - This is critical. Your job is to act as a high level director of the team, not a builder.
+  - Your role is to validate all work is going well and make sure the team is on track to complete the plan.
+  - You'll orchestrate this by using the Task\* Tools to manage coordination between the team members.
+  - Communication is paramount. You'll use the Task\* Tools to communicate with the team members and ensure they're on track to complete the plan.
+- Take note of the session id of each team member. This is how you'll reference them.
+
+### Team Members
+
+- Specialist
+  - Name: `builder-ux-polish`
+  - Role: Issue A. Card rename, tooltips, percent-display helper, all
+    within `apps/hubspot-extension/src/settings/` and
+    `apps/hubspot-project/src/app/cards/card-hsmeta.json`. TDD: failing
+    percent-format test first, green after.
+  - Agent Type: `frontend-specialist`
+  - Resume: true
+- Specialist
+  - Name: `builder-wire-contract`
+  - Role: Issue B wire + validator + domain-types changes
+    (`packages/config`, `packages/validators`). Drops `news`, drops
+    enrichment `apiKey`, adds the LLM catalog module + shape test.
+  - Agent Type: `backend-engineer`
+  - Resume: true
+- Specialist
+  - Name: `builder-settings-backend`
+  - Role: Issue B backend. `apps/api/src/lib/settings-service.ts`,
+    `apps/api/src/routes/settings.ts`, adapter factory wiring so the
+    `news` adapter is driven by the Exa provider row. DB migration to
+    merge/drop existing `news` provider rows.
+  - Agent Type: `backend-engineer`
+  - Resume: true
+- Specialist
+  - Name: `builder-settings-frontend`
+  - Role: Issue B frontend. Rewrite `settings-page.tsx` for the new
+    surface: provider→model cascade, curated catalog, conditional
+    endpoint URL, key masking + clear, enrichment OAuth copy, single
+    Exa toggle.
+  - Agent Type: `frontend-specialist`
+  - Resume: true
+- Security Reviewer
+  - Name: `security-review`
+  - Role: Confirm AES-256-GCM envelope path still in force, masked
+    inputs + `hasApiKey` boolean are the only surfaces, `clearApiKey`
+    path verified, no accidental plaintext leakage in logs or error
+    bodies.
+  - Agent Type: `security-auditor`
+  - Resume: false
+- Quality Engineer (Validator)
+  - Name: `validator`
+  - Role: Validate completed work against acceptance criteria
+    (read-only inspection mode). Runs every validation command, records
+    pass/fail, confirms no out-of-scope files touched.
+  - Agent Type: quality-engineer
+  - Resume: false
+
+## Step by Step Tasks
+
+- IMPORTANT: Execute every step in order, top to bottom. Each task maps directly to a `TaskCreate` call.
+- Before you start, run `TaskCreate` to create the initial task list that all team members can see and execute.
+
+### 0. Preflight: merge the verified #17 fix first
+
+- **Task ID**: `merge-issue-17-base`
+- **Depends On**: none
+- **Assigned To**: team lead / operator
+- **Parallel**: false
+- Merge or rebase `codex/issue-17-settings-crash` into
+  `codex/settings-product-followup` so commit `c49e239` is reachable from
+  `HEAD` before starting any delegated work.
+- Verify with:
+  - `git merge-base --is-ancestor c49e239 HEAD`
+  - exit code must be `0`
+- If this preflight is not satisfied, stop. Do not delegate Issue A or B.
+
+### 1. Research: HubSpot UI-extensions tooltip & Select APIs
+
+- **Task ID**: `research-ui-extension-apis`
+- **Depends On**: none
+- **Assigned To**: `builder-ux-polish`
+- **Agent Type**: `frontend-specialist`
+- **Parallel**: true
+- Use Context7 (`/hubspot/ui-extensions` — resolve latest) to confirm:
+  - `NumberInput` supports `tooltip` prop (or the equivalent).
+  - `Select` supports a reactive re-render when options change.
+- Capture the verified API surface in a short note in the PR body.
+
+### 2. Research: curated LLM model catalog verification
+
+- **Task ID**: `research-llm-catalog`
+- **Depends On**: none
+- **Assigned To**: `builder-wire-contract`
+- **Agent Type**: `backend-engineer`
+- **Parallel**: true
+- Verify each model ID against live docs via Context7:
+  `/openai` OpenAI platform, `/anthropics/claude-docs` Anthropic,
+  `/google-gemini` Gemini, `/openrouter` OpenRouter.
+- Produce the final model list per provider (update the catalog list in
+  this plan's Phase 1 section if any ID is wrong or missing).
+- Record the verification snapshot (library id + topic + date) in the
+  commit message.
+
+### 3. Issue A: card rename
+
+- **Task ID**: `rename-card-account-planning`
+- **Depends On**: `research-ui-extension-apis`
+- **Assigned To**: `builder-ux-polish`
+- **Agent Type**: `frontend-specialist`
+- **Parallel**: false
+- Change `apps/hubspot-project/src/app/cards/card-hsmeta.json`
+  `config.name` from `"Account Signal"` to `"Account Planning"`.
+- Grep the repo for other user-facing `"Account Signal"` copy; change
+  those too (e.g., docs, PR templates), but scope strictly to
+  user-facing strings — do not rename code identifiers.
+- Rebuild via `pnpm tsx scripts/bundle-hubspot-card-cli.ts`; verify the
+  rebuilt card bundle still externalizes React.
+
+### 4. Issue A: percent-format helper + test (red → green)
+
+- **Task ID**: `percent-format-helper`
+- **Depends On**: `research-ui-extension-apis`
+- **Assigned To**: `builder-ux-polish`
+- **Agent Type**: `frontend-specialist`
+- **Parallel**: true (with task 3)
+- Create
+  `apps/hubspot-extension/src/settings/percent-format.ts` with
+  `decimalToPercent(n: number): number` (multiply by 100, round to 1
+  decimal) and `percentToDecimal(n: number): number` (divide by 100,
+  clamp 0..1).
+- Create `__tests__/percent-format.test.ts` asserting round-trip for
+  `0`, `0.65`, `1`, boundary rounding, and NaN-rejection.
+- Confirm red first, then green.
+
+### 5. Issue A: tooltips + percent display in settings page
+
+- **Task ID**: `tooltips-and-percent`
+- **Depends On**: `percent-format-helper`, `research-ui-extension-apis`
+- **Assigned To**: `builder-ux-polish`
+- **Agent Type**: `frontend-specialist`
+- **Parallel**: false
+- In `settings-page.tsx`:
+  - Attach `tooltip` prop to the two `NumberInput` controls:
+    - Freshness max days: "Evidence older than this is treated as stale
+      and won't feed the reason-to-contact."
+    - Minimum confidence: "Evidence below this confidence (0–100%) is
+      dropped before it reaches the UI."
+  - Wrap the min-confidence NumberInput with the percent helpers so the
+    user sees `65` / `65%` while the wire payload stays `0.65`.
+- Update
+  `apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx`
+  to assert the percent round-trip and that the tooltip prop is set.
+
+### 6. Issue A: Release Issue A
+
+- **Task ID**: `ship-issue-a`
+- **Depends On**: `rename-card-account-planning`, `tooltips-and-percent`
+- **Assigned To**: `builder-ux-polish`
+- **Agent Type**: `frontend-specialist`
+- **Parallel**: false
+- Run the focused validation commands (see Validation Commands).
+- Rebuild bundles; operator smoke-tests the portal.
+- Open PR for Issue A. Do not start Issue B work until A is merged (or
+  Romeo explicitly greenlights parallel work).
+
+### 7. Issue B: pre-migration DB inspection
+
+- **Task ID**: `inspect-news-rows`
+- **Depends On**: `ship-issue-a`
+- **Assigned To**: `builder-settings-backend`
+- **Agent Type**: `backend-engineer`
+- **Parallel**: false
+- Query local + staging for
+  `SELECT tenant_id, enabled FROM provider_config WHERE provider_name = 'news';`
+- Record findings. Drives migration strategy (merge/delete vs preserve
+  for manual follow-up in the `news`-only case).
+
+### 8. Issue B: wire contract + validators update
+
+- **Task ID**: `wire-drop-news-and-enrichment-key`
+- **Depends On**: `ship-issue-a`, `research-llm-catalog`
+- **Assigned To**: `builder-wire-contract`
+- **Agent Type**: `backend-engineer`
+- **Parallel**: true (with task 7)
+- Remove `news` from `SettingsSignalProviders` and
+  `SettingsSignalProviderUpdates` in
+  `packages/config/src/domain-types.ts`.
+- Remove `apiKey` from the `hubspotEnrichment` update leaf.
+- Remove both from `packages/validators/src/settings.ts`. Add `.strict()`
+  to the signal-providers object schema (or equivalent) so unknown keys
+  fail validation.
+- Create `packages/config/src/llm-catalog.ts` with the curated catalog
+  finalized in task 2.
+- Add `packages/config/src/__tests__/llm-catalog.test.ts` locking the
+  catalog shape.
+- Red-first: add a failing test asserting the new wire shape, watch it
+  fail, then apply the change.
+
+### 9. Issue B: settings-service backend update
+
+- **Task ID**: `settings-service-drop-news`
+- **Depends On**: `wire-drop-news-and-enrichment-key`,
+  `inspect-news-rows`
+- **Assigned To**: `builder-settings-backend`
+- **Agent Type**: `backend-engineer`
+- **Parallel**: false
+- `apps/api/src/lib/settings-service.ts`: stop reading/writing the
+  `news` slot. Reject `hubspotEnrichment.apiKey` explicitly (defense in
+  depth — validator should already catch it, but a 400 guard is cheap).
+- Add failing unit tests in
+  `apps/api/src/lib/__tests__/settings-service.test.ts` (reject
+  enrichment apiKey, no news slot).
+- Add failing route test in
+  `apps/api/src/routes/__tests__/settings.test.ts` (POST with news field
+  returns 400).
+
+### 10. Issue B: signal adapter factory rewire
+
+- **Task ID**: `factory-news-from-exa`
+- **Depends On**: `settings-service-drop-news`
+- **Assigned To**: `builder-settings-backend`
+- **Agent Type**: `backend-engineer`
+- **Parallel**: false
+- In `apps/api/src/adapters/signal/factory.ts`: when building the `news`
+  adapter, source the API key from the Exa provider config instead of a
+  separate `news` row. Keep both adapters running (Exa news vertical
+  remains a distinct evidence source; we just share a single credential).
+- Decide gating: `NewsAdapter` runs only if Exa is enabled. Add a
+  settings-JSONB flag on the Exa row (`settings.newsEnabled: boolean`,
+  default true) so operators can still turn off news specifically
+  without disabling Exa.
+- Update `apps/api/src/adapters/signal/__tests__/factory.test.ts` to
+  cover: Exa row → builds both adapters; Exa disabled → neither runs;
+  `settings.newsEnabled=false` → only Exa main runs.
+
+### 11. Issue B: DB migration for news rows
+
+- **Task ID**: `db-migrate-drop-news`
+- **Depends On**: `factory-news-from-exa`
+- **Assigned To**: `builder-settings-backend`
+- **Agent Type**: `backend-engineer`
+- **Parallel**: false
+- Write a new migration `<timestamp>_drop-news-provider.sql` that:
+  - For each tenant with both `news` and `exa` rows: set Exa's
+    `settings.newsEnabled` to (news.enabled) and delete the news row.
+  - For each tenant with only a `news` row and no `exa` row: leave the
+    news row but log a warning in the migration script (no tenant data
+    loss).
+  - For tenants with neither: no-op.
+- Add an integration test that boots the migration against a fixture DB
+  with all three cases.
+
+### 12. Issue B: frontend settings-page rewrite
+
+- **Task ID**: `settings-page-rewrite`
+- **Depends On**: `wire-drop-news-and-enrichment-key`
+- **Assigned To**: `builder-settings-frontend`
+- **Agent Type**: `frontend-specialist`
+- **Parallel**: false
+- Rewrite `settings-page.tsx` per the Solution Approach:
+  - Single Exa provider section (rename label to "Web research (Exa)"
+    or similar — lock exact copy via task 1 research).
+  - Remove News toggle + News key input.
+  - Remove HubSpot enrichment API key input. Keep toggle. Add OAuth
+    explainer copy.
+  - LLM section: Provider dropdown → Model dropdown from
+    `LLM_CATALOG`. Conditional Endpoint URL field for `provider ===
+"custom"`. Clear-key button when `hasApiKey` is true (sends
+    `clearApiKey: true`).
+  - Wire the percent-format helper from Issue A into Minimum confidence.
+- Update `__tests__/settings-page.test.tsx` to cover:
+  - Only Exa + HubSpot enrichment sections render.
+  - No News-related controls exist.
+  - No HubSpot enrichment API key input exists.
+  - Endpoint URL only appears for Custom.
+  - Model dropdown switches when Provider switches.
+  - Clear-key button sends the right payload.
+
+### 12a. Issue B (B4): test-connection endpoint scaffold
+
+- **Task ID**: `test-connection-endpoint-scaffold`
+- **Depends On**: `wire-drop-news-and-enrichment-key`
+- **Assigned To**: `builder-settings-backend`
+- **Agent Type**: `backend-engineer`
+- **Parallel**: true (with `settings-page-rewrite`)
+- Extend `packages/config/src/domain-types.ts` with
+  `TestConnectionBody` and `TestConnectionResponse` wire types per the
+  Solution Approach B4 spec (discriminated union on `target`).
+- Extend `packages/validators/src/settings.ts` with
+  `testConnectionBodySchema` + `testConnectionResponseSchema`.
+  `.strict()` on every object; refine to reject `apiKey` + `useSavedKey`
+  present together (XOR).
+- Add a new Hono route at `apps/api/src/routes/settings-test-connection.ts`
+  mounted under the existing settings router. Enforce tenant auth
+  middleware (reuse whatever `routes/settings.ts` already uses). Dispatch
+  to the service layer by discriminator. Sanitize all vendor errors to
+  the narrow `code` union.
+- Wire a per-tenant rate limiter (5 req/min default). Pick the existing
+  rate-limit primitive in the codebase if one exists; otherwise add a
+  minimal in-memory token-bucket keyed by `tenant_id`.
+- Red-first: add failing tests in
+  `apps/api/src/routes/__tests__/settings-test-connection.test.ts`:
+  - 400 on missing `target`
+  - 400 when `apiKey` and `useSavedKey` both set
+  - 400 when `custom` provider lacks `endpointUrl`
+  - 401/403 for untenanted request
+  - cross-tenant isolation: tenant A cannot hit tenant B's saved key
+  - rate limit triggers 429 after N calls
+  - success response shape matches the schema (type-check test)
+
+### 12b. Issue B (B4): LLM connection-test service
+
+- **Task ID**: `llm-connection-test-service`
+- **Depends On**: `test-connection-endpoint-scaffold`
+- **Assigned To**: `builder-settings-backend`
+- **Agent Type**: `backend-engineer`
+- **Parallel**: true (with `exa-connection-test-service`)
+- In `apps/api/src/lib/settings-connection-test.ts`, add
+  `testLlmConnection(tenantId, body)` covering all 5 provider branches:
+  - OpenAI → `GET /v1/models`
+  - Anthropic → `POST /v1/messages` `max_tokens: 1`
+  - Gemini → cheapest verified endpoint (confirm via Context7 at build
+    time)
+  - OpenRouter → `GET /api/v1/models` + slug filter
+  - Custom → `GET {endpointUrl}/models` with SSRF guard
+- Saved-key path: load ciphertext via the existing encryption helper,
+  decrypt in-process, never log, never echo.
+- Red-first tests (unit level with mocked fetch):
+  - each provider maps 401 → `{ ok: false, code: "auth" }`
+  - each provider maps 404-on-model → `{ ok: false, code: "model" }`
+  - custom provider rejects http://localhost/, 169.254.169.254, 10.x,
+    172.16.x, 192.168.x URLs with `code: "endpoint"`
+  - custom provider rejects non-HTTPS with `code: "endpoint"`
+  - success returns `latencyMs > 0` and `providerEcho.model`
+  - logger spy receives no plaintext key fragment
+
+### 12c. Issue B (B4): Exa connection-test service
+
+- **Task ID**: `exa-connection-test-service`
+- **Depends On**: `test-connection-endpoint-scaffold`
+- **Assigned To**: `builder-settings-backend`
+- **Agent Type**: `backend-engineer`
+- **Parallel**: true (with `llm-connection-test-service`)
+- In the same `settings-connection-test.ts` module, add
+  `testExaConnection(tenantId, body)`:
+  - POST `https://api.exa.ai/search` with a trivial query + `numResults:
+1` using draft-or-saved key.
+  - Map 401/403 → `code: "auth"`; 429 → `code: "rate_limit"`;
+    network/5xx → `code: "network"`.
+- Red-first tests (same test file):
+  - 401 → `code: "auth"`
+  - 429 → `code: "rate_limit"`
+  - success returns `latencyMs > 0`
+  - logger spy receives no plaintext key fragment
+  - saved-key path loads ciphertext for the correct tenant only
+
+### 12d. Issue B (B4): Test-connection UI
+
+- **Task ID**: `test-connection-ui`
+- **Depends On**: `settings-page-rewrite`, `llm-connection-test-service`,
+  `exa-connection-test-service`
+- **Assigned To**: `builder-settings-frontend`
+- **Agent Type**: `frontend-specialist`
+- **Parallel**: false
+- Add `apps/hubspot-extension/src/settings/connection-test-status.tsx`
+  — tiny component rendering one of: idle, loading (spinner), success
+  (green check + `{latencyMs}ms`), failure (red + `{code}: {message}`).
+- Add a `testConnection()` helper to
+  `apps/hubspot-extension/src/settings/use-settings.ts`.
+- Add a `Test connection` button to the LLM block AND the Exa block in
+  `settings-page.tsx`:
+  - Disabled when no draft key AND no `hasApiKey` on file.
+  - Uses draft key if the password input has a value, otherwise sends
+    `useSavedKey: true`. Never sends the masked placeholder.
+  - Never auto-fires on keystroke. Only on click.
+  - Renders `connection-test-status.tsx` inline directly below the
+    button.
+- Red-first tests in
+  `apps/hubspot-extension/src/settings/__tests__/connection-test-status.test.tsx`
+  and
+  `apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx`:
+  - button disabled when neither draft nor saved key exists
+  - click with draft key sends `apiKey`, never `useSavedKey`
+  - click with stored key only sends `useSavedKey: true`
+  - success status renders latency
+  - failure status renders `code` and `message`
+  - status component does NOT auto-fire on input change
+
+### 13. Issue B: security review
+
+- **Task ID**: `issue-b-security-review`
+- **Depends On**: `settings-page-rewrite`, `db-migrate-drop-news`
+- **Assigned To**: `security-review`
+- **Agent Type**: `security-auditor`
+- **Parallel**: false
+- Confirm AES-256-GCM envelope is still used for Exa + LLM key
+  persistence, `keyVersion` path intact, masked inputs (`type=password`),
+  no plaintext in server logs or error bodies, `clearApiKey` clears both
+  ciphertext and key version correctly, multi-tenant isolation on the
+  affected queries.
+- Operates in read-only review mode; report findings, do not modify
+  files.
+
+### 14. Issue B: final validation
+
+- **Task ID**: `validate-all`
+- **Depends On**: `settings-page-rewrite`, `db-migrate-drop-news`,
+  `issue-b-security-review`
+- **Assigned To**: `validator`
+- **Agent Type**: `quality-engineer`
+- **Parallel**: false
+- Run all Validation Commands.
+- Verify acceptance criteria met (every bullet in the Acceptance Criteria
+  section).
+- Operate in validation mode: inspect and report only, do not modify
+  files.
+- Confirm zero changes to lifecycle code (issue #19), Taskmaster state,
+  `apps/hubspot-project/src/app/app-hsmeta.json` (no scope changes —
+  scope work is Issue C).
+
+### 15. Issue B: PR + operator verification
+
+- **Task ID**: `ship-issue-b`
+- **Depends On**: `validate-all`
+- **Assigned To**: `builder-settings-frontend`
+- **Agent Type**: `frontend-specialist`
+- **Parallel**: false
+- Open PR for Issue B.
+- Operator runs `pnpm tsx scripts/hs-project-upload.ts --profile local`
+  and verifies the portal surface.
+- Issue C remains deferred; do NOT start it in this lane.
+
+## Acceptance Criteria
+
+Issue A:
+
+1. `apps/hubspot-project/src/app/cards/card-hsmeta.json` `config.name`
+   reads `Account Planning`.
+2. Freshness max days and Minimum confidence both have tooltips
+   rendered in the HubSpot settings page.
+3. Minimum confidence is displayed to the operator as a percent
+   (`0.65 ↔ 65%`), but the wire/DB value is still the raw decimal
+   `0.65`. Round-trip test locks this invariant.
+4. Existing settings behavior unchanged otherwise.
+5. No scope changes, no wire contract changes, no DB changes.
+
+Issue B:
+
+6. `SettingsSignalProviders` and `SettingsSignalProviderUpdates` no
+   longer expose `news`.
+7. `SettingsUpdate.llm` no longer accepts an `apiKey` field on
+   `hubspotEnrichment`. The validator rejects it (400).
+8. `NewsAdapter` still runs and produces evidence, now driven by the
+   Exa provider's API key; disabling Exa disables News; Exa-row
+   `settings.newsEnabled=false` disables News only.
+9. DB migration handles all three tenant states truthfully:
+   - both `news` + `exa` rows: merge into Exa and delete the news row
+   - `exa`-only: no-op
+   - `news`-only: do **not** silently delete tenant data; either preserve
+     the row for manual follow-up or convert it safely via an explicit
+     migration rule proved by test
+10. Settings page renders: one Exa section (no separate News), HubSpot
+    enrichment section with OAuth copy and NO API key input, LLM
+    section with provider dropdown → model dropdown, endpoint URL field
+    appears only for `provider === "custom"`, API key field is masked,
+    Clear-key button posts `clearApiKey: true`.
+11. `packages/config/src/llm-catalog.ts` exists and is covered by a
+    shape test; catalog includes OpenAI, Anthropic, Gemini, OpenRouter
+    curated top models, DeepSeek, MiniMax, and at least 3 open-source /
+    free options.
+12. AES-256-GCM envelope still used for Exa + LLM keys; `hasApiKey`
+    boolean is the only exposure; security review signs off.
+13. No changes to `apps/hubspot-project/src/app/app-hsmeta.json` scopes.
+14. No changes to lifecycle files (issue #19), no Taskmaster changes,
+    no changes outside the Relevant Files list.
+15. All focused tests green; portal smoke passes.
+
+Issue B — B4 (connection testing):
+
+16. `POST /settings/test-connection` exists, is tenant-scoped, and
+    validates the discriminated-union body. Missing or ambiguous body
+    fields return 400.
+17. LLM test path verifies (a) API key accepted by the provider, (b)
+    selected model is callable, and (c) for `provider === "custom"` the
+    endpoint URL is valid (HTTPS, non-private, non-metadata). Failures
+    are mapped to `code ∈ { auth, model, endpoint, network, rate_limit,
+unknown }` with a sanitized `message`.
+18. Exa test path verifies the Exa API key by performing a minimal
+    `api.exa.ai/search` call with a trivial query.
+19. Both paths support a draft (unsaved) key via `apiKey` in the request
+    body AND a saved key via `useSavedKey: true`. Draft and saved are
+    mutually exclusive (XOR enforced by validator).
+20. Plaintext keys NEVER appear in HTTP responses, server logs, or
+    error bodies. Logger-spy tests assert no key fragment leaks.
+21. Tenants cannot test another tenant's saved key — cross-tenant
+    isolation test green.
+22. Per-tenant rate limit returns 429 after threshold (default 5/min)
+    and the limiter is covered by a test.
+23. Frontend renders a `Test connection` button in the LLM block AND
+    the Exa block. Button is disabled when no draft key and no
+    `hasApiKey` on file. Button never auto-fires on keystroke.
+24. Inline status UI renders idle / loading / success (latency) /
+    failure (code + message). No automatic retest on input change.
+25. No plaintext key value is passed to the status component or stored
+    in frontend state beyond the single in-flight request body.
+
+## Validation Commands
+
+Execute these commands to validate the task is complete:
+
+Issue A:
+
+- `git merge-base --is-ancestor c49e239 HEAD` — expect exit code `0`
+  before any other command in this lane.
+- `pnpm exec vitest run apps/hubspot-extension/src/settings` — settings
+  UI and percent-format tests.
+- `API_ORIGIN=https://hap.mandigital.dev pnpm tsx scripts/bundle-hubspot-card-cli.ts`
+  — rebuild bundles with a real origin.
+- `grep -c "Account Signal" apps/hubspot-project/src/app/cards/card-hsmeta.json`
+  — expect 0.
+- Operator portal smoke: open the company record, confirm card title is
+  "Account Planning"; open Connected Apps → HAP Signal Workspace →
+  Settings, confirm tooltips appear and minimum confidence shows `%`.
+
+Issue B:
+
+- `git merge-base --is-ancestor c49e239 HEAD` — expect exit code `0`
+  before any Issue B work begins.
+- `pnpm exec vitest run packages/config packages/validators` — wire +
+  validator + catalog tests.
+- `pnpm exec vitest run apps/api/src/lib/__tests__/settings-service.test.ts apps/api/src/routes/__tests__/settings.test.ts`
+  — backend settings tests.
+- `pnpm exec vitest run apps/api/src/adapters/signal/__tests__/factory.test.ts`
+  — signal factory rewire.
+- `pnpm exec vitest run apps/hubspot-extension/src/settings` — frontend
+  settings tests.
+- Run the DB migration against a local fixture DB with all three
+  tenant-state cases (news-only, exa-only, both) and verify the
+  resulting rows.
+- Operator portal smoke: save the settings page with a new Exa key,
+  reload, confirm "Stored key on file"; swap providers in the LLM
+  dropdown and confirm the model dropdown updates; select Custom and
+  confirm Endpoint URL appears.
+
+Issue B — B4 (connection testing):
+
+- `pnpm exec vitest run apps/api/src/routes/__tests__/settings-test-connection.test.ts`
+  — route scaffold, 400/401/403/429 paths, XOR enforcement, cross-tenant
+  isolation.
+- `pnpm exec vitest run apps/api/src/lib/__tests__/settings-connection-test.test.ts`
+  — per-provider mapping (OpenAI/Anthropic/Gemini/OpenRouter/Custom/Exa),
+  SSRF guard, logger-spy leak check, saved-key tenant scoping.
+- `pnpm exec vitest run apps/hubspot-extension/src/settings/__tests__/connection-test-status.test.tsx`
+  — idle/loading/success/failure render.
+- `pnpm exec vitest run apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx`
+  — button-disabled rules, draft-vs-saved dispatch, no-auto-fire on
+  keystroke.
+- Operator portal smoke: click `Test connection` on the LLM block with
+  a wrong key — expect red failure with `auth` code; click with a real
+  key — expect green success with latency; repeat for Exa block;
+  attempt 6 rapid clicks — expect rate-limit 429 response rendered
+  inline.
+
+## Notes
+
+- Issue #19 (lifecycle subscription delivery) is explicitly out of
+  scope. No changes to
+  `apps/hubspot-project/src/app/webhooks/webhooks-hsmeta.json`, no
+  changes to `apps/api/scripts/lifecycle-bootstrap.ts`, no changes to
+  `apps/api/src/routes/admin/lifecycle-bootstrap.ts`.
+- Issue C (scope expansion) is explicitly deferred. The research output
+  in "Solution Approach" captures the recommended scope set so Romeo
+  can stage it as a separate issue when he's ready to absorb the
+  marketplace-listing update + forced re-install.
+- No changes to Taskmaster state, no push without explicit operator
+  approval, no broadening into unrelated cleanup.
+- Base commit: either `c49e239` (post-#17 fix) if Issue A should build
+  on that fix, or `e8adc0b` (Slice 11 checkpoint, current branch HEAD)
+  if Romeo wants this lane independent of #17. For this plan, treat
+  `c49e239` as mandatory. The current worktree is branched from
+  `e8adc0b`; merge `c49e239` in before starting Issue A so the settings
+  surface continues to render in the portal during development.
+- Live docs must be re-verified at implementation time via Context7
+  (preferred) and Firecrawl only as a fallback. Commit messages must
+  record the verification snapshot.
+- **B4 security posture (connection testing):** plaintext API keys
+  MUST remain write-only. The test-connection endpoint accepts drafts
+  in the request body and saved-key requests via a boolean; it never
+  echoes keys in responses, never logs them, and never returns vendor
+  error bodies verbatim. Vendor errors are sanitized to a narrow
+  `code` union. Custom-provider endpoint URLs are SSRF-guarded
+  (HTTPS-only, reject loopback/link-local/private ranges and cloud
+  metadata IPs). A per-tenant rate limiter (default 5/min) prevents
+  the test path from becoming a free-tier DoS vector. Saved-key
+  decryption happens in-process only and the plaintext is discarded
+  immediately after the vendor call. Cross-tenant isolation is
+  covered by an explicit test.

--- a/apps/api/src/adapters/signal/__tests__/factory.test.ts
+++ b/apps/api/src/adapters/signal/__tests__/factory.test.ts
@@ -2,7 +2,7 @@ import type { ProviderConfig } from "@hap/config";
 import type { Database } from "@hap/db";
 import { describe, expect, it } from "vitest";
 import { ExaAdapter } from "../exa";
-import { createSignalAdapter } from "../factory";
+import { createExaSignalAdapters, createSignalAdapter } from "../factory";
 import { HubSpotEnrichmentAdapter } from "../hubspot-enrichment";
 import { NewsAdapter } from "../news";
 
@@ -37,10 +37,12 @@ describe("createSignalAdapter", () => {
     expect(() => createSignalAdapter(cfg({ name: "hubspot-enrichment" }))).toThrow(/tenantId.*db/i);
   });
 
-  it("resolves news to a real NewsAdapter", () => {
-    const adapter = createSignalAdapter(cfg({ name: "news" }));
-    expect(adapter).toBeInstanceOf(NewsAdapter);
-    expect(adapter.name).toBe("news");
+  it("no longer treats 'news' as a top-level provider — factory throws", () => {
+    // News is now driven from the Exa row via createExaSignalAdapters. Any
+    // caller still asking for `name: "news"` is stale and must surface loudly.
+    expect(() => createSignalAdapter(cfg({ name: "news" as "exa" }))).toThrow(
+      /Unknown signal provider: news/,
+    );
   });
 
   it("throws on unknown provider", () => {
@@ -65,7 +67,10 @@ describe("createSignalAdapter", () => {
     const adapter = createSignalAdapter(cfg({ name: "exa" }), {
       fetch: fakeFetch,
     });
-    const ev = await adapter.fetchSignals("t1", { companyId: "co-acme", companyName: "Acme" });
+    const ev = await adapter.fetchSignals("t1", {
+      companyId: "co-acme",
+      companyName: "Acme",
+    });
     expect(called).toBe(true);
     expect(ev).toEqual([]);
   });
@@ -80,5 +85,69 @@ describe("createSignalAdapter", () => {
     expect(a).not.toBe(b);
     expect(a.name).toBe("exa");
     expect(b.name).toBe("exa");
+  });
+});
+
+describe("createExaSignalAdapters", () => {
+  it("returns [Exa, News] when the Exa row is enabled and newsEnabled is unset", () => {
+    const adapters = createExaSignalAdapters(cfg({ name: "exa" }));
+    expect(adapters).toHaveLength(2);
+    expect(adapters[0]).toBeInstanceOf(ExaAdapter);
+    expect(adapters[1]).toBeInstanceOf(NewsAdapter);
+  });
+
+  it("returns [Exa, News] when newsEnabled is explicitly true", () => {
+    const adapters = createExaSignalAdapters(cfg({ name: "exa", settings: { newsEnabled: true } }));
+    expect(adapters.map((a) => a.name)).toEqual(["exa", "news"]);
+  });
+
+  it("returns [Exa] only when settings.newsEnabled is false", () => {
+    const adapters = createExaSignalAdapters(
+      cfg({ name: "exa", settings: { newsEnabled: false } }),
+    );
+    expect(adapters).toHaveLength(1);
+    expect(adapters[0]).toBeInstanceOf(ExaAdapter);
+  });
+
+  it("returns [] when Exa is disabled, disabling news with it", () => {
+    const adapters = createExaSignalAdapters(cfg({ name: "exa", enabled: false }));
+    expect(adapters).toEqual([]);
+  });
+
+  it("refuses any config whose name is not 'exa'", () => {
+    expect(() => createExaSignalAdapters(cfg({ name: "hubspot-enrichment" }))).toThrow(
+      /expects an exa provider config/,
+    );
+  });
+
+  it("wires the same API key into both adapters", async () => {
+    const calls: Array<{ url: string; auth: string | null }> = [];
+    const fakeFetch: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : ((input as Request).url ?? String(input));
+      const authHeader = new Headers(init?.headers).get("x-api-key");
+      calls.push({ url, auth: authHeader });
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const adapters = createExaSignalAdapters(cfg({ name: "exa", apiKeyRef: "shared-exa-key" }), {
+      fetch: fakeFetch,
+    });
+    expect(adapters).toHaveLength(2);
+    await adapters[0]!.fetchSignals("tenant-1", {
+      companyId: "co-1",
+      companyName: "Acme",
+    });
+    await adapters[1]!.fetchSignals("tenant-1", {
+      companyId: "co-1",
+      companyName: "Acme",
+    });
+    // Both made requests using the same shared API key.
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call.auth).toBe("shared-exa-key");
+    }
   });
 });

--- a/apps/api/src/adapters/signal/factory.ts
+++ b/apps/api/src/adapters/signal/factory.ts
@@ -10,9 +10,11 @@
  * `api_key_encrypted` into `apiKeyRef` before returning, so this factory just
  * reads plaintext from the config. The factory never touches ciphertext.
  *
- * Provider status (Slice 3):
- *  - `exa` → real {@link ./exa.ExaAdapter}.
- *  - `news` → real {@link ./news.NewsAdapter} (Exa news vertical).
+ * Provider status:
+ *  - `exa` → real {@link ./exa.ExaAdapter}. The Exa provider row also drives
+ *    the {@link ./news.NewsAdapter} via the shared API key — see
+ *    {@link createExaSignalAdapters}. News is no longer a top-level provider
+ *    slot.
  *  - `hubspot-enrichment` → real per-tenant HubSpot CRM enrichment
  *    backed by the OAuth-aware `HubSpotClient`.
  *
@@ -97,16 +99,55 @@ export function createSignalAdapter(
         })();
       return new HubSpotEnrichmentAdapter(client);
     }
-    case "news":
-      return new NewsAdapter({
-        apiKey: config.apiKeyRef,
-        fetch: fetchImpl,
-      });
     default: {
       const name = (config as { name: string }).name;
       throw new Error(`Unknown signal provider: ${name}`);
     }
   }
+}
+
+/**
+ * Build the full set of signal adapters driven by the Exa provider row.
+ *
+ * News is no longer a top-level provider slot — it shares Exa's credential
+ * and runs as a secondary adapter. Gating rules:
+ *
+ *  - `config.enabled === false` → returns `[]`. Neither Exa main nor News.
+ *  - `config.settings.newsEnabled === false` → returns `[ExaAdapter]` only.
+ *  - Otherwise (enabled, `newsEnabled` unset or `true`) → returns
+ *    `[ExaAdapter, NewsAdapter]` both wired to the same API key.
+ *
+ * The caller is responsible for wrapping each returned adapter with
+ * {@link wrapSignalWithGuards} per-tenant before handing them to the
+ * snapshot assembler.
+ */
+export function createExaSignalAdapters(
+  config: ProviderConfig,
+  deps?: SignalFactoryDeps,
+): ProviderAdapter[] {
+  if (config.name !== "exa") {
+    throw new Error(`createExaSignalAdapters expects an exa provider config; got '${config.name}'`);
+  }
+  if (!config.enabled) {
+    return [];
+  }
+
+  const fetchImpl = deps?.fetch;
+  const adapters: ProviderAdapter[] = [
+    new ExaAdapter({ apiKey: config.apiKeyRef, fetch: fetchImpl }),
+  ];
+
+  const newsEnabled =
+    config.settings && typeof config.settings === "object"
+      ? (config.settings as Record<string, unknown>).newsEnabled
+      : undefined;
+
+  // Default: news on. Only `newsEnabled === false` turns it off.
+  if (newsEnabled !== false) {
+    adapters.push(new NewsAdapter({ apiKey: config.apiKeyRef, fetch: fetchImpl }));
+  }
+
+  return adapters;
 }
 
 /** Context required to wrap an adapter call with rate-limiter + observability. */

--- a/apps/api/src/lib/__tests__/settings-connection-test.test.ts
+++ b/apps/api/src/lib/__tests__/settings-connection-test.test.ts
@@ -381,6 +381,83 @@ describe("assertSafeCustomEndpoint — IPv4-mapped IPv6 + unspecified + hex", ()
   });
 });
 
+describe("assertSafeCustomEndpoint — 6to4 / Teredo / IPv4-compatible IPv6", () => {
+  const customBody = (endpointUrl: string): TestConnectionBody => ({
+    target: "llm",
+    provider: "custom",
+    model: "oss-model",
+    endpointUrl,
+    apiKey: PLAINTEXT_SENTINEL,
+  });
+
+  it("rejects 6to4 encapsulation of AWS metadata: https://[2002:a9fe:a9fe::]/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[2002:a9fe:a9fe::]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("rejects arbitrary 6to4 prefix: https://[2002::1]/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[2002::1]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects Teredo prefix: https://[2001::1]/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[2001::1]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects IPv4-compatible IPv6 dotted form: https://[::169.254.169.254]/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::169.254.169.254]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("rejects IPv4-compatible IPv6 hex form: https://[::a9fe:a9fe]/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::a9fe:a9fe]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects IPv4-compatible loopback: https://[::127.0.0.1]/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::127.0.0.1]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("sanity: public IPv6 addresses outside tunnel/compat ranges still succeed", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, { data: [{ id: "oss-model" }] }));
+    // 2606:4700:4700::1111 is Cloudflare public DNS — a valid public IPv6
+    // that must NOT be blocked by our guard.
+    const result = await testConnection(tenantA, customBody("https://[2606:4700:4700::1111]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
 describe("testExaConnection", () => {
   const body = (): TestConnectionBody => ({
     target: "exa",

--- a/apps/api/src/lib/__tests__/settings-connection-test.test.ts
+++ b/apps/api/src/lib/__tests__/settings-connection-test.test.ts
@@ -264,6 +264,123 @@ describe("testLlmConnection — Custom (SSRF + URL rules)", () => {
   });
 });
 
+describe("assertSafeCustomEndpoint — IPv4-mapped IPv6 + unspecified + hex", () => {
+  const customBody = (endpointUrl: string): TestConnectionBody => ({
+    target: "llm",
+    provider: "custom",
+    model: "oss-model",
+    endpointUrl,
+    apiKey: PLAINTEXT_SENTINEL,
+  });
+
+  it("rejects https://[::ffff:169.254.169.254]/v1/models (AWS metadata via v4-mapped v6)", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, { data: [{ id: "oss-model" }] }));
+    const result = await testConnection(
+      tenantA,
+      customBody("https://[::ffff:169.254.169.254]/v1/models"),
+      { fetch: fetchImpl, now: () => 1 },
+    );
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("rejects https://[::ffff:169.254.169.254]/ bare (AWS metadata via v4-mapped v6)", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::ffff:169.254.169.254]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://[::ffff:127.0.0.1]/ (loopback via v4-mapped v6)", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::ffff:127.0.0.1]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://[::ffff:10.0.0.5]/ (private v4 via v4-mapped v6)", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::ffff:10.0.0.5]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://[::ffff:192.168.1.1]/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::ffff:192.168.1.1]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://[::ffff:172.16.0.1]/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::ffff:172.16.0.1]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://[::]/ (unspecified IPv6)", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://[::ffff:a9fe:a9fe]/ (hex form of 169.254.169.254)", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::ffff:a9fe:a9fe]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://[::ffff:7f00:1]/ (hex form of 127.0.0.1)", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://[::ffff:7f00:1]/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://foo.localhost/ (hostname ending in .localhost)", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://foo.localhost/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("sanity: https://api.openai.com/v1/models still succeeds", async () => {
+    const seen: string[] = [];
+    const fetchImpl = stubFetch((url) => {
+      seen.push(url);
+      return jsonResponse(200, { data: [{ id: "oss-model" }] });
+    });
+    const result = await testConnection(tenantA, customBody("https://api.openai.com"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result.ok).toBe(true);
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[0]).toMatch(/^https:\/\/api\.openai\.com\/(v1\/)?models$/);
+  });
+});
+
 describe("testExaConnection", () => {
   const body = (): TestConnectionBody => ({
     target: "exa",

--- a/apps/api/src/lib/__tests__/settings-connection-test.test.ts
+++ b/apps/api/src/lib/__tests__/settings-connection-test.test.ts
@@ -1,0 +1,407 @@
+import type { TestConnectionBody } from "@hap/config";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertSafeCustomEndpoint,
+  type ConnectionTestLogger,
+  type SavedKeyLoader,
+  SsrfError,
+  testConnection,
+} from "../settings-connection-test";
+
+/** Sentinel used by logger-spy tests to prove we never log plaintext keys. */
+const PLAINTEXT_SENTINEL = "sk-test-PLAINTEXT-SENTINEL-1234567890";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makeLoggerSpy(): {
+  logger: ConnectionTestLogger;
+  captured: Array<{
+    level: string;
+    event: string;
+    fields: Record<string, unknown>;
+  }>;
+} {
+  const captured: Array<{
+    level: string;
+    event: string;
+    fields: Record<string, unknown>;
+  }> = [];
+  const record = (level: string) => (event: string, fields: Record<string, unknown>) => {
+    captured.push({ level, event, fields });
+  };
+  return {
+    logger: {
+      info: record("info"),
+      warn: record("warn"),
+      error: record("error"),
+    },
+    captured,
+  };
+}
+
+function stubFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  return vi.fn((input: string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return Promise.resolve(handler(url, init));
+  }) as unknown as typeof fetch;
+}
+
+const tenantA = "tenant-a";
+const tenantB = "tenant-b";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("testLlmConnection — OpenAI", () => {
+  const body = (model = "gpt-5.4"): TestConnectionBody => ({
+    target: "llm",
+    provider: "openai",
+    model,
+    apiKey: PLAINTEXT_SENTINEL,
+  });
+
+  it("maps a 401 from /v1/models to code: 'auth'", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(401, { error: "invalid" }));
+    const { logger, captured } = makeLoggerSpy();
+    const result = await testConnection(tenantA, body(), {
+      fetch: fetchImpl,
+      logger,
+      now: () => 1000,
+    });
+    expect(result).toEqual({
+      ok: false,
+      code: "auth",
+      message: expect.any(String),
+    });
+    // No plaintext leak in logs.
+    const joined = JSON.stringify(captured);
+    expect(joined).not.toContain(PLAINTEXT_SENTINEL);
+  });
+
+  it("maps a 200 without the selected model to code: 'model'", async () => {
+    const fetchImpl = stubFetch(() =>
+      jsonResponse(200, { data: [{ id: "gpt-5.4-mini" }, { id: "o4-mini" }] }),
+    );
+    const result = await testConnection(tenantA, body("gpt-5.4"), {
+      fetch: fetchImpl,
+      now: () => 1000,
+    });
+    expect(result).toEqual({
+      ok: false,
+      code: "model",
+      message: expect.any(String),
+    });
+  });
+
+  it("returns ok with latencyMs and providerEcho when the model is present", async () => {
+    const fetchImpl = stubFetch(() =>
+      jsonResponse(200, { data: [{ id: "gpt-5.4" }, { id: "gpt-5.4-mini" }] }),
+    );
+    let t = 1000;
+    const now = () => {
+      const v = t;
+      t += 42;
+      return v;
+    };
+    const result = await testConnection(tenantA, body("gpt-5.4"), {
+      fetch: fetchImpl,
+      now,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+      expect(result.providerEcho?.model).toBe("gpt-5.4");
+    }
+  });
+});
+
+describe("testLlmConnection — Anthropic", () => {
+  const body = (model = "claude-sonnet-4-6"): TestConnectionBody => ({
+    target: "llm",
+    provider: "anthropic",
+    model,
+    apiKey: PLAINTEXT_SENTINEL,
+  });
+
+  it("maps a 401 to code: 'auth'", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(401, {}));
+    const result = await testConnection(tenantA, body(), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "auth" });
+  });
+
+  it("maps a 404 model-not-found to code: 'model'", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(404, { error: { type: "not_found_error" } }));
+    const result = await testConnection(tenantA, body(), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "model" });
+  });
+
+  it("maps a 429 to code: 'rate_limit'", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(429, {}));
+    const result = await testConnection(tenantA, body(), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "rate_limit" });
+  });
+});
+
+describe("testLlmConnection — Gemini", () => {
+  const body = (model = "gemini-2.5-pro"): TestConnectionBody => ({
+    target: "llm",
+    provider: "gemini",
+    model,
+    apiKey: PLAINTEXT_SENTINEL,
+  });
+
+  it("maps a 404 to code: 'model'", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(404, {}));
+    const result = await testConnection(tenantA, body(), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "model" });
+  });
+});
+
+describe("testLlmConnection — OpenRouter", () => {
+  const body = (model = "anthropic/claude-sonnet-4.5"): TestConnectionBody => ({
+    target: "llm",
+    provider: "openrouter",
+    model,
+    apiKey: PLAINTEXT_SENTINEL,
+  });
+
+  it("maps a missing slug in the catalog to code: 'model'", async () => {
+    const fetchImpl = stubFetch(() =>
+      jsonResponse(200, { data: [{ id: "anthropic/claude-haiku-4.5" }] }),
+    );
+    const result = await testConnection(tenantA, body("anthropic/claude-sonnet-4.5"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "model" });
+  });
+});
+
+describe("testLlmConnection — Custom (SSRF + URL rules)", () => {
+  const customBody = (endpointUrl: string): TestConnectionBody => ({
+    target: "llm",
+    provider: "custom",
+    model: "oss-model",
+    endpointUrl,
+    apiKey: PLAINTEXT_SENTINEL,
+  });
+
+  it("rejects http:// URLs with code: 'endpoint'", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, { data: [{ id: "oss-model" }] }));
+    const result = await testConnection(tenantA, customBody("http://example.com"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+    // fetch must NOT have been called for a rejected endpoint.
+    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("rejects https://localhost/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://localhost/v1"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://169.254.169.254/ (cloud metadata)", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://169.254.169.254/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("rejects https://10.0.0.5/", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(tenantA, customBody("https://10.0.0.5/"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "endpoint" });
+  });
+
+  it("accepts a safe HTTPS URL and probes it", async () => {
+    const seen: string[] = [];
+    const fetchImpl = stubFetch((url) => {
+      seen.push(url);
+      return jsonResponse(200, { data: [{ id: "oss-model" }] });
+    });
+    const result = await testConnection(tenantA, customBody("https://api.example.com"), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result.ok).toBe(true);
+    expect(seen[0]).toMatch(/^https:\/\/api\.example\.com\/(v1\/)?models$/);
+  });
+
+  it("unit: assertSafeCustomEndpoint rejects additional private ranges", () => {
+    expect(() => assertSafeCustomEndpoint("https://172.16.0.1/")).toThrow(SsrfError);
+    expect(() => assertSafeCustomEndpoint("https://192.168.1.1/")).toThrow(SsrfError);
+    expect(() => assertSafeCustomEndpoint("https://[::1]/")).toThrow(SsrfError);
+    expect(() => assertSafeCustomEndpoint("not a url")).toThrow(SsrfError);
+  });
+});
+
+describe("testExaConnection", () => {
+  const body = (): TestConnectionBody => ({
+    target: "exa",
+    apiKey: PLAINTEXT_SENTINEL,
+  });
+
+  it("maps a 401 to code: 'auth'", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(401, {}));
+    const result = await testConnection(tenantA, body(), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "auth" });
+  });
+
+  it("maps a 429 to code: 'rate_limit'", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(429, {}));
+    const result = await testConnection(tenantA, body(), {
+      fetch: fetchImpl,
+      now: () => 1,
+    });
+    expect(result).toMatchObject({ ok: false, code: "rate_limit" });
+  });
+
+  it("returns ok with latencyMs on a 200", async () => {
+    const fetchImpl = stubFetch(() => jsonResponse(200, { results: [] }));
+    let t = 500;
+    const now = () => {
+      const v = t;
+      t += 12;
+      return v;
+    };
+    const result = await testConnection(tenantA, body(), {
+      fetch: fetchImpl,
+      now,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("saved-key path", () => {
+  it("returns { code: 'auth', message: 'No stored key' } when no key is stored", async () => {
+    const loader: SavedKeyLoader = async () => null;
+    const fetchImpl = stubFetch(() => jsonResponse(200, { data: [{ id: "gpt-5.4" }] }));
+    const result = await testConnection(
+      tenantA,
+      {
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4",
+        useSavedKey: true,
+      },
+      { fetch: fetchImpl, loadSavedKey: loader, now: () => 1 },
+    );
+    expect(result).toEqual({
+      ok: false,
+      code: "auth",
+      message: "No stored key",
+    });
+  });
+
+  it("scopes saved-key loads to the requesting tenant (cross-tenant isolation)", async () => {
+    // tenantA should never see tenantB's saved key.
+    const loader: SavedKeyLoader = vi.fn(async (tenantId, target) => {
+      if (tenantId === tenantB && target.target === "exa") return "secret-for-b";
+      return null;
+    });
+    const fetchImpl = stubFetch(() => jsonResponse(200, {}));
+    const result = await testConnection(
+      tenantA,
+      { target: "exa", useSavedKey: true },
+      { fetch: fetchImpl, loadSavedKey: loader, now: () => 1 },
+    );
+    expect(result).toEqual({
+      ok: false,
+      code: "auth",
+      message: "No stored key",
+    });
+    // The loader was called with tenantA, never tenantB.
+    expect((loader as unknown as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])).toEqual([
+      tenantA,
+    ]);
+  });
+});
+
+describe("logger spy — no plaintext key fragment leaks", () => {
+  it("does not log the plaintext key on auth failures", async () => {
+    const { logger, captured } = makeLoggerSpy();
+    const fetchImpl = stubFetch(() => jsonResponse(401, { error: "bad key" }));
+    await testConnection(
+      tenantA,
+      {
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4",
+        apiKey: PLAINTEXT_SENTINEL,
+      },
+      { fetch: fetchImpl, logger, now: () => 1 },
+    );
+    const joined = JSON.stringify(captured);
+    expect(joined).not.toContain(PLAINTEXT_SENTINEL);
+  });
+
+  it("does not log the plaintext key on network errors", async () => {
+    const { logger, captured } = makeLoggerSpy();
+    const fetchImpl = vi.fn(() =>
+      Promise.reject(new Error(`connection refused for key=${PLAINTEXT_SENTINEL}`)),
+    ) as unknown as typeof fetch;
+    const result = await testConnection(
+      tenantA,
+      {
+        target: "exa",
+        apiKey: PLAINTEXT_SENTINEL,
+      },
+      { fetch: fetchImpl, logger, now: () => 1 },
+    );
+    expect(result).toMatchObject({ ok: false, code: "network" });
+    const joined = JSON.stringify(captured);
+    expect(joined).not.toContain(PLAINTEXT_SENTINEL);
+  });
+
+  it("does not log the plaintext key on success paths", async () => {
+    const { logger, captured } = makeLoggerSpy();
+    const fetchImpl = stubFetch(() => jsonResponse(200, { data: [{ id: "gpt-5.4" }] }));
+    await testConnection(
+      tenantA,
+      {
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4",
+        apiKey: PLAINTEXT_SENTINEL,
+      },
+      { fetch: fetchImpl, logger, now: () => 1 },
+    );
+    const joined = JSON.stringify(captured);
+    expect(joined).not.toContain(PLAINTEXT_SENTINEL);
+  });
+});

--- a/apps/api/src/lib/__tests__/settings-service.test.ts
+++ b/apps/api/src/lib/__tests__/settings-service.test.ts
@@ -3,7 +3,7 @@ import { createDatabase, llmConfig, providerConfig, tenants } from "@hap/db";
 import { and, eq, like } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { __resetEncryptionCacheForTests, decryptProviderKey } from "../encryption";
-import { readSettings, updateSettings } from "../settings-service";
+import { readSettings, SettingsValidationError, updateSettings } from "../settings-service";
 
 const DATABASE_URL =
   process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
@@ -60,7 +60,6 @@ describe("readSettings", () => {
       tenantId: tenant.id,
       signalProviders: {
         exa: { enabled: false, hasApiKey: false },
-        news: { enabled: false, hasApiKey: false },
         hubspotEnrichment: { enabled: false, hasApiKey: false },
       },
       llm: {
@@ -89,7 +88,6 @@ describe("updateSettings", () => {
       {
         signalProviders: {
           exa: { enabled: true, apiKey: "exa-secret-1" },
-          news: { enabled: true },
           hubspotEnrichment: { enabled: true },
         },
         llm: {
@@ -124,12 +122,15 @@ describe("updateSettings", () => {
     expect(decryptProviderKey(tenant.id, llmRow?.apiKeyEncrypted ?? "")).toBe("openai-secret-1");
 
     const settings = await readSettings({ db, tenantId: tenant.id });
-    expect(settings.signalProviders.exa).toEqual({ enabled: true, hasApiKey: true });
-    expect(settings.signalProviders.news).toEqual({ enabled: true, hasApiKey: false });
+    expect(settings.signalProviders.exa).toEqual({
+      enabled: true,
+      hasApiKey: true,
+    });
     expect(settings.signalProviders.hubspotEnrichment).toEqual({
       enabled: true,
       hasApiKey: false,
     });
+    expect((settings.signalProviders as Record<string, unknown>).news).toBeUndefined();
     expect(settings.llm).toEqual({
       provider: "openai",
       model: "gpt-5.4-mini",
@@ -315,5 +316,56 @@ describe("updateSettings", () => {
       endpointUrl: undefined,
       hasApiKey: true,
     });
+  });
+
+  it("rejects an attempt to store an apiKey on hubspotEnrichment", async () => {
+    const tenant = await seedTenant();
+
+    await expect(
+      updateSettings(
+        { db, tenantId: tenant.id },
+        {
+          signalProviders: {
+            hubspotEnrichment: { enabled: true, apiKey: "fake" } as unknown as {
+              enabled?: boolean;
+            },
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(SettingsValidationError);
+
+    // Guard must run before any write — no row should exist.
+    const rows = await db
+      .select()
+      .from(providerConfig)
+      .where(
+        and(
+          eq(providerConfig.tenantId, tenant.id),
+          eq(providerConfig.providerName, "hubspot-enrichment"),
+        ),
+      );
+    expect(rows[0]?.apiKeyEncrypted ?? null).toBeNull();
+  });
+
+  it("no longer writes or reads a 'news' provider slot", async () => {
+    const tenant = await seedTenant();
+
+    await updateSettings(
+      { db, tenantId: tenant.id },
+      {
+        signalProviders: {
+          exa: { enabled: true, apiKey: "exa-secret" },
+        },
+      },
+    );
+
+    const rows = await db
+      .select()
+      .from(providerConfig)
+      .where(and(eq(providerConfig.tenantId, tenant.id), eq(providerConfig.providerName, "news")));
+    expect(rows).toHaveLength(0);
+
+    const settings = await readSettings({ db, tenantId: tenant.id });
+    expect((settings.signalProviders as Record<string, unknown>).news).toBeUndefined();
   });
 });

--- a/apps/api/src/lib/settings-connection-test.ts
+++ b/apps/api/src/lib/settings-connection-test.ts
@@ -23,6 +23,7 @@
  * responses, assert log outputs, and stub the encryption path without a DB.
  */
 
+import { BlockList, isIP } from "node:net";
 import type {
   LlmProviderType,
   TestConnectionBody,
@@ -33,6 +34,38 @@ import type {
 import { type Database, llmConfig, providerConfig } from "@hap/db";
 import { and, eq } from "drizzle-orm";
 import { decryptProviderKey } from "./encryption";
+
+/**
+ * Authoritative blocklist of IP ranges that are unsafe for outbound
+ * custom-endpoint probes. Uses Node's built-in {@link BlockList} — the
+ * same primitive undici/fetch uses internally to parse addresses — so
+ * IPv4-mapped IPv6 forms like `::ffff:169.254.169.254` and hex forms
+ * like `::ffff:a9fe:a9fe` are normalized and matched correctly.
+ *
+ * Naive string-prefix checks on the bracket-stripped host are NOT
+ * sufficient: they miss v4-mapped v6 (credential-metadata bypass) and
+ * the hex representation of the same addresses.
+ */
+const BLOCKED_IPS: BlockList = (() => {
+  const list = new BlockList();
+  // IPv4 unsafe ranges.
+  list.addSubnet("0.0.0.0", 8, "ipv4");
+  list.addSubnet("10.0.0.0", 8, "ipv4");
+  list.addSubnet("127.0.0.0", 8, "ipv4");
+  list.addSubnet("169.254.0.0", 16, "ipv4");
+  list.addSubnet("172.16.0.0", 12, "ipv4");
+  list.addSubnet("192.168.0.0", 16, "ipv4");
+  // IPv6 unsafe ranges.
+  list.addAddress("::", "ipv6"); // unspecified
+  list.addAddress("::1", "ipv6"); // loopback
+  list.addSubnet("fc00::", 7, "ipv6"); // unique-local (ULA)
+  list.addSubnet("fe80::", 10, "ipv6"); // link-local
+  // IPv4-mapped IPv6 space (::ffff:0:0/96) — covers every v4-mapped v6
+  // including hex forms like ::ffff:a9fe:a9fe. `BlockList.check` with
+  // family "ipv6" resolves the embedded IPv4 against this subnet.
+  list.addSubnet("::ffff:0:0", 96, "ipv6");
+  return list;
+})();
 
 /**
  * Minimal structured logger surface. Matches the fields emitted by
@@ -114,12 +147,19 @@ function fail(code: TestConnectionErrorCode, message: string): TestConnectionRes
  * Rules:
  *   - Must parse as a URL.
  *   - Must use https scheme.
- *   - Hostname must not be loopback (`localhost`, `127.0.0.0/8`, `::1`),
- *     link-local (`169.254.0.0/16`), private (`10/8`, `172.16/12`,
- *     `192.168/16`), or an IPv6 ULA (`fc00::/7`).
+ *   - Must not contain userinfo (`https://example.com@169.254.169.254/`
+ *     style bypass).
+ *   - IP literal hosts (v4 or v6, in any normalized form) are checked
+ *     against {@link BLOCKED_IPS} — a Node {@link BlockList} covering
+ *     loopback, link-local, private, ULA, unspecified, and the
+ *     IPv4-mapped-IPv6 (`::ffff:0:0/96`) subnet so that forms like
+ *     `::ffff:169.254.169.254` and `::ffff:a9fe:a9fe` cannot bypass
+ *     the v4 checks.
+ *   - Hostnames resolving to `localhost` or ending in `.localhost`
+ *     (per RFC 6761) are rejected.
  *
- * The string-only host check is sufficient for V1: it blocks the obvious
- * SSRF vectors. A stricter DNS-resolution pass is out of scope.
+ * A DNS-resolution pass for arbitrary hostnames is out of scope for V1;
+ * this still blocks the literal-IP and localhost bypass classes.
  */
 export function assertSafeCustomEndpoint(rawUrl: string): void {
   let parsed: URL;
@@ -131,44 +171,36 @@ export function assertSafeCustomEndpoint(rawUrl: string): void {
   if (parsed.protocol !== "https:") {
     throw new SsrfError("must be HTTPS");
   }
+  // Reject userinfo in the authority — e.g. https://example.com@169.254.169.254/.
+  // URL.username/password are empty strings when absent.
+  if (parsed.username !== "" || parsed.password !== "") {
+    throw new SsrfError("userinfo not allowed");
+  }
+
   const host = parsed.hostname.toLowerCase();
   const stripped = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
 
+  const family = isIP(stripped);
+  if (family === 4) {
+    if (BLOCKED_IPS.check(stripped, "ipv4")) {
+      throw new SsrfError("blocked IPv4 host");
+    }
+    return;
+  }
+  if (family === 6) {
+    if (BLOCKED_IPS.check(stripped, "ipv6")) {
+      throw new SsrfError("blocked IPv6 host");
+    }
+    return;
+  }
+
+  // Hostname path. family === 0.
   if (stripped === "localhost" || stripped === "ip6-localhost") {
     throw new SsrfError("loopback host not allowed");
   }
-  // IPv6 loopback (::1)
-  if (stripped === "::1") {
+  // RFC 6761: any name ending in `.localhost` must resolve to loopback.
+  if (stripped.endsWith(".localhost")) {
     throw new SsrfError("loopback host not allowed");
-  }
-  // IPv6 link-local (fe80::/10) and ULA (fc00::/7)
-  if (stripped.startsWith("fe80:") || /^fc[0-9a-f]{2}:/.test(stripped)) {
-    throw new SsrfError("link-local or unique-local host not allowed");
-  }
-  if (stripped.startsWith("fc") && stripped.includes(":")) {
-    throw new SsrfError("unique-local host not allowed");
-  }
-
-  // IPv4 literal checks.
-  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(stripped);
-  if (ipv4) {
-    const octets = ipv4.slice(1, 5).map((s) => Number.parseInt(s, 10));
-    if (octets.some((o) => Number.isNaN(o) || o < 0 || o > 255)) {
-      throw new SsrfError("invalid IPv4");
-    }
-    const [a = 0, b = 0] = octets;
-    // 127.0.0.0/8
-    if (a === 127) throw new SsrfError("loopback host not allowed");
-    // 10.0.0.0/8
-    if (a === 10) throw new SsrfError("private host not allowed");
-    // 169.254.0.0/16 (link-local, AWS/GCP metadata 169.254.169.254)
-    if (a === 169 && b === 254) throw new SsrfError("link-local host not allowed");
-    // 172.16.0.0/12
-    if (a === 172 && b >= 16 && b <= 31) throw new SsrfError("private host not allowed");
-    // 192.168.0.0/16
-    if (a === 192 && b === 168) throw new SsrfError("private host not allowed");
-    // 0.0.0.0/8
-    if (a === 0) throw new SsrfError("unspecified host not allowed");
   }
 }
 

--- a/apps/api/src/lib/settings-connection-test.ts
+++ b/apps/api/src/lib/settings-connection-test.ts
@@ -1,0 +1,545 @@
+/**
+ * Settings connection-test service.
+ *
+ * Owned by Issue B (B4). Backs `POST /api/settings/test-connection`, the
+ * explicit verification path for LLM + Exa credentials. Operators currently
+ * find out their credentials are wrong via a silently empty snapshot; this
+ * service fails loud at save time.
+ *
+ * Security posture (non-negotiable — enforced by tests):
+ *   - Plaintext keys are NEVER logged, NEVER echoed in responses, NEVER
+ *     persisted from this code path. Draft keys live in the request body
+ *     for the duration of one vendor call, saved keys are decrypted in-process
+ *     and discarded immediately after use.
+ *   - Vendor error bodies are NOT forwarded verbatim. Every failure maps to
+ *     a narrow {@link TestConnectionErrorCode}.
+ *   - Custom endpoint URLs are SSRF-guarded here: HTTPS-only, reject
+ *     loopback / link-local / private-range / cloud-metadata hosts.
+ *   - The caller (route layer) is responsible for tenant auth + rate
+ *     limiting. This service trusts its `tenantId` input.
+ *
+ * Dependency injection: {@link TestConnectionDeps} exposes `fetch`, `logger`,
+ * and `loadSavedKey` as injectable seams so unit tests can mock vendor
+ * responses, assert log outputs, and stub the encryption path without a DB.
+ */
+
+import type {
+  LlmProviderType,
+  TestConnectionBody,
+  TestConnectionErrorCode,
+  TestConnectionLlmBody,
+  TestConnectionResponse,
+} from "@hap/config";
+import { type Database, llmConfig, providerConfig } from "@hap/db";
+import { and, eq } from "drizzle-orm";
+import { decryptProviderKey } from "./encryption";
+
+/**
+ * Minimal structured logger surface. Matches the fields emitted by
+ * {@link ./observability} but decoupled so we can inject a spy.
+ *
+ * IMPORTANT: callers of this service MUST NOT put plaintext keys into any
+ * field passed to the logger. Tests assert against a captured logger spy
+ * with a sentinel plaintext string to guarantee no accidental leaks.
+ */
+export interface ConnectionTestLogger {
+  info(event: string, fields: Record<string, unknown>): void;
+  warn(event: string, fields: Record<string, unknown>): void;
+  error(event: string, fields: Record<string, unknown>): void;
+}
+
+const DEFAULT_LOGGER: ConnectionTestLogger = {
+  info: (event, fields) => console.error(JSON.stringify({ level: "info", event, ...fields })),
+  warn: (event, fields) => console.error(JSON.stringify({ level: "warn", event, ...fields })),
+  error: (event, fields) => console.error(JSON.stringify({ level: "error", event, ...fields })),
+};
+
+/**
+ * Resolve a saved API key for the given tenant/target. Returns `null` when
+ * no saved key exists.
+ *
+ * The default impl queries `provider_config` for Exa and `llm_config` for
+ * LLM targets, then {@link decryptProviderKey decrypts} in-process. Tests
+ * inject a stub to avoid touching the DB.
+ */
+export type SavedKeyTarget = { target: "exa" } | { target: "llm"; provider: LlmProviderType };
+
+export type SavedKeyLoader = (tenantId: string, target: SavedKeyTarget) => Promise<string | null>;
+
+export interface TestConnectionDeps {
+  fetch?: typeof fetch;
+  logger?: ConnectionTestLogger;
+  loadSavedKey?: SavedKeyLoader;
+  /** Clock source for latency measurement; defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Default {@link SavedKeyLoader}. Reads the ciphertext for the requested
+ * target from the tenant's provider_config / llm_config rows and decrypts
+ * in-process via {@link decryptProviderKey}. Plaintext is returned to the
+ * caller and discarded by the caller immediately after the vendor call.
+ */
+export function createDefaultSavedKeyLoader(db: Database): SavedKeyLoader {
+  return async (tenantId, target) => {
+    if (target.target === "exa") {
+      const rows = await db
+        .select({ ciphertext: providerConfig.apiKeyEncrypted })
+        .from(providerConfig)
+        .where(and(eq(providerConfig.tenantId, tenantId), eq(providerConfig.providerName, "exa")))
+        .limit(1);
+      const ct = rows[0]?.ciphertext ?? null;
+      return ct ? decryptProviderKey(tenantId, ct) : null;
+    }
+    const rows = await db
+      .select({ ciphertext: llmConfig.apiKeyEncrypted })
+      .from(llmConfig)
+      .where(and(eq(llmConfig.tenantId, tenantId), eq(llmConfig.providerName, target.provider)))
+      .limit(1);
+    const ct = rows[0]?.ciphertext ?? null;
+    return ct ? decryptProviderKey(tenantId, ct) : null;
+  };
+}
+
+const DEFAULT_NOW = () => Date.now();
+
+/** Build a short sanitized failure message. NEVER includes plaintext keys. */
+function fail(code: TestConnectionErrorCode, message: string): TestConnectionResponse {
+  return { ok: false, code, message };
+}
+
+/**
+ * SSRF guard for `provider === "custom"` endpoint URLs.
+ *
+ * Rules:
+ *   - Must parse as a URL.
+ *   - Must use https scheme.
+ *   - Hostname must not be loopback (`localhost`, `127.0.0.0/8`, `::1`),
+ *     link-local (`169.254.0.0/16`), private (`10/8`, `172.16/12`,
+ *     `192.168/16`), or an IPv6 ULA (`fc00::/7`).
+ *
+ * The string-only host check is sufficient for V1: it blocks the obvious
+ * SSRF vectors. A stricter DNS-resolution pass is out of scope.
+ */
+export function assertSafeCustomEndpoint(rawUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new SsrfError("invalid URL");
+  }
+  if (parsed.protocol !== "https:") {
+    throw new SsrfError("must be HTTPS");
+  }
+  const host = parsed.hostname.toLowerCase();
+  const stripped = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+
+  if (stripped === "localhost" || stripped === "ip6-localhost") {
+    throw new SsrfError("loopback host not allowed");
+  }
+  // IPv6 loopback (::1)
+  if (stripped === "::1") {
+    throw new SsrfError("loopback host not allowed");
+  }
+  // IPv6 link-local (fe80::/10) and ULA (fc00::/7)
+  if (stripped.startsWith("fe80:") || /^fc[0-9a-f]{2}:/.test(stripped)) {
+    throw new SsrfError("link-local or unique-local host not allowed");
+  }
+  if (stripped.startsWith("fc") && stripped.includes(":")) {
+    throw new SsrfError("unique-local host not allowed");
+  }
+
+  // IPv4 literal checks.
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(stripped);
+  if (ipv4) {
+    const octets = ipv4.slice(1, 5).map((s) => Number.parseInt(s, 10));
+    if (octets.some((o) => Number.isNaN(o) || o < 0 || o > 255)) {
+      throw new SsrfError("invalid IPv4");
+    }
+    const [a = 0, b = 0] = octets;
+    // 127.0.0.0/8
+    if (a === 127) throw new SsrfError("loopback host not allowed");
+    // 10.0.0.0/8
+    if (a === 10) throw new SsrfError("private host not allowed");
+    // 169.254.0.0/16 (link-local, AWS/GCP metadata 169.254.169.254)
+    if (a === 169 && b === 254) throw new SsrfError("link-local host not allowed");
+    // 172.16.0.0/12
+    if (a === 172 && b >= 16 && b <= 31) throw new SsrfError("private host not allowed");
+    // 192.168.0.0/16
+    if (a === 192 && b === 168) throw new SsrfError("private host not allowed");
+    // 0.0.0.0/8
+    if (a === 0) throw new SsrfError("unspecified host not allowed");
+  }
+}
+
+/** Internal sentinel — collapsed to `code: "endpoint"` by callers. */
+export class SsrfError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SsrfError";
+  }
+}
+
+/**
+ * Resolve the API key for a draft or saved-key request. Returns `null` when
+ * the saved-key path was requested but no key is stored.
+ */
+async function resolveKey(
+  tenantId: string,
+  body: TestConnectionBody,
+  loader: SavedKeyLoader,
+): Promise<string | null> {
+  if (body.apiKey) return body.apiKey;
+  if (!body.useSavedKey) return null; // validator guarantees we don't reach here
+  const target: SavedKeyTarget =
+    body.target === "exa" ? { target: "exa" } : { target: "llm", provider: body.provider };
+  return loader(tenantId, target);
+}
+
+/**
+ * Map a fetch Response to a TestConnectionErrorCode for the common HTTP
+ * failure shapes. 200-299 is NOT handled here; callers own success.
+ */
+function mapHttpStatusToCode(status: number): TestConnectionErrorCode {
+  if (status === 401 || status === 403) return "auth";
+  if (status === 404) return "model";
+  if (status === 429) return "rate_limit";
+  if (status >= 500) return "network";
+  return "unknown";
+}
+
+/**
+ * Public entry point: dispatch on `body.target`. Delegates to the LLM or Exa
+ * branch and guarantees the response never leaks plaintext keys.
+ */
+export async function testConnection(
+  tenantId: string,
+  body: TestConnectionBody,
+  deps: TestConnectionDeps = {},
+): Promise<TestConnectionResponse> {
+  if (body.target === "llm") {
+    return testLlmConnection(tenantId, body, deps);
+  }
+  return testExaConnection(tenantId, body, deps);
+}
+
+/**
+ * LLM test dispatcher. For each provider we pick the cheapest possible
+ * auth-gated check and validate that the selected `model` is actually
+ * callable (either by listing models or by asking for one token).
+ */
+export async function testLlmConnection(
+  tenantId: string,
+  body: TestConnectionLlmBody,
+  deps: TestConnectionDeps = {},
+): Promise<TestConnectionResponse> {
+  const logger = deps.logger ?? DEFAULT_LOGGER;
+  const fetchImpl = deps.fetch ?? fetch;
+  const now = deps.now ?? DEFAULT_NOW;
+  const loader =
+    deps.loadSavedKey ??
+    (async () => {
+      // If no loader is configured the caller forgot to wire one; fail safely.
+      return null;
+    });
+
+  // SSRF guard runs BEFORE key resolution so a malicious custom endpoint
+  // cannot cause us to decrypt a saved key and then fail.
+  if (body.provider === "custom") {
+    if (!body.endpointUrl) {
+      return fail("endpoint", "endpointUrl is required for custom provider");
+    }
+    try {
+      assertSafeCustomEndpoint(body.endpointUrl);
+    } catch (err) {
+      logger.warn("settings.test_connection.ssrf_rejected", {
+        tenantId,
+        provider: body.provider,
+        // NB: do not log the URL host even here — it may be attacker-controlled.
+        reason: err instanceof Error ? err.name : "unknown",
+      });
+      return fail("endpoint", "endpoint rejected");
+    }
+  }
+
+  const key = await resolveKey(tenantId, body, loader);
+  if (!key) {
+    return fail("auth", "No stored key");
+  }
+
+  const started = now();
+  try {
+    switch (body.provider) {
+      case "openai":
+        return await probeOpenAi(fetchImpl, key, body.model, started, now);
+      case "anthropic":
+        return await probeAnthropic(fetchImpl, key, body.model, started, now);
+      case "gemini":
+        return await probeGemini(fetchImpl, key, body.model, started, now);
+      case "openrouter":
+        return await probeOpenRouter(fetchImpl, key, body.model, started, now);
+      case "custom":
+        return await probeCustom(
+          fetchImpl,
+          key,
+          body.model,
+          body.endpointUrl as string,
+          started,
+          now,
+        );
+    }
+  } catch (err) {
+    logger.error("settings.test_connection.fetch_failed", {
+      tenantId,
+      provider: body.provider,
+      errorClass: err instanceof Error ? err.name : "Unknown",
+    });
+    return fail("network", "network error");
+  }
+}
+
+/**
+ * Exa test. POST `api.exa.ai/search` with a trivial single-result query.
+ * 2xx → ok. Standard status-code mapping otherwise.
+ */
+export async function testExaConnection(
+  tenantId: string,
+  body: { target: "exa"; apiKey?: string; useSavedKey?: true },
+  deps: TestConnectionDeps = {},
+): Promise<TestConnectionResponse> {
+  const logger = deps.logger ?? DEFAULT_LOGGER;
+  const fetchImpl = deps.fetch ?? fetch;
+  const now = deps.now ?? DEFAULT_NOW;
+  const loader = deps.loadSavedKey ?? (async () => null);
+
+  const key = await resolveKey(tenantId, body, loader);
+  if (!key) {
+    return fail("auth", "No stored key");
+  }
+
+  const started = now();
+  try {
+    const res = await fetchImpl("https://api.exa.ai/search", {
+      method: "POST",
+      headers: {
+        "x-api-key": key,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query: "connection test", numResults: 1 }),
+    });
+    if (res.ok) {
+      return { ok: true, latencyMs: Math.max(0, now() - started) };
+    }
+    return fail(mapHttpStatusToCode(res.status), `exa status ${res.status}`);
+  } catch (err) {
+    logger.error("settings.test_connection.fetch_failed", {
+      tenantId,
+      provider: "exa",
+      errorClass: err instanceof Error ? err.name : "Unknown",
+    });
+    return fail("network", "network error");
+  }
+}
+
+// -- Provider probes --------------------------------------------------------
+
+async function probeOpenAi(
+  fetchImpl: typeof fetch,
+  key: string,
+  model: string,
+  started: number,
+  now: () => number,
+): Promise<TestConnectionResponse> {
+  const res = await fetchImpl("https://api.openai.com/v1/models", {
+    method: "GET",
+    headers: { Authorization: `Bearer ${key}` },
+  });
+  if (!res.ok) {
+    return fail(mapHttpStatusToCode(res.status), `openai status ${res.status}`);
+  }
+  const models = await extractOpenAiStyleModelIds(res);
+  if (!models.includes(model)) {
+    return fail("model", `model '${model}' not available`);
+  }
+  return {
+    ok: true,
+    latencyMs: Math.max(0, now() - started),
+    providerEcho: { model },
+  };
+}
+
+async function probeAnthropic(
+  fetchImpl: typeof fetch,
+  key: string,
+  model: string,
+  started: number,
+  now: () => number,
+): Promise<TestConnectionResponse> {
+  const res = await fetchImpl("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": key,
+      "anthropic-version": "2023-06-01",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 1,
+      messages: [{ role: "user", content: "." }],
+    }),
+  });
+  if (res.ok) {
+    return {
+      ok: true,
+      latencyMs: Math.max(0, now() - started),
+      providerEcho: { model },
+    };
+  }
+  // Anthropic surfaces "model not found" as 404 AND as 400 with a specific
+  // error.type. We treat both paths as `code: "model"` without forwarding the
+  // vendor body verbatim.
+  if (res.status === 404) {
+    return fail("model", `model '${model}' not available`);
+  }
+  if (res.status === 400) {
+    const detail = await peekJsonErrorType(res);
+    if (detail && /not_found|invalid_request/i.test(detail)) {
+      return fail("model", `model '${model}' not available`);
+    }
+  }
+  return fail(mapHttpStatusToCode(res.status), `anthropic status ${res.status}`);
+}
+
+async function probeGemini(
+  fetchImpl: typeof fetch,
+  key: string,
+  model: string,
+  started: number,
+  now: () => number,
+): Promise<TestConnectionResponse> {
+  // `GET /v1beta/models/{model}?key={apiKey}` — auth-gated, no billed tokens.
+  // The model id often appears in the docs with a `models/` prefix; pass it
+  // through as-is. Gemini returns 403 for bad auth and 404 for unknown model.
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(
+    model,
+  )}?key=${encodeURIComponent(key)}`;
+  const res = await fetchImpl(url, { method: "GET" });
+  if (res.ok) {
+    return {
+      ok: true,
+      latencyMs: Math.max(0, now() - started),
+      providerEcho: { model },
+    };
+  }
+  if (res.status === 404) {
+    return fail("model", `model '${model}' not available`);
+  }
+  return fail(mapHttpStatusToCode(res.status), `gemini status ${res.status}`);
+}
+
+async function probeOpenRouter(
+  fetchImpl: typeof fetch,
+  key: string,
+  model: string,
+  started: number,
+  now: () => number,
+): Promise<TestConnectionResponse> {
+  const res = await fetchImpl("https://openrouter.ai/api/v1/models", {
+    method: "GET",
+    headers: { Authorization: `Bearer ${key}` },
+  });
+  if (!res.ok) {
+    return fail(mapHttpStatusToCode(res.status), `openrouter status ${res.status}`);
+  }
+  const models = await extractOpenAiStyleModelIds(res);
+  if (!models.includes(model)) {
+    return fail("model", `model '${model}' not available`);
+  }
+  return {
+    ok: true,
+    latencyMs: Math.max(0, now() - started),
+    providerEcho: { model },
+  };
+}
+
+async function probeCustom(
+  fetchImpl: typeof fetch,
+  key: string,
+  model: string,
+  endpointUrl: string,
+  started: number,
+  now: () => number,
+): Promise<TestConnectionResponse> {
+  // Tolerate trailing slash. Try `/v1/models` first, fall back to `/models`
+  // for OpenAI-compatible servers that don't namespace under `/v1`.
+  const base = endpointUrl.replace(/\/+$/, "");
+  const candidates = [`${base}/v1/models`, `${base}/models`];
+  let lastStatus = 0;
+  for (const url of candidates) {
+    const res = await fetchImpl(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${key}` },
+    });
+    if (res.ok) {
+      const models = await extractOpenAiStyleModelIds(res);
+      if (!models.includes(model)) {
+        return fail("model", `model '${model}' not available`);
+      }
+      return {
+        ok: true,
+        latencyMs: Math.max(0, now() - started),
+        providerEcho: { model },
+      };
+    }
+    lastStatus = res.status;
+    if (res.status === 401 || res.status === 403) {
+      return fail("auth", `custom status ${res.status}`);
+    }
+    // 404 on one path may mean the other path is canonical; keep trying.
+    if (res.status !== 404) {
+      return fail(mapHttpStatusToCode(res.status), `custom status ${res.status}`);
+    }
+  }
+  return fail(mapHttpStatusToCode(lastStatus || 404), `custom status ${lastStatus || 404}`);
+}
+
+// -- Helpers ----------------------------------------------------------------
+
+async function extractOpenAiStyleModelIds(res: Response): Promise<string[]> {
+  try {
+    const json = (await res.json()) as unknown;
+    if (
+      json &&
+      typeof json === "object" &&
+      "data" in json &&
+      Array.isArray((json as { data: unknown }).data)
+    ) {
+      return ((json as { data: unknown[] }).data as unknown[])
+        .map((item) =>
+          item && typeof item === "object" && "id" in item
+            ? String((item as { id: unknown }).id)
+            : "",
+        )
+        .filter((s) => s.length > 0);
+    }
+  } catch {
+    // Fall through; treat as empty.
+  }
+  return [];
+}
+
+async function peekJsonErrorType(res: Response): Promise<string | null> {
+  try {
+    const json = (await res.json()) as unknown;
+    if (json && typeof json === "object" && "error" in json) {
+      const err = (json as { error: unknown }).error;
+      if (err && typeof err === "object" && "type" in err) {
+        const t = (err as { type: unknown }).type;
+        if (typeof t === "string") return t;
+      }
+    }
+  } catch {
+    // Fall through.
+  }
+  return null;
+}

--- a/apps/api/src/lib/settings-connection-test.ts
+++ b/apps/api/src/lib/settings-connection-test.ts
@@ -64,8 +64,43 @@ const BLOCKED_IPS: BlockList = (() => {
   // including hex forms like ::ffff:a9fe:a9fe. `BlockList.check` with
   // family "ipv6" resolves the embedded IPv4 against this subnet.
   list.addSubnet("::ffff:0:0", 96, "ipv6");
+  // 6to4 encapsulation (RFC 3056). 2002:<v4>::/48 decodes to an arbitrary
+  // IPv4 destination, so 2002:a9fe:a9fe::/48 → 169.254.169.254 metadata.
+  // Block the entire 2002::/16 tunnel prefix — we never legitimately probe
+  // a 6to4-encapsulated endpoint from this service.
+  list.addSubnet("2002::", 16, "ipv6");
+  // Teredo (RFC 4380) — 2001::/32 tunnels IPv4 over UDP/IPv6. Same class
+  // of v4 smuggling risk as 6to4. Block the tunnel prefix.
+  list.addSubnet("2001::", 32, "ipv6");
   return list;
 })();
+
+/**
+ * Detect IPv4-compatible IPv6 addresses (`::a.b.c.d`, deprecated per
+ * RFC 4291 §2.5.5.1 but still resolvable on some stacks). These are
+ * distinct from the IPv4-mapped form (`::ffff:a.b.c.d`) already handled
+ * by the BlockList: IPv4-compat has zero in the "ffff" word, so
+ * `::169.254.169.254` → `::a9fe:a9fe`, which passes `::ffff:0:0/96`.
+ *
+ * Any non-zero IPv4 embedded in the last 32 bits of an all-zero-upper
+ * IPv6 address is suspect. `::` and `::1` are already separately
+ * blocked; this helper covers the rest of `::/96` with a non-zero v4.
+ */
+function isBlockedIpv4CompatibleIpv6(hostStripped: string, family: number): boolean {
+  if (family !== 6) return false;
+  // Normalize "::a.b.c.d" to "::a.b.c.d" and "::hex:hex" forms by parsing
+  // through URL. A 6-word-zero + final 32-bit form means the upper 96 bits
+  // are zero.
+  // Quick literal check for dotted form.
+  const dotted = /^::(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(hostStripped);
+  if (dotted) return true;
+  // Hex form: `::x:y` where x,y are 1-4 hex. Reject unless explicitly
+  // whitelisted (::1 and :: are already handled upstream).
+  if (/^::[0-9a-f]{1,4}:[0-9a-f]{1,4}$/.test(hostStripped)) {
+    return hostStripped !== "::1"; // ::1 already caught earlier
+  }
+  return false;
+}
 
 /**
  * Minimal structured logger surface. Matches the fields emitted by
@@ -190,6 +225,13 @@ export function assertSafeCustomEndpoint(rawUrl: string): void {
   if (family === 6) {
     if (BLOCKED_IPS.check(stripped, "ipv6")) {
       throw new SsrfError("blocked IPv6 host");
+    }
+    // IPv4-compatible IPv6 (`::a.b.c.d`, deprecated) is not caught by
+    // `::ffff:0:0/96` because the "ffff" word is zero. Reject these too —
+    // they smuggle the v4 destination through a format the BlockList
+    // can't match without a separate check.
+    if (isBlockedIpv4CompatibleIpv6(stripped, family)) {
+      throw new SsrfError("blocked IPv4-compatible IPv6 host");
     }
     return;
   }

--- a/apps/api/src/lib/settings-service.ts
+++ b/apps/api/src/lib/settings-service.ts
@@ -10,9 +10,20 @@ import { DEFAULT_ELIGIBILITY_PROPERTY } from "../services/eligibility";
 import { DEFAULT_THRESHOLDS, invalidateTenantConfig } from "./config-resolver";
 import { encryptProviderKey } from "./encryption";
 
+/**
+ * Thrown when `updateSettings` receives a payload that passed initial
+ * validation but violates a service-level invariant (defense-in-depth). The
+ * route layer maps this to HTTP 400.
+ */
+export class SettingsValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SettingsValidationError";
+  }
+}
+
 const MANAGED_SIGNAL_PROVIDERS = [
   { key: "exa", providerName: "exa" },
-  { key: "news", providerName: "news" },
   { key: "hubspotEnrichment", providerName: "hubspot-enrichment" },
 ] as const;
 
@@ -143,10 +154,6 @@ export async function readSettings(deps: SettingsServiceDeps): Promise<SettingsR
       exa: {
         enabled: rowByProvider.get("exa")?.enabled ?? false,
         hasApiKey: !!rowByProvider.get("exa")?.apiKeyEncrypted,
-      },
-      news: {
-        enabled: rowByProvider.get("news")?.enabled ?? false,
-        hasApiKey: !!rowByProvider.get("news")?.apiKeyEncrypted,
       },
       hubspotEnrichment: {
         enabled: rowByProvider.get("hubspot-enrichment")?.enabled ?? false,
@@ -286,17 +293,45 @@ export async function updateSettings(
     }
 
     if (update.signalProviders) {
-      for (const { key, providerName } of MANAGED_SIGNAL_PROVIDERS) {
-        const patch = update.signalProviders[key];
-        if (!patch) continue;
-        const existing = providerByName.get(providerName);
-        await upsertSignalProvider(txDb, tenantId, providerName, {
-          enabled: patch.enabled ?? existing?.enabled ?? false,
-          apiKeyEncrypted: patch.clearApiKey
+      const exaPatch = update.signalProviders.exa;
+      if (exaPatch) {
+        const existing = providerByName.get("exa");
+        await upsertSignalProvider(txDb, tenantId, "exa", {
+          enabled: exaPatch.enabled ?? existing?.enabled ?? false,
+          apiKeyEncrypted: exaPatch.clearApiKey
             ? null
-            : patch.apiKey
-              ? encryptProviderKey(tenantId, patch.apiKey)
+            : exaPatch.apiKey
+              ? encryptProviderKey(tenantId, exaPatch.apiKey)
               : (existing?.apiKeyEncrypted ?? null),
+          thresholds: {
+            ...DEFAULT_THRESHOLDS,
+            ...parseThresholds(existing?.thresholds),
+            ...update.thresholds,
+          },
+        });
+      }
+
+      const enrichmentPatch = update.signalProviders.hubspotEnrichment;
+      if (enrichmentPatch) {
+        // Defense in depth: the validator already rejects `apiKey` /
+        // `clearApiKey` for the OAuth-backed HubSpot enrichment slot. If a
+        // caller somehow bypasses the validator, surface a hard error rather
+        // than silently dropping the field.
+        const stray = enrichmentPatch as {
+          apiKey?: unknown;
+          clearApiKey?: unknown;
+        };
+        if (stray.apiKey !== undefined || stray.clearApiKey !== undefined) {
+          throw new SettingsValidationError(
+            "hubspotEnrichment does not accept apiKey/clearApiKey; it is OAuth-backed",
+          );
+        }
+        const existing = providerByName.get("hubspot-enrichment");
+        await upsertSignalProvider(txDb, tenantId, "hubspot-enrichment", {
+          enabled: enrichmentPatch.enabled ?? existing?.enabled ?? false,
+          // Preserve any historical ciphertext rather than deleting — the DB
+          // migration path owns cleanup. No API key is ever written here.
+          apiKeyEncrypted: existing?.apiKeyEncrypted ?? null,
           thresholds: {
             ...DEFAULT_THRESHOLDS,
             ...parseThresholds(existing?.thresholds),

--- a/apps/api/src/lib/test-connection-rate-limit.ts
+++ b/apps/api/src/lib/test-connection-rate-limit.ts
@@ -1,0 +1,84 @@
+/**
+ * Per-tenant token-bucket rate limiter for the settings test-connection
+ * endpoint.
+ *
+ * Distinct from {@link ./rate-limiter} (which is keyed `(tenantId, provider)`
+ * and protects downstream adapter calls with a DEFAULT of 60-burst/1-rps). The
+ * test-connection path wants a stricter policy: 5 tests per 60 seconds per
+ * tenant, so a single compromised tenant cannot turn the endpoint into a
+ * free-tier DoS vector against upstream vendors.
+ *
+ * The bucket is in-process; multi-instance deployments will see up to
+ * N * capacity per 60s across the fleet, which is acceptable for a human-
+ * driven "Test connection" button.
+ */
+
+export interface TestConnectionRateLimiterOptions {
+  /** Max tests per window. Default: 5. */
+  capacity?: number;
+  /** Window size in milliseconds. Default: 60_000. */
+  windowMs?: number;
+  /** Clock source for testability. */
+  now?: () => number;
+}
+
+interface Bucket {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+export class TestConnectionRateLimiter {
+  private readonly capacity: number;
+  private readonly windowMs: number;
+  private readonly now: () => number;
+  private readonly buckets = new Map<string, Bucket>();
+
+  constructor(opts: TestConnectionRateLimiterOptions = {}) {
+    this.capacity = opts.capacity ?? 5;
+    this.windowMs = opts.windowMs ?? 60_000;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Try to consume one token for `tenantId`. Returns `true` when allowed,
+   * `false` when the bucket is empty.
+   */
+  allow(tenantId: string): boolean {
+    const now = this.now();
+    const refillRatePerMs = this.capacity / this.windowMs;
+    let bucket = this.buckets.get(tenantId);
+    if (!bucket) {
+      bucket = { tokens: this.capacity, lastRefillMs: now };
+      this.buckets.set(tenantId, bucket);
+    } else {
+      const elapsed = Math.max(0, now - bucket.lastRefillMs);
+      if (elapsed > 0) {
+        bucket.tokens = Math.min(this.capacity, bucket.tokens + elapsed * refillRatePerMs);
+        bucket.lastRefillMs = now;
+      }
+    }
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return true;
+    }
+    return false;
+  }
+
+  /** @internal — test hook. */
+  __clear(): void {
+    this.buckets.clear();
+  }
+}
+
+/** Module-level singleton used by the default route wiring. */
+let processLimiter: TestConnectionRateLimiter | null = null;
+
+export function getTestConnectionRateLimiter(): TestConnectionRateLimiter {
+  if (!processLimiter) processLimiter = new TestConnectionRateLimiter();
+  return processLimiter;
+}
+
+/** TEST-ONLY: reset the singleton. */
+export function __resetTestConnectionRateLimiterForTests(): void {
+  processLimiter = null;
+}

--- a/apps/api/src/routes/__tests__/compose-signal-adapters.test.ts
+++ b/apps/api/src/routes/__tests__/compose-signal-adapters.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression test for C1 (code-reviewer finding on PR #20):
+ * `createExaSignalAdapters` was wired into `resolveSignalAdapter` via this
+ * composite helper. Prior to the fix, only `createSignalAdapter` ran, so
+ * tenants with `exa.settings.newsEnabled !== false` silently lost the News
+ * evidence source in production.
+ *
+ * These tests lock the contract the snapshot assembler depends on:
+ *  - the composite's `fetchSignals` calls EVERY sub-adapter,
+ *  - flattens their evidence into one array,
+ *  - rejects when any sub-adapter rejects (so the assembler marks the
+ *    snapshot `degraded` the same way the single-adapter path would).
+ */
+
+import { createEvidence, type Evidence } from "@hap/config";
+import { describe, expect, it, vi } from "vitest";
+import type { ProviderAdapter, ProviderCompanyContext } from "../../adapters/provider-adapter";
+import { composeSignalAdapters } from "../snapshot";
+
+function stubAdapter(name: string, evidence: Evidence[]): ProviderAdapter {
+  return {
+    name,
+    fetchSignals: vi.fn(async () => evidence),
+  };
+}
+
+function stubRejector(name: string, err: Error): ProviderAdapter {
+  return {
+    name,
+    fetchSignals: vi.fn(async () => {
+      throw err;
+    }),
+  };
+}
+
+const TENANT_ID = "tenant-a";
+const COMPANY: ProviderCompanyContext = {
+  companyId: "123",
+  companyName: "Acme",
+};
+
+function makeEvidence(source: string): Evidence {
+  return createEvidence(TENANT_ID, {
+    id: `${source}:1`,
+    source,
+    timestamp: new Date(),
+    confidence: 0.5,
+    content: `${source} finding`,
+    isRestricted: false,
+  });
+}
+
+describe("composeSignalAdapters", () => {
+  it("calls every sub-adapter and flattens evidence from all of them", async () => {
+    const exa = stubAdapter("exa", [makeEvidence("exa")]);
+    const news = stubAdapter("news", [makeEvidence("nytimes.com"), makeEvidence("reuters.com")]);
+
+    const composite = composeSignalAdapters([exa, news], "exa");
+    const result = await composite.fetchSignals(TENANT_ID, COMPANY);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.source)).toEqual(["exa", "nytimes.com", "reuters.com"]);
+    expect(exa.fetchSignals).toHaveBeenCalledTimes(1);
+    expect(news.fetchSignals).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the composite name (used by downstream logs/metrics)", async () => {
+    const composite = composeSignalAdapters([stubAdapter("exa", [])], "exa");
+    expect(composite.name).toBe("exa");
+  });
+
+  it("returns an empty array when all sub-adapters return empty", async () => {
+    const composite = composeSignalAdapters(
+      [stubAdapter("exa", []), stubAdapter("news", [])],
+      "exa",
+    );
+    const result = await composite.fetchSignals(TENANT_ID, COMPANY);
+    expect(result).toEqual([]);
+  });
+
+  it("rejects when any sub-adapter rejects (so the snapshot assembler marks degraded)", async () => {
+    const exa = stubAdapter("exa", [makeEvidence("exa")]);
+    const news = stubRejector("news", new Error("Exa news vertical failed"));
+
+    const composite = composeSignalAdapters([exa, news], "exa");
+    await expect(composite.fetchSignals(TENANT_ID, COMPANY)).rejects.toThrow(
+      /Exa news vertical failed/,
+    );
+  });
+
+  it("calls sub-adapters in parallel, not serially", async () => {
+    const calls: string[] = [];
+    const makeSlow = (name: string, delayMs: number): ProviderAdapter => ({
+      name,
+      fetchSignals: async () => {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        calls.push(name);
+        return [];
+      },
+    });
+
+    const composite = composeSignalAdapters([makeSlow("exa", 20), makeSlow("news", 5)], "exa");
+    const start = Date.now();
+    await composite.fetchSignals(TENANT_ID, COMPANY);
+    const elapsed = Date.now() - start;
+
+    // news (5ms) should finish first; exa (20ms) determines total time.
+    // If serial, total would be ~25ms. In parallel, ~20ms. Give generous
+    // margin for CI flake.
+    expect(calls).toEqual(["news", "exa"]);
+    expect(elapsed).toBeLessThan(50);
+  });
+});

--- a/apps/api/src/routes/__tests__/settings-test-connection.test.ts
+++ b/apps/api/src/routes/__tests__/settings-test-connection.test.ts
@@ -1,0 +1,251 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SavedKeyLoader, TestConnectionDeps } from "../../lib/settings-connection-test";
+import { TestConnectionRateLimiter } from "../../lib/test-connection-rate-limit";
+import type { TenantVariables } from "../../middleware/tenant";
+import {
+  createTestConnectionRoute,
+  type TestConnectionRouteDeps,
+} from "../settings-test-connection";
+
+/**
+ * Build a standalone Hono app with:
+ *   - a fake tenant middleware that sets `tenantId` from the
+ *     `x-test-tenant-id` header (or returns 401 when absent — matching the
+ *     auth posture of the real middleware chain).
+ *   - the test-connection route mounted under `/test-connection`.
+ *
+ * This avoids pulling the real `authMiddleware` / `tenantMiddleware` / DB
+ * transaction handle into a unit test. Cross-tenant isolation + auth-missing
+ * behavior are exercised through the fake middleware, which mirrors the
+ * contract the real chain sets up (see `apps/api/src/middleware/tenant.ts`).
+ */
+function buildApp(
+  routeDeps: TestConnectionRouteDeps = {},
+  opts: { requireTenant?: boolean } = { requireTenant: true },
+) {
+  const app = new Hono<{ Variables: TenantVariables }>();
+  app.use("*", async (c, next) => {
+    const header = c.req.header("x-test-tenant-id");
+    if (opts.requireTenant !== false) {
+      if (!header) return c.json({ error: "unauthorized" }, 401);
+    }
+    if (header) c.set("tenantId", header);
+    await next();
+  });
+  app.route("/test-connection", createTestConnectionRoute(routeDeps));
+  return app;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /test-connection — body validation", () => {
+  it("returns 400 when body is missing `target`", async () => {
+    const app = buildApp({});
+    const res = await app.request("/test-connection", {
+      method: "POST",
+      headers: {
+        "x-test-tenant-id": "t-a",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ apiKey: "whatever" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_body");
+  });
+
+  it("returns 400 when apiKey AND useSavedKey are both present (XOR)", async () => {
+    const app = buildApp({});
+    const res = await app.request("/test-connection", {
+      method: "POST",
+      headers: {
+        "x-test-tenant-id": "t-a",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4",
+        apiKey: "sk-draft",
+        useSavedKey: true,
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when apiKey AND useSavedKey are both absent (XOR)", async () => {
+    const app = buildApp({});
+    const res = await app.request("/test-connection", {
+      method: "POST",
+      headers: {
+        "x-test-tenant-id": "t-a",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when provider === 'custom' and endpointUrl is missing", async () => {
+    const app = buildApp({});
+    const res = await app.request("/test-connection", {
+      method: "POST",
+      headers: {
+        "x-test-tenant-id": "t-a",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        target: "llm",
+        provider: "custom",
+        model: "oss",
+        apiKey: "k",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /test-connection — auth posture", () => {
+  it("returns 401 when the request has no resolved tenant", async () => {
+    const app = buildApp({});
+    const res = await app.request("/test-connection", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        target: "exa",
+        apiKey: "exa-draft",
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /test-connection — cross-tenant isolation", () => {
+  it("never surfaces tenant B's saved key to tenant A", async () => {
+    const loader = vi.fn<SavedKeyLoader>(async (tenantId) => {
+      if (tenantId === "t-b") return "secret-for-b";
+      return null;
+    });
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(jsonResponse(200, {})),
+    ) as unknown as typeof fetch;
+    const serviceDeps: TestConnectionDeps = {
+      fetch: fetchImpl,
+      loadSavedKey: loader,
+      now: () => 0,
+    };
+    const app = buildApp({ serviceDeps });
+
+    const res = await app.request("/test-connection", {
+      method: "POST",
+      headers: {
+        "x-test-tenant-id": "t-a",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        target: "exa",
+        useSavedKey: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: false; code: string };
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe("auth");
+    // The loader was only called with tenant A; tenant B's key was never loaded.
+    expect(loader.mock.calls.map((c) => c[0])).toEqual(["t-a"]);
+    // The vendor fetch must not fire when no key resolved.
+    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+});
+
+describe("POST /test-connection — rate limit", () => {
+  it("returns 429 on the 6th rapid request within the window", async () => {
+    const limiter = new TestConnectionRateLimiter({
+      capacity: 5,
+      windowMs: 60_000,
+      now: () => 1,
+    });
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(jsonResponse(200, { data: [{ id: "gpt-5.4" }] })),
+    ) as unknown as typeof fetch;
+    const app = buildApp({
+      serviceDeps: { fetch: fetchImpl, now: () => 1 },
+      rateLimiter: limiter,
+    });
+
+    const makeReq = () =>
+      app.request("/test-connection", {
+        method: "POST",
+        headers: {
+          "x-test-tenant-id": "t-a",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          target: "llm",
+          provider: "openai",
+          model: "gpt-5.4",
+          apiKey: "sk-draft",
+        }),
+      });
+
+    for (let i = 0; i < 5; i++) {
+      const r = await makeReq();
+      expect(r.status).toBe(200);
+    }
+    const sixth = await makeReq();
+    expect(sixth.status).toBe(429);
+    const body = (await sixth.json()) as { ok: false; code: string };
+    expect(body.code).toBe("rate_limit");
+  });
+});
+
+describe("POST /test-connection — happy path", () => {
+  it("returns 200 with a schema-valid success body for a draft LLM key", async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(jsonResponse(200, { data: [{ id: "gpt-5.4" }] })),
+    ) as unknown as typeof fetch;
+    const app = buildApp({
+      serviceDeps: { fetch: fetchImpl, now: () => 1 },
+    });
+
+    const res = await app.request("/test-connection", {
+      method: "POST",
+      headers: {
+        "x-test-tenant-id": "t-a",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4",
+        apiKey: "sk-draft",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: true;
+      latencyMs: number;
+      providerEcho?: { model?: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(typeof body.latencyMs).toBe("number");
+    expect(body.providerEcho?.model).toBe("gpt-5.4");
+    // Response JSON must never contain the plaintext key.
+    expect(JSON.stringify(body)).not.toContain("sk-draft");
+  });
+});

--- a/apps/api/src/routes/__tests__/settings.test.ts
+++ b/apps/api/src/routes/__tests__/settings.test.ts
@@ -106,7 +106,12 @@ describe("GET /api/settings", () => {
     const body = (await res.json()) as {
       tenantId: string;
       signalProviders: Record<string, { enabled: boolean; hasApiKey: boolean }>;
-      llm: { provider: string | null; model: string; hasApiKey: boolean; endpointUrl?: string };
+      llm: {
+        provider: string | null;
+        model: string;
+        hasApiKey: boolean;
+        endpointUrl?: string;
+      };
       eligibility: { propertyName: string };
       thresholds: { freshnessMaxDays: number; minConfidence: number };
     };
@@ -115,7 +120,6 @@ describe("GET /api/settings", () => {
       tenantId: tenant.id,
       signalProviders: {
         exa: { enabled: false, hasApiKey: false },
-        news: { enabled: false, hasApiKey: false },
         hubspotEnrichment: { enabled: false, hasApiKey: false },
       },
       llm: {
@@ -149,7 +153,6 @@ describe("PUT /api/settings", () => {
       body: JSON.stringify({
         signalProviders: {
           exa: { enabled: true, apiKey: "exa-secret-route" },
-          news: { enabled: true },
           hubspotEnrichment: { enabled: true },
         },
         llm: {
@@ -175,7 +178,6 @@ describe("PUT /api/settings", () => {
       tenantId: tenant.id,
       signalProviders: {
         exa: { enabled: true, hasApiKey: true },
-        news: { enabled: true, hasApiKey: false },
         hubspotEnrichment: { enabled: true, hasApiKey: false },
       },
       llm: {
@@ -327,7 +329,10 @@ describe("PUT /api/settings", () => {
       signalProviders: { exa: { enabled: boolean; hasApiKey: boolean } };
     };
     expect(body.tenantId).toBe(tenantB.id);
-    expect(body.signalProviders.exa).toEqual({ enabled: false, hasApiKey: false });
+    expect(body.signalProviders.exa).toEqual({
+      enabled: false,
+      hasApiKey: false,
+    });
   });
 
   it("invalidates cached provider and llm config immediately after settings save", async () => {
@@ -394,5 +399,45 @@ describe("PUT /api/settings", () => {
     expect(freshLlm?.provider).toBe("openai");
     expect(freshLlm?.model).toBe("gpt-5.4-mini");
     expect(freshLlm?.apiKeyRef).toBe("openai-new");
+  });
+
+  it("rejects a PUT payload that includes the legacy 'news' signal provider slot with 400", async () => {
+    const tenant = await seedTenant();
+    const app = await loadApp();
+
+    const res = await app.request("/api/settings", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        signalProviders: {
+          news: { enabled: true, apiKey: "news-key" },
+        },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a PUT payload that attaches an apiKey to hubspotEnrichment with 400", async () => {
+    const tenant = await seedTenant();
+    const app = await loadApp();
+
+    const res = await app.request("/api/settings", {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        signalProviders: {
+          hubspotEnrichment: { enabled: true, apiKey: "fake-key" },
+        },
+      }),
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/api/src/routes/settings-test-connection.ts
+++ b/apps/api/src/routes/settings-test-connection.ts
@@ -1,0 +1,98 @@
+/**
+ * `POST /api/settings/test-connection` — explicit credential verification.
+ *
+ * Mounted under the settings router so it inherits the full auth + tenant
+ * middleware chain configured in {@link ../index}. The route:
+ *
+ *   1. Validates the body against the {@link testConnectionBodySchema}
+ *      discriminated union (XOR on apiKey/useSavedKey, HTTPS for custom).
+ *   2. Enforces a per-tenant rate limit (default 5 tests / 60s) so a
+ *      compromised tenant cannot spam upstream vendors.
+ *   3. Dispatches to {@link testConnection} which never logs or echoes the
+ *      plaintext key, SSRF-guards custom endpoints, and maps all vendor
+ *      errors to a narrow `code` union.
+ *
+ * The route intentionally returns `200` for both success and vendor-failure
+ * cases — the UI treats the response body as authoritative. Shape errors
+ * (missing discriminator, XOR violation, etc.) remain 400 so the FE form
+ * handler surfaces them as developer/integration errors rather than as an
+ * "ordinary" connection-test failure.
+ */
+
+import { testConnectionBodySchema } from "@hap/validators";
+import { Hono } from "hono";
+import {
+  createDefaultSavedKeyLoader,
+  type TestConnectionDeps,
+  testConnection,
+} from "../lib/settings-connection-test";
+import {
+  getTestConnectionRateLimiter,
+  type TestConnectionRateLimiter,
+} from "../lib/test-connection-rate-limit";
+import type { TenantVariables } from "../middleware/tenant";
+
+export interface TestConnectionRouteDeps {
+  /** Override connection-test service deps (fetch, logger, loadSavedKey). */
+  serviceDeps?: TestConnectionDeps;
+  /** Override the rate limiter — useful for test isolation. */
+  rateLimiter?: TestConnectionRateLimiter;
+}
+
+/**
+ * Build a Hono sub-app for the test-connection route. Callers mount it under
+ * the parent settings app so the same auth + tenant middleware chain runs.
+ */
+export function createTestConnectionRoute(
+  deps: TestConnectionRouteDeps = {},
+): Hono<{ Variables: TenantVariables }> {
+  const router = new Hono<{ Variables: TenantVariables }>();
+
+  router.post("/", async (c) => {
+    const tenantId = c.get("tenantId");
+    const db = c.get("db");
+    if (!tenantId) {
+      return c.json({ error: "tenant_context_missing" }, 401);
+    }
+
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid_json" }, 400);
+    }
+
+    const parsed = testConnectionBodySchema.safeParse(raw);
+    if (!parsed.success) {
+      return c.json({ error: "invalid_body", issues: parsed.error.issues }, 400);
+    }
+
+    const limiter = deps.rateLimiter ?? getTestConnectionRateLimiter();
+    if (!limiter.allow(tenantId)) {
+      return c.json(
+        {
+          ok: false as const,
+          code: "rate_limit" as const,
+          message: "Too many test requests",
+        },
+        429,
+      );
+    }
+
+    // If no loader was injected, default to the in-process DB-backed loader
+    // keyed on the per-request tenant transaction handle. When `db` is absent
+    // (defensive — the tenant middleware chain normally provides one) the
+    // saved-key path degrades gracefully to "No stored key".
+    const serviceDeps: TestConnectionDeps = {
+      ...(deps.serviceDeps ?? {}),
+    };
+    if (!serviceDeps.loadSavedKey && db) {
+      serviceDeps.loadSavedKey = createDefaultSavedKeyLoader(db);
+    }
+
+    const result = await testConnection(tenantId, parsed.data, serviceDeps);
+    return c.json(result, 200);
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -1,7 +1,7 @@
 import type { SettingsUpdate } from "@hap/config";
 import { settingsResponseSchema, settingsUpdateSchema } from "@hap/validators";
 import { Hono } from "hono";
-import { readSettings, updateSettings } from "../lib/settings-service";
+import { readSettings, SettingsValidationError, updateSettings } from "../lib/settings-service";
 import type { TenantVariables } from "../middleware/tenant";
 
 export const settingsRoutes = new Hono<{ Variables: TenantVariables }>();
@@ -40,7 +40,14 @@ settingsRoutes.put("/", async (c) => {
     return c.json({ error: "invalid_settings", issues: parsed.error.issues }, 400);
   }
 
-  await updateSettings({ db, tenantId }, parsed.data as SettingsUpdate);
+  try {
+    await updateSettings({ db, tenantId }, parsed.data as SettingsUpdate);
+  } catch (err) {
+    if (err instanceof SettingsValidationError) {
+      return c.json({ error: "invalid_settings", detail: err.message }, 400);
+    }
+    throw err;
+  }
   const settings = await readSettings({ db, tenantId });
   const response = settingsResponseSchema.safeParse(settings);
   if (!response.success) {

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -3,8 +3,14 @@ import { settingsResponseSchema, settingsUpdateSchema } from "@hap/validators";
 import { Hono } from "hono";
 import { readSettings, SettingsValidationError, updateSettings } from "../lib/settings-service";
 import type { TenantVariables } from "../middleware/tenant";
+import { createTestConnectionRoute } from "./settings-test-connection";
 
 export const settingsRoutes = new Hono<{ Variables: TenantVariables }>();
+
+// B4: Credential verification endpoint — mounted under the settings router so
+// it inherits the `/api/*` auth + tenant middleware chain. See
+// `./settings-test-connection.ts` for the full contract.
+settingsRoutes.route("/test-connection", createTestConnectionRoute());
 
 settingsRoutes.get("/", async (c) => {
   const tenantId = c.get("tenantId");

--- a/apps/api/src/routes/snapshot.ts
+++ b/apps/api/src/routes/snapshot.ts
@@ -10,7 +10,11 @@ import { Hono } from "hono";
 import { createLlmAdapter, wrapWithGuards } from "../adapters/llm/factory";
 import type { LlmAdapter } from "../adapters/llm-adapter";
 import type { ProviderAdapter } from "../adapters/provider-adapter";
-import { createSignalAdapter, wrapSignalWithGuards } from "../adapters/signal/factory";
+import {
+  createExaSignalAdapters,
+  createSignalAdapter,
+  wrapSignalWithGuards,
+} from "../adapters/signal/factory";
 import { DEFAULT_THRESHOLDS, getLlmConfig, getProviderConfig } from "../lib/config-resolver";
 import { TenantAccessRevokedError } from "../lib/hubspot-client";
 import { getProcessRateLimiter } from "../lib/rate-limiter";
@@ -152,12 +156,43 @@ type SignalResolution = {
 };
 
 /**
+ * Compose N wrapped adapters into a single `ProviderAdapter` whose
+ * `fetchSignals` runs all of them in parallel and flattens the resulting
+ * evidence arrays.
+ *
+ * If any sub-adapter rejects, the composite rejects — matching the existing
+ * single-adapter contract. The snapshot assembler catches that rejection and
+ * marks the snapshot `degraded`.
+ *
+ * The composite's `name` mirrors the primary provider (e.g. `"exa"`) so
+ * upstream logs and metrics don't suddenly see a new adapter name. Each
+ * sub-adapter retains its own `name` inside the `wrapSignalWithGuards`
+ * wrapper, so rate-limit buckets + observability log lines attribute
+ * correctly per source (`exa` vs `news`).
+ */
+export function composeSignalAdapters(
+  adapters: ProviderAdapter[],
+  compositeName: string,
+): ProviderAdapter {
+  return {
+    name: compositeName,
+    async fetchSignals(tenantId, company) {
+      const results = await Promise.all(adapters.map((a) => a.fetchSignals(tenantId, company)));
+      return results.flat();
+    },
+  };
+}
+
+/**
  * Resolve the signal adapter for a tenant.
  *
  * Probes `provider_config` for each of {@link REAL_SIGNAL_PROVIDERS} in order.
  * On the first enabled hit, builds the real adapter and wraps with guards.
- * Returns `null` when no enabled provider row exists or adapter construction
- * fails. The caller short-circuits to `eligibilityState: "unconfigured"`.
+ * For the Exa row this fans out to both Exa search and the Exa news vertical
+ * (NewsAdapter) via {@link createExaSignalAdapters}, gated by the row's
+ * `settings.newsEnabled` flag. Returns `null` when no enabled provider row
+ * exists or adapter construction fails. The caller short-circuits to
+ * `eligibilityState: "unconfigured"`.
  */
 async function resolveSignalAdapter(
   db: Database,
@@ -185,12 +220,38 @@ async function resolveSignalAdapter(
   // Construction can throw — e.g., required tenant-scoped deps are missing,
   // or a provider config row has a non-null field that's nullable in the
   // schema. Treat as unconfigured, not a 500.
-  let real: ProviderAdapter;
+  //
+  // For the Exa row we fan out: `createExaSignalAdapters` returns the main
+  // ExaAdapter plus (when `settings.newsEnabled !== false`) a NewsAdapter
+  // driven off the same API key. Each sub-adapter is wrapped individually
+  // so the process rate limiter + observability log apply per-source; the
+  // composite is then handed to the snapshot assembler as a single
+  // `ProviderAdapter` whose `fetchSignals` flattens evidence from all
+  // sub-adapters. Non-Exa providers (none today — `hubspot-enrichment` is
+  // excluded from `REAL_SIGNAL_PROVIDERS`) stay on the single-adapter path.
+  let adapter: ProviderAdapter;
   try {
-    real = createSignalAdapter(chosen, {
-      db,
-      tenantId,
-    });
+    if (chosen.name === "exa") {
+      const subAdapters = createExaSignalAdapters(chosen, { db, tenantId });
+      if (subAdapters.length === 0) {
+        return null;
+      }
+      const wrapped = subAdapters.map((sub) =>
+        wrapSignalWithGuards(sub, {
+          tenantId,
+          correlationId,
+          rateLimiter: getProcessRateLimiter(),
+        }),
+      );
+      adapter = composeSignalAdapters(wrapped, chosen.name);
+    } else {
+      const real = createSignalAdapter(chosen, { db, tenantId });
+      adapter = wrapSignalWithGuards(real, {
+        tenantId,
+        correlationId,
+        rateLimiter: getProcessRateLimiter(),
+      });
+    }
   } catch (err) {
     console.error("signal_adapter_construction_failed", {
       tenantId,
@@ -200,11 +261,6 @@ async function resolveSignalAdapter(
     return null;
   }
 
-  const adapter = wrapSignalWithGuards(real, {
-    tenantId,
-    correlationId,
-    rateLimiter: getProcessRateLimiter(),
-  });
   return {
     adapter,
     allowList: chosen.allowList,

--- a/apps/api/src/routes/snapshot.ts
+++ b/apps/api/src/routes/snapshot.ts
@@ -132,11 +132,13 @@ async function resolveLlmAdapter(
  * Signal providers probed from `provider_config` rows in listed order; first
  * enabled match wins.
  *
- * Slice 3 adds `news` (now a real adapter). `hubspot-enrichment` stays out
- * until the adapter body is implemented — its factory throws at construction,
- * which `resolveSignalAdapter` treats the same as "no config row" = `null`.
+ * `news` was removed as a top-level provider slot — it now runs as a
+ * secondary adapter driven by the Exa row via {@link createExaSignalAdapters}.
+ * `hubspot-enrichment` stays out of this probe list because its factory
+ * throws when tenant-scoped deps are missing; the snapshot path treats that
+ * the same as "no config row".
  */
-const REAL_SIGNAL_PROVIDERS = ["exa", "news"] as const;
+const REAL_SIGNAL_PROVIDERS = ["exa"] as const;
 
 /**
  * Successful signal resolution — contains the adapter plus per-provider

--- a/apps/hubspot-extension/__tests__/vite-config.test.ts
+++ b/apps/hubspot-extension/__tests__/vite-config.test.ts
@@ -76,6 +76,22 @@ describe("hubspot-extension vite.config.ts", () => {
     expect(block.__HAP_API_ORIGIN__).toBe(JSON.stringify(""));
   });
 
+  it("externalizes react, react-dom, react/jsx-runtime, and @hubspot/ui-extensions", async () => {
+    // Vite lib mode only auto-externalizes peerDependencies. react/react-dom
+    // are declared in `dependencies` so without this explicit list the
+    // bundle inlines a second copy of React, and at runtime the first
+    // useState call throws "Cannot read properties of null (reading
+    // 'useState')". Pin the external contract here so a refactor cannot
+    // silently regress the settings extension.
+    const cfg = await loadConfigWithEnv({ API_ORIGIN: "https://example.test" });
+    const external = cfg.build?.rollupOptions?.external;
+    expect(external).toBeDefined();
+    const externalArray = Array.isArray(external) ? external : [external];
+    for (const entry of ["react", "react-dom", "react/jsx-runtime", "@hubspot/ui-extensions"]) {
+      expect(externalArray).toContain(entry);
+    }
+  });
+
   it("preserves the API_ORIGIN value verbatim (no trailing-slash normalization)", async () => {
     // Clarity: the resolver does NOT strip trailing slashes. If a profile
     // supplies "https://host/" the built bundle carries that exact string

--- a/apps/hubspot-extension/src/settings/__tests__/connection-test-status.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/connection-test-status.test.tsx
@@ -1,0 +1,104 @@
+import { Text } from "@hubspot/ui-extensions";
+import { createRenderer } from "@hubspot/ui-extensions/testing";
+import { describe, expect, it } from "vitest";
+import { ConnectionTestStatus } from "../connection-test-status";
+
+describe("ConnectionTestStatus", () => {
+  it("renders nothing when state is idle", () => {
+    const renderer = createRenderer("settings");
+    renderer.render(<ConnectionTestStatus state="idle" />);
+    const texts = renderer.findAll(Text);
+    expect(texts.length).toBe(0);
+  });
+
+  it("renders 'Testing…' when state is loading", () => {
+    const renderer = createRenderer("settings");
+    renderer.render(<ConnectionTestStatus state="loading" />);
+    const combined = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(combined).toMatch(/Testing/);
+  });
+
+  it("renders success with latency", () => {
+    const renderer = createRenderer("settings");
+    renderer.render(<ConnectionTestStatus state={{ ok: true, latencyMs: 42 }} />);
+    const combined = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(combined).toContain("Connected");
+    expect(combined).toContain("42ms");
+  });
+
+  it("renders failure with human message for auth", () => {
+    const renderer = createRenderer("settings");
+    renderer.render(
+      <ConnectionTestStatus state={{ ok: false, code: "auth", message: "invalid" }} />,
+    );
+    const combined = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(combined).toMatch(/Authentication failed/i);
+  });
+
+  it("renders failure with human message for model", () => {
+    const renderer = createRenderer("settings");
+    renderer.render(<ConnectionTestStatus state={{ ok: false, code: "model", message: "nope" }} />);
+    const combined = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(combined).toMatch(/Model is not available/i);
+  });
+
+  it("renders failure with human message for endpoint", () => {
+    const renderer = createRenderer("settings");
+    renderer.render(
+      <ConnectionTestStatus state={{ ok: false, code: "endpoint", message: "bad url" }} />,
+    );
+    const combined = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(combined).toMatch(/HTTPS and non-private/i);
+  });
+
+  it("renders failure with human message for rate_limit", () => {
+    const renderer = createRenderer("settings");
+    renderer.render(
+      <ConnectionTestStatus state={{ ok: false, code: "rate_limit", message: "slow down" }} />,
+    );
+    const combined = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(combined).toMatch(/Wait a minute/i);
+  });
+
+  it("renders failure with human message for network", () => {
+    const renderer = createRenderer("settings");
+    renderer.render(
+      <ConnectionTestStatus state={{ ok: false, code: "network", message: "timeout" }} />,
+    );
+    const combined = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(combined).toMatch(/Network error/i);
+  });
+
+  it("renders failure with human message for unknown", () => {
+    const renderer = createRenderer("settings");
+    renderer.render(
+      <ConnectionTestStatus state={{ ok: false, code: "unknown", message: "boom" }} />,
+    );
+    const combined = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(combined).toMatch(/Unexpected error/i);
+  });
+});

--- a/apps/hubspot-extension/src/settings/__tests__/percent-format.test.ts
+++ b/apps/hubspot-extension/src/settings/__tests__/percent-format.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { decimalToPercent, percentToDecimal } from "../percent-format";
+
+describe("percent-format", () => {
+  describe("decimalToPercent", () => {
+    it("converts 0 to 0", () => {
+      expect(decimalToPercent(0)).toBe(0);
+    });
+
+    it("converts 0.65 to 65", () => {
+      expect(decimalToPercent(0.65)).toBe(65);
+    });
+
+    it("converts 1 to 100", () => {
+      expect(decimalToPercent(1)).toBe(100);
+    });
+
+    it("rounds to 1 decimal place", () => {
+      expect(decimalToPercent(0.12345)).toBe(12.3);
+      expect(decimalToPercent(0.126)).toBe(12.6);
+    });
+
+    it("clamps values below 0 to 0", () => {
+      expect(decimalToPercent(-0.5)).toBe(0);
+    });
+
+    it("clamps values above 1 to 100", () => {
+      expect(decimalToPercent(1.5)).toBe(100);
+    });
+
+    it("throws on NaN", () => {
+      expect(() => decimalToPercent(Number.NaN)).toThrow();
+    });
+  });
+
+  describe("percentToDecimal", () => {
+    it("converts 0 to 0", () => {
+      expect(percentToDecimal(0)).toBe(0);
+    });
+
+    it("converts 65 to 0.65", () => {
+      expect(percentToDecimal(65)).toBe(0.65);
+    });
+
+    it("converts 100 to 1", () => {
+      expect(percentToDecimal(100)).toBe(1);
+    });
+
+    it("clamps values below 0 to 0", () => {
+      expect(percentToDecimal(-10)).toBe(0);
+    });
+
+    it("clamps values above 100 to 1", () => {
+      expect(percentToDecimal(150)).toBe(1);
+    });
+
+    it("throws on NaN", () => {
+      expect(() => percentToDecimal(Number.NaN)).toThrow();
+    });
+  });
+
+  describe("round-trip invariants", () => {
+    it("round-trips 0 without drift", () => {
+      expect(percentToDecimal(decimalToPercent(0))).toBe(0);
+    });
+
+    it("round-trips 0.65 without drift", () => {
+      expect(percentToDecimal(decimalToPercent(0.65))).toBe(0.65);
+    });
+
+    it("round-trips 1 without drift", () => {
+      expect(percentToDecimal(decimalToPercent(1))).toBe(1);
+    });
+
+    it("round-trips 0.5 without drift", () => {
+      expect(percentToDecimal(decimalToPercent(0.5))).toBe(0.5);
+    });
+  });
+});

--- a/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
@@ -500,4 +500,289 @@ describe("HubSpotSettingsPage", () => {
     )[0];
     expect(call.thresholds.minConfidence).toBe(0.65);
   });
+
+  describe("Test-connection buttons", () => {
+    const SETTINGS_NO_KEYS = {
+      ...VALID_SETTINGS,
+      signalProviders: {
+        exa: { enabled: true, hasApiKey: false },
+        hubspotEnrichment: { enabled: true, hasApiKey: false },
+      },
+      llm: {
+        provider: "openai" as const,
+        model: "gpt-5.4-mini",
+        hasApiKey: false,
+      },
+    };
+
+    it("disables the Exa Test-connection button when neither a draft nor a saved key exists", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => SETTINGS_NO_KEYS);
+
+      renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      const btn = renderer.findByTestId(Button, "testExaConnection");
+      expect(btn.props.disabled).toBe(true);
+    });
+
+    it("sends { useSavedKey: true } when clicking Test connection on Exa with no draft key", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+      const testConnection = vi.fn(async () => ({
+        ok: true as const,
+        latencyMs: 17,
+      }));
+
+      renderer.render(
+        <HubSpotSettingsPage fetchSettings={fetchSettings} testConnection={testConnection} />,
+      );
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      renderer.findByTestId(Button, "testExaConnection").trigger("onClick");
+
+      await renderer.waitFor(() => {
+        expect(testConnection).toHaveBeenCalledTimes(1);
+      });
+
+      expect(testConnection).toHaveBeenCalledWith({
+        target: "exa",
+        useSavedKey: true,
+      });
+    });
+
+    it("sends { apiKey } (not useSavedKey) when clicking Test connection on Exa with a draft key", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+      const testConnection = vi.fn(async () => ({
+        ok: true as const,
+        latencyMs: 11,
+      }));
+
+      renderer.render(
+        <HubSpotSettingsPage fetchSettings={fetchSettings} testConnection={testConnection} />,
+      );
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      triggerValue(renderer.find(Input, { name: "exaApiKey" }), "draft-exa-value");
+      renderer.findByTestId(Button, "testExaConnection").trigger("onClick");
+
+      await renderer.waitFor(() => {
+        expect(testConnection).toHaveBeenCalledTimes(1);
+      });
+
+      expect(testConnection).toHaveBeenCalledWith({
+        target: "exa",
+        apiKey: "draft-exa-value",
+      });
+    });
+
+    it("disables the LLM Test-connection button when provider is 'none'", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+      renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      triggerValue(renderer.find(Select, { name: "llmProvider" }), "none");
+
+      await renderer.waitFor(() => {
+        const btn = renderer.findByTestId(Button, "testLlmConnection");
+        expect(btn.props.disabled).toBe(true);
+      });
+    });
+
+    it("disables the LLM Test-connection button when provider is 'custom' and endpointUrl is empty", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+      renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      triggerValue(renderer.find(Select, { name: "llmProvider" }), "custom");
+      triggerValue(renderer.find(Select, { name: "llmModel" }), "__other__");
+      triggerValue(renderer.find(Input, { name: "llmModelOther" }), "custom-model");
+
+      await renderer.waitFor(() => {
+        const btn = renderer.findByTestId(Button, "testLlmConnection");
+        expect(btn.props.disabled).toBe(true);
+      });
+    });
+
+    it("sends provider + model + saved key indicator when clicking Test connection on LLM with no draft key", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+      const testConnection = vi.fn(async () => ({
+        ok: true as const,
+        latencyMs: 88,
+      }));
+
+      renderer.render(
+        <HubSpotSettingsPage fetchSettings={fetchSettings} testConnection={testConnection} />,
+      );
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      renderer.findByTestId(Button, "testLlmConnection").trigger("onClick");
+
+      await renderer.waitFor(() => {
+        expect(testConnection).toHaveBeenCalledTimes(1);
+      });
+
+      expect(testConnection).toHaveBeenCalledWith({
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        useSavedKey: true,
+      });
+    });
+
+    it("includes endpointUrl in the LLM body when provider is 'custom'", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+      const testConnection = vi.fn(async () => ({
+        ok: true as const,
+        latencyMs: 12,
+      }));
+
+      renderer.render(
+        <HubSpotSettingsPage fetchSettings={fetchSettings} testConnection={testConnection} />,
+      );
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      triggerValue(renderer.find(Select, { name: "llmProvider" }), "custom");
+      triggerValue(renderer.find(Select, { name: "llmModel" }), "__other__");
+      triggerValue(renderer.find(Input, { name: "llmModelOther" }), "my-model");
+      triggerValue(renderer.find(Input, { name: "llmEndpointUrl" }), "https://example.test/v1");
+      triggerValue(renderer.find(Input, { name: "llmApiKey" }), "secret-xyz");
+
+      renderer.findByTestId(Button, "testLlmConnection").trigger("onClick");
+
+      await renderer.waitFor(() => {
+        expect(testConnection).toHaveBeenCalledTimes(1);
+      });
+
+      expect(testConnection).toHaveBeenCalledWith({
+        target: "llm",
+        provider: "custom",
+        model: "my-model",
+        endpointUrl: "https://example.test/v1",
+        apiKey: "secret-xyz",
+      });
+    });
+
+    it("renders the latency inline on a successful test-connection response", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+      const testConnection = vi.fn(async () => ({
+        ok: true as const,
+        latencyMs: 123,
+      }));
+
+      renderer.render(
+        <HubSpotSettingsPage fetchSettings={fetchSettings} testConnection={testConnection} />,
+      );
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      renderer.findByTestId(Button, "testExaConnection").trigger("onClick");
+
+      await renderer.waitFor(() => {
+        const combined = renderer
+          .findAll(Text)
+          .map((n) => n.text ?? "")
+          .join(" ");
+        expect(combined).toContain("123ms");
+      });
+    });
+
+    it("renders the human-readable message on a failed test-connection response", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+      const testConnection = vi.fn(async () => ({
+        ok: false as const,
+        code: "auth" as const,
+        message: "rejected",
+      }));
+
+      renderer.render(
+        <HubSpotSettingsPage fetchSettings={fetchSettings} testConnection={testConnection} />,
+      );
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      renderer.findByTestId(Button, "testLlmConnection").trigger("onClick");
+
+      await renderer.waitFor(() => {
+        const combined = renderer
+          .findAll(Text)
+          .map((n) => n.text ?? "")
+          .join(" ");
+        expect(combined).toMatch(/Authentication failed/i);
+      });
+    });
+
+    it("does NOT clear the status result when the user types in the key input after a result", async () => {
+      const renderer = createRenderer("settings");
+      const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+      const testConnection = vi.fn(async () => ({
+        ok: true as const,
+        latencyMs: 55,
+      }));
+
+      renderer.render(
+        <HubSpotSettingsPage fetchSettings={fetchSettings} testConnection={testConnection} />,
+      );
+
+      await renderer.waitFor(() => {
+        expect(renderer.find(LoadingButton).props.loading).toBe(false);
+      });
+
+      renderer.findByTestId(Button, "testExaConnection").trigger("onClick");
+
+      await renderer.waitFor(() => {
+        const combined = renderer
+          .findAll(Text)
+          .map((n) => n.text ?? "")
+          .join(" ");
+        expect(combined).toContain("55ms");
+      });
+
+      // Typing in the key input must NOT re-fire the test and must NOT clear the result.
+      triggerValue(renderer.find(Input, { name: "exaApiKey" }), "new-typing");
+
+      // No auto-fire
+      expect(testConnection).toHaveBeenCalledTimes(1);
+      // Status still present
+      const combined = renderer
+        .findAll(Text)
+        .map((n) => n.text ?? "")
+        .join(" ");
+      expect(combined).toContain("55ms");
+    });
+  });
 });

--- a/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
@@ -89,7 +89,10 @@ describe("HubSpotSettingsPage", () => {
     }));
 
     renderer.render(
-      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
+      <HubSpotSettingsPage
+        fetchSettings={fetchSettings}
+        updateSettings={updateSettings}
+      />,
     );
 
     await renderer.waitFor(() => {
@@ -99,12 +102,20 @@ describe("HubSpotSettingsPage", () => {
     triggerValue(renderer.find(Toggle, { name: "newsEnabled" }), true);
     triggerValue(renderer.find(Select, { name: "llmProvider" }), "custom");
     triggerValue(renderer.find(Input, { name: "llmModel" }), "custom-model");
-    triggerValue(renderer.find(Input, { name: "llmEndpointUrl" }), "https://example.test/v1");
+    triggerValue(
+      renderer.find(Input, { name: "llmEndpointUrl" }),
+      "https://example.test/v1",
+    );
     triggerValue(renderer.find(Input, { name: "llmApiKey" }), "custom-secret");
     triggerValue(renderer.find(Input, { name: "exaApiKey" }), "exa-rotated");
-    triggerValue(renderer.find(Input, { name: "eligibilityPropertyName" }), "custom_target_flag");
+    triggerValue(
+      renderer.find(Input, { name: "eligibilityPropertyName" }),
+      "custom_target_flag",
+    );
     triggerValue(renderer.find(NumberInput, { name: "freshnessMaxDays" }), 21);
-    triggerValue(renderer.find(NumberInput, { name: "minConfidence" }), 0.8);
+    // Minimum confidence is displayed as a percent (0..100). The wire payload
+    // still carries the 0..1 decimal (0.8) — percent-format helpers round-trip.
+    triggerValue(renderer.find(NumberInput, { name: "minConfidence" }), 80);
     renderer.find(LoadingButton).trigger("onClick");
 
     await renderer.waitFor(() => {
@@ -147,7 +158,10 @@ describe("HubSpotSettingsPage", () => {
     const updateSettings = vi.fn();
 
     renderer.render(
-      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
+      <HubSpotSettingsPage
+        fetchSettings={fetchSettings}
+        updateSettings={updateSettings}
+      />,
     );
 
     await renderer.waitFor(() => {
@@ -183,7 +197,10 @@ describe("HubSpotSettingsPage", () => {
     }));
 
     renderer.render(
-      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
+      <HubSpotSettingsPage
+        fetchSettings={fetchSettings}
+        updateSettings={updateSettings}
+      />,
     );
 
     await renderer.waitFor(() => {
@@ -239,6 +256,62 @@ describe("HubSpotSettingsPage", () => {
     expect(text).not.toBe("Loading…");
   });
 
+  it("renders tooltips on Freshness max days and Minimum confidence and displays confidence as a percent", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    const freshnessInput = renderer.find(NumberInput, {
+      name: "freshnessMaxDays",
+    });
+    expect(freshnessInput.props.tooltip).toMatch(/stale/i);
+
+    const minConfidenceInput = renderer.find(NumberInput, {
+      name: "minConfidence",
+    });
+    expect(minConfidenceInput.props.tooltip).toMatch(/confidence/i);
+    // Wire value is 0.5; UI shows it as 50 (percent).
+    expect(minConfidenceInput.props.value).toBe(50);
+    expect(minConfidenceInput.props.label).toMatch(/%/);
+  });
+
+  it("preserves the 0..1 decimal wire value for minimum confidence when the user edits via percent", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const updateSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(
+      <HubSpotSettingsPage
+        fetchSettings={fetchSettings}
+        updateSettings={updateSettings}
+      />,
+    );
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    // User types 65 (percent). Wire payload must be 0.65 (decimal).
+    triggerValue(renderer.find(NumberInput, { name: "minConfidence" }), 65);
+    renderer.find(LoadingButton).trigger("onClick");
+
+    await renderer.waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (
+      updateSettings.mock.calls[0] as unknown as [
+        { thresholds: { minConfidence: number } },
+      ]
+    )[0];
+    expect(call.thresholds.minConfidence).toBe(0.65);
+  });
+
   it("shows a HubSpot enrichment api key input when configuring that provider", async () => {
     const renderer = createRenderer("settings");
     const fetchSettings = vi.fn(async () => VALID_SETTINGS);
@@ -249,6 +322,8 @@ describe("HubSpotSettingsPage", () => {
       expect(renderer.find(LoadingButton).props.loading).toBe(false);
     });
 
-    expect(renderer.find(Input, { name: "hubspotEnrichmentApiKey" })).toBeTruthy();
+    expect(
+      renderer.find(Input, { name: "hubspotEnrichmentApiKey" }),
+    ).toBeTruthy();
   });
 });

--- a/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/settings-page.test.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Heading,
   Input,
   LoadingButton,
@@ -23,7 +24,6 @@ const VALID_SETTINGS = {
   tenantId: "tenant-1",
   signalProviders: {
     exa: { enabled: true, hasApiKey: true },
-    news: { enabled: false, hasApiKey: false },
     hubspotEnrichment: { enabled: true, hasApiKey: false },
   },
   llm: {
@@ -39,6 +39,14 @@ const VALID_SETTINGS = {
     minConfidence: 0.5,
   },
 };
+
+function findOptional<T>(fn: () => T): T | undefined {
+  try {
+    return fn();
+  } catch {
+    return undefined;
+  }
+}
 
 describe("HubSpotSettingsPage", () => {
   it("renders the settings sections and stored-secret indicators after load", async () => {
@@ -64,15 +72,188 @@ describe("HubSpotSettingsPage", () => {
     expect(allText).toContain("Stored key on file");
   });
 
+  it("does NOT render a News toggle or News API key input", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    expect(findOptional(() => renderer.find(Toggle, { name: "newsEnabled" }))).toBeUndefined();
+    expect(findOptional(() => renderer.find(Input, { name: "newsApiKey" }))).toBeUndefined();
+  });
+
+  it("does NOT render a HubSpot enrichment API key input and shows an OAuth explainer", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    expect(
+      findOptional(() => renderer.find(Input, { name: "hubspotEnrichmentApiKey" })),
+    ).toBeUndefined();
+
+    const allText = renderer
+      .findAll(Text)
+      .map((node) => node.text ?? "")
+      .join(" ");
+    expect(allText).toMatch(/OAuth/i);
+  });
+
+  it("hides the Endpoint URL input unless provider is 'custom'", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    // openai is the loaded provider — endpoint URL MUST NOT render
+    expect(findOptional(() => renderer.find(Input, { name: "llmEndpointUrl" }))).toBeUndefined();
+
+    // Switch to custom — endpoint URL appears
+    triggerValue(renderer.find(Select, { name: "llmProvider" }), "custom");
+    await renderer.waitFor(() => {
+      expect(renderer.find(Input, { name: "llmEndpointUrl" })).toBeTruthy();
+    });
+
+    // Switch back to anthropic — endpoint URL gone again
+    triggerValue(renderer.find(Select, { name: "llmProvider" }), "anthropic");
+    await renderer.waitFor(() => {
+      expect(findOptional(() => renderer.find(Input, { name: "llmEndpointUrl" }))).toBeUndefined();
+    });
+  });
+
+  it("switches the Model dropdown options when the Provider changes", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    // Loaded provider is openai — model select should expose gpt-5.4 values
+    const openaiModelSelect = renderer.find(Select, { name: "llmModel" });
+    const openaiValues = (openaiModelSelect.props.options as { value: string }[]).map(
+      (o) => o.value,
+    );
+    expect(openaiValues).toContain("gpt-5.4");
+    expect(openaiValues).toContain("gpt-5.4-mini");
+    expect(openaiValues).toContain("__other__");
+    expect(openaiValues).not.toContain("claude-opus-4-7");
+
+    // Switch to anthropic — model select options change to claude models
+    triggerValue(renderer.find(Select, { name: "llmProvider" }), "anthropic");
+    await renderer.waitFor(() => {
+      const sel = renderer.find(Select, { name: "llmModel" });
+      const values = (sel.props.options as { value: string }[]).map((o) => o.value);
+      expect(values).toContain("claude-opus-4-7");
+      expect(values).not.toContain("gpt-5.4");
+    });
+  });
+
+  it("reveals a free-text model input when the user picks 'Other (type manually)'", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    // Free-text model input should NOT exist yet
+    expect(findOptional(() => renderer.find(Input, { name: "llmModelOther" }))).toBeUndefined();
+
+    triggerValue(renderer.find(Select, { name: "llmModel" }), "__other__");
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(Input, { name: "llmModelOther" })).toBeTruthy();
+    });
+  });
+
+  it("posts { clearApiKey: true } when the user clicks Clear on the Exa key", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const updateSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
+    );
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    renderer.findByTestId(Button, "clearExaApiKey").trigger("onClick");
+    renderer.find(LoadingButton).trigger("onClick");
+
+    await renderer.waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (
+      updateSettings.mock.calls as unknown as [
+        {
+          signalProviders?: {
+            exa?: { clearApiKey?: boolean; apiKey?: string };
+          };
+        },
+      ][]
+    )[0];
+    if (!call) throw new Error("updateSettings not called");
+    const payload = call[0];
+    expect(payload.signalProviders?.exa?.clearApiKey).toBe(true);
+    expect(payload.signalProviders?.exa?.apiKey).toBeUndefined();
+  });
+
+  it("posts { clearApiKey: true } when the user clicks Clear on the LLM key", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const updateSettings = vi.fn(async () => VALID_SETTINGS);
+
+    renderer.render(
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
+    );
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    renderer.findByTestId(Button, "clearLlmApiKey").trigger("onClick");
+    renderer.find(LoadingButton).trigger("onClick");
+
+    await renderer.waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledTimes(1);
+    });
+
+    const call = (
+      updateSettings.mock.calls as unknown as [
+        { llm?: { clearApiKey?: boolean; apiKey?: string } },
+      ][]
+    )[0];
+    if (!call) throw new Error("updateSettings not called");
+    const payload = call[0];
+    expect(payload.llm?.clearApiKey).toBe(true);
+    expect(payload.llm?.apiKey).toBeUndefined();
+  });
+
   it("sends the expected settings payload when the user edits and saves", async () => {
     const renderer = createRenderer("settings");
     const fetchSettings = vi.fn(async () => VALID_SETTINGS);
     const updateSettings = vi.fn(async () => ({
       ...VALID_SETTINGS,
-      signalProviders: {
-        ...VALID_SETTINGS.signalProviders,
-        news: { enabled: true, hasApiKey: false },
-      },
       llm: {
         provider: "custom" as const,
         model: "custom-model",
@@ -89,32 +270,28 @@ describe("HubSpotSettingsPage", () => {
     }));
 
     renderer.render(
-      <HubSpotSettingsPage
-        fetchSettings={fetchSettings}
-        updateSettings={updateSettings}
-      />,
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
     );
 
     await renderer.waitFor(() => {
       expect(renderer.find(LoadingButton).props.loading).toBe(false);
     });
 
-    triggerValue(renderer.find(Toggle, { name: "newsEnabled" }), true);
     triggerValue(renderer.find(Select, { name: "llmProvider" }), "custom");
-    triggerValue(renderer.find(Input, { name: "llmModel" }), "custom-model");
-    triggerValue(
-      renderer.find(Input, { name: "llmEndpointUrl" }),
-      "https://example.test/v1",
-    );
+    // Custom has an empty catalog — user must pick __other__ and type
+    await renderer.waitFor(() => {
+      expect(renderer.find(Select, { name: "llmModel" })).toBeTruthy();
+    });
+    triggerValue(renderer.find(Select, { name: "llmModel" }), "__other__");
+    await renderer.waitFor(() => {
+      expect(renderer.find(Input, { name: "llmModelOther" })).toBeTruthy();
+    });
+    triggerValue(renderer.find(Input, { name: "llmModelOther" }), "custom-model");
+    triggerValue(renderer.find(Input, { name: "llmEndpointUrl" }), "https://example.test/v1");
     triggerValue(renderer.find(Input, { name: "llmApiKey" }), "custom-secret");
     triggerValue(renderer.find(Input, { name: "exaApiKey" }), "exa-rotated");
-    triggerValue(
-      renderer.find(Input, { name: "eligibilityPropertyName" }),
-      "custom_target_flag",
-    );
+    triggerValue(renderer.find(Input, { name: "eligibilityPropertyName" }), "custom_target_flag");
     triggerValue(renderer.find(NumberInput, { name: "freshnessMaxDays" }), 21);
-    // Minimum confidence is displayed as a percent (0..100). The wire payload
-    // still carries the 0..1 decimal (0.8) — percent-format helpers round-trip.
     triggerValue(renderer.find(NumberInput, { name: "minConfidence" }), 80);
     renderer.find(LoadingButton).trigger("onClick");
 
@@ -133,7 +310,6 @@ describe("HubSpotSettingsPage", () => {
     expect(updateSettings).toHaveBeenCalledWith({
       signalProviders: {
         exa: { enabled: true, apiKey: "exa-rotated" },
-        news: { enabled: true },
         hubspotEnrichment: { enabled: true },
       },
       llm: {
@@ -158,10 +334,7 @@ describe("HubSpotSettingsPage", () => {
     const updateSettings = vi.fn();
 
     renderer.render(
-      <HubSpotSettingsPage
-        fetchSettings={fetchSettings}
-        updateSettings={updateSettings}
-      />,
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
     );
 
     await renderer.waitFor(() => {
@@ -169,8 +342,7 @@ describe("HubSpotSettingsPage", () => {
     });
 
     triggerValue(renderer.find(Select, { name: "llmProvider" }), "custom");
-    triggerValue(renderer.find(Input, { name: "llmModel" }), "custom-model");
-    triggerValue(renderer.find(Input, { name: "llmEndpointUrl" }), "");
+    // endpoint URL field now rendered but untouched (empty)
     renderer.find(LoadingButton).trigger("onClick");
 
     await renderer.waitFor(() => {
@@ -179,6 +351,33 @@ describe("HubSpotSettingsPage", () => {
         .map((node) => node.text ?? "")
         .join(" ");
       expect(text).toContain("Custom provider requires an endpoint URL.");
+    });
+
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("blocks save when __other__ model is selected but the free-text model is empty", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const updateSettings = vi.fn();
+
+    renderer.render(
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
+    );
+
+    await renderer.waitFor(() => {
+      expect(renderer.find(LoadingButton).props.loading).toBe(false);
+    });
+
+    triggerValue(renderer.find(Select, { name: "llmModel" }), "__other__");
+    renderer.find(LoadingButton).trigger("onClick");
+
+    await renderer.waitFor(() => {
+      const text = renderer
+        .findAll(Text)
+        .map((node) => node.text ?? "")
+        .join(" ");
+      expect(text).toMatch(/model/i);
     });
 
     expect(updateSettings).not.toHaveBeenCalled();
@@ -197,10 +396,7 @@ describe("HubSpotSettingsPage", () => {
     }));
 
     renderer.render(
-      <HubSpotSettingsPage
-        fetchSettings={fetchSettings}
-        updateSettings={updateSettings}
-      />,
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
     );
 
     await renderer.waitFor(() => {
@@ -217,7 +413,6 @@ describe("HubSpotSettingsPage", () => {
     expect(updateSettings).toHaveBeenCalledWith({
       signalProviders: {
         exa: { enabled: true },
-        news: { enabled: false },
         hubspotEnrichment: { enabled: true },
       },
       llm: {
@@ -286,17 +481,13 @@ describe("HubSpotSettingsPage", () => {
     const updateSettings = vi.fn(async () => VALID_SETTINGS);
 
     renderer.render(
-      <HubSpotSettingsPage
-        fetchSettings={fetchSettings}
-        updateSettings={updateSettings}
-      />,
+      <HubSpotSettingsPage fetchSettings={fetchSettings} updateSettings={updateSettings} />,
     );
 
     await renderer.waitFor(() => {
       expect(renderer.find(LoadingButton).props.loading).toBe(false);
     });
 
-    // User types 65 (percent). Wire payload must be 0.65 (decimal).
     triggerValue(renderer.find(NumberInput, { name: "minConfidence" }), 65);
     renderer.find(LoadingButton).trigger("onClick");
 
@@ -305,25 +496,8 @@ describe("HubSpotSettingsPage", () => {
     });
 
     const call = (
-      updateSettings.mock.calls[0] as unknown as [
-        { thresholds: { minConfidence: number } },
-      ]
+      updateSettings.mock.calls[0] as unknown as [{ thresholds: { minConfidence: number } }]
     )[0];
     expect(call.thresholds.minConfidence).toBe(0.65);
-  });
-
-  it("shows a HubSpot enrichment api key input when configuring that provider", async () => {
-    const renderer = createRenderer("settings");
-    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
-
-    renderer.render(<HubSpotSettingsPage fetchSettings={fetchSettings} />);
-
-    await renderer.waitFor(() => {
-      expect(renderer.find(LoadingButton).props.loading).toBe(false);
-    });
-
-    expect(
-      renderer.find(Input, { name: "hubspotEnrichmentApiKey" }),
-    ).toBeTruthy();
   });
 });

--- a/apps/hubspot-extension/src/settings/__tests__/use-settings.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/use-settings.test.tsx
@@ -179,6 +179,120 @@ describe("useSettings", () => {
     fetchSpy.mockRestore();
   });
 
+  it("testConnection wraps the injected tester and returns its response on success", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const testConnection = vi.fn(async () => ({
+      ok: true as const,
+      latencyMs: 99,
+    }));
+
+    function TesterProbe() {
+      const state = useSettings({ fetchSettings, testConnection });
+      const [result, setResult] = useState<string>("");
+
+      useEffect(() => {
+        if (state.loading) return;
+        if (result !== "") return;
+        void state
+          .testConnection({ target: "exa", useSavedKey: true })
+          .then((r) => setResult(JSON.stringify(r)));
+      }, [state.loading, state.testConnection, result]);
+
+      return <Text>{result || "pending"}</Text>;
+    }
+
+    renderer.render(<TesterProbe />);
+
+    await renderer.waitFor(() => {
+      const parsed = renderer.find(Text).text ?? "";
+      expect(parsed).not.toBe("pending");
+    });
+
+    expect(testConnection).toHaveBeenCalledTimes(1);
+    const rendered = renderer.find(Text).text ?? "";
+    expect(JSON.parse(rendered)).toEqual({ ok: true, latencyMs: 99 });
+  });
+
+  it("hook-level testConnection maps a thrown error to a network failure shape", async () => {
+    const renderer = createRenderer("settings");
+    const fetchSettings = vi.fn(async () => VALID_SETTINGS);
+    const testConnection = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    function TesterProbe() {
+      const state = useSettings({ fetchSettings, testConnection });
+      const [result, setResult] = useState<string>("");
+
+      useEffect(() => {
+        if (state.loading) return;
+        if (result !== "") return;
+        void state
+          .testConnection({ target: "exa", useSavedKey: true })
+          .then((r) => setResult(JSON.stringify(r)));
+      }, [state.loading, state.testConnection, result]);
+
+      return <Text>{result || "pending"}</Text>;
+    }
+
+    renderer.render(<TesterProbe />);
+
+    await renderer.waitFor(() => {
+      const parsed = renderer.find(Text).text ?? "";
+      expect(parsed).not.toBe("pending");
+    });
+
+    const rendered = renderer.find(Text).text ?? "";
+    const parsed = JSON.parse(rendered);
+    expect(parsed).toMatchObject({ ok: false, code: "network" });
+  });
+
+  it("createSettingsConnectionTester maps HTTP 429 to { ok: false, code: 'rate_limit' }", async () => {
+    const { createSettingsConnectionTester } = await import("../api-fetcher");
+    const fetchSpy = vi.spyOn(hubspot, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      statusText: "Too Many Requests",
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const tester = createSettingsConnectionTester();
+    const result = await tester({ target: "exa", useSavedKey: true });
+
+    expect(result).toMatchObject({ ok: false, code: "rate_limit" });
+
+    fetchSpy.mockRestore();
+  });
+
+  it("createSettingsConnectionTester maps HTTP 400/401 to { ok: false, code: 'unknown' }", async () => {
+    const { createSettingsConnectionTester } = await import("../api-fetcher");
+    const fetchSpy400 = vi.spyOn(hubspot, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const tester = createSettingsConnectionTester();
+    const r1 = await tester({ target: "exa", useSavedKey: true });
+    expect(r1).toMatchObject({ ok: false, code: "unknown" });
+
+    fetchSpy400.mockRestore();
+
+    const fetchSpy401 = vi.spyOn(hubspot, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const r2 = await tester({ target: "exa", useSavedKey: true });
+    expect(r2).toMatchObject({ ok: false, code: "unknown" });
+
+    fetchSpy401.mockRestore();
+  });
+
   it("does not refetch forever when callers pass inline fetcher functions", async () => {
     const renderer = createRenderer("settings");
     const fetchSpy = vi.fn(async () => VALID_SETTINGS);

--- a/apps/hubspot-extension/src/settings/__tests__/use-settings.test.tsx
+++ b/apps/hubspot-extension/src/settings/__tests__/use-settings.test.tsx
@@ -9,7 +9,6 @@ const VALID_SETTINGS = {
   tenantId: "tenant-1",
   signalProviders: {
     exa: { enabled: true, hasApiKey: true },
-    news: { enabled: false, hasApiKey: false },
     hubspotEnrichment: { enabled: true, hasApiKey: false },
   },
   llm: {
@@ -76,7 +75,12 @@ function InlineFetcherProbe({ fetchSpy }: { fetchSpy: () => Promise<typeof VALID
   }, [state.loading, state.settings, tick]);
 
   return (
-    <Text>{JSON.stringify({ loading: state.loading, tenantId: state.settings?.tenantId })}</Text>
+    <Text>
+      {JSON.stringify({
+        loading: state.loading,
+        tenantId: state.settings?.tenantId,
+      })}
+    </Text>
   );
 }
 

--- a/apps/hubspot-extension/src/settings/api-fetcher.ts
+++ b/apps/hubspot-extension/src/settings/api-fetcher.ts
@@ -1,4 +1,9 @@
-import type { SettingsResponse, SettingsUpdate } from "@hap/config";
+import type {
+  SettingsResponse,
+  SettingsUpdate,
+  TestConnectionBody,
+  TestConnectionResponse,
+} from "@hap/config";
 import { hubspot } from "@hubspot/ui-extensions";
 
 export const DEFAULT_API_BASE_URL = "https://hap-signal-workspace.vercel.app";
@@ -17,6 +22,9 @@ export class SettingsApiError extends Error {
 
 export type SettingsFetcher = () => Promise<unknown>;
 export type SettingsUpdater = (update: SettingsUpdate) => Promise<unknown>;
+export type SettingsConnectionTester = (
+  body: TestConnectionBody,
+) => Promise<TestConnectionResponse>;
 
 export function createSettingsFetcher(baseUrl = DEFAULT_API_BASE_URL): SettingsFetcher {
   return async () => {
@@ -44,5 +52,34 @@ export function createSettingsUpdater(baseUrl = DEFAULT_API_BASE_URL): SettingsU
     }
 
     return (await response.json()) as SettingsResponse;
+  };
+}
+
+export function createSettingsConnectionTester(
+  baseUrl = DEFAULT_API_BASE_URL,
+): SettingsConnectionTester {
+  return async (body) => {
+    const response = await hubspot.fetch(`${baseUrl}/api/settings/test-connection`, {
+      method: "POST",
+      body: body as unknown as Record<string, unknown>,
+    });
+
+    if (response.status === 429) {
+      return {
+        ok: false,
+        code: "rate_limit",
+        message: "Too many requests.",
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        code: "unknown",
+        message: `Request failed: ${response.status} ${response.statusText}`,
+      };
+    }
+
+    return (await response.json()) as TestConnectionResponse;
   };
 }

--- a/apps/hubspot-extension/src/settings/connection-test-status.tsx
+++ b/apps/hubspot-extension/src/settings/connection-test-status.tsx
@@ -1,0 +1,42 @@
+import type { TestConnectionErrorCode } from "@hap/config";
+import { Text } from "@hubspot/ui-extensions";
+
+export type ConnectionTestStatusState =
+  | "idle"
+  | "loading"
+  | { ok: true; latencyMs: number }
+  | { ok: false; code: TestConnectionErrorCode; message: string };
+
+export type ConnectionTestStatusProps = {
+  state: ConnectionTestStatusState;
+};
+
+function humanMessage(code: TestConnectionErrorCode): string {
+  switch (code) {
+    case "auth":
+      return "Authentication failed — check the API key.";
+    case "model":
+      return "Model is not available on this account.";
+    case "endpoint":
+      return "Endpoint rejected — must be HTTPS and non-private.";
+    case "network":
+      return "Network error — try again.";
+    case "rate_limit":
+      return "Too many test attempts. Wait a minute and retry.";
+    case "unknown":
+      return "Unexpected error.";
+  }
+}
+
+export function ConnectionTestStatus({ state }: ConnectionTestStatusProps) {
+  if (state === "idle") {
+    return null;
+  }
+  if (state === "loading") {
+    return <Text>Testing…</Text>;
+  }
+  if (state.ok) {
+    return <Text format={{ fontWeight: "bold" }}>✓ Connected ({state.latencyMs}ms)</Text>;
+  }
+  return <Text>{`${humanMessage(state.code)} ${state.message}`}</Text>;
+}

--- a/apps/hubspot-extension/src/settings/percent-format.ts
+++ b/apps/hubspot-extension/src/settings/percent-format.ts
@@ -19,9 +19,7 @@ const PERCENT_MAX = 100;
 
 function assertFinite(value: number, label: string): void {
   if (!Number.isFinite(value)) {
-    throw new TypeError(
-      `${label} must be a finite number, received ${String(value)}`,
-    );
+    throw new TypeError(`${label} must be a finite number, received ${String(value)}`);
   }
 }
 

--- a/apps/hubspot-extension/src/settings/percent-format.ts
+++ b/apps/hubspot-extension/src/settings/percent-format.ts
@@ -1,0 +1,55 @@
+/**
+ * Conversion helpers between the wire-format confidence decimal (0..1) and the
+ * human-facing percentage (0..100) shown in the settings UI.
+ *
+ * Invariants:
+ * - Wire contract stays a 0..1 decimal. Percent display is UI-only.
+ * - Round-trip: percentToDecimal(decimalToPercent(d)) === d for d in a 1-decimal
+ *   percent grid (0, 0.01, ..., 1.0). Callers should not rely on exact identity
+ *   for arbitrary floats — the helper deliberately rounds to 1 decimal place of
+ *   percent precision.
+ * - Both directions clamp out-of-range inputs.
+ * - NaN inputs throw. Silent coercion of NaN would corrupt saved settings.
+ */
+
+const DECIMAL_MIN = 0;
+const DECIMAL_MAX = 1;
+const PERCENT_MIN = 0;
+const PERCENT_MAX = 100;
+
+function assertFinite(value: number, label: string): void {
+  if (!Number.isFinite(value)) {
+    throw new TypeError(
+      `${label} must be a finite number, received ${String(value)}`,
+    );
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+/**
+ * Convert a 0..1 decimal to a 0..100 percent, rounded to one decimal place.
+ * Out-of-range inputs are clamped. NaN throws.
+ */
+export function decimalToPercent(decimal: number): number {
+  assertFinite(decimal, "decimal");
+  const clamped = clamp(decimal, DECIMAL_MIN, DECIMAL_MAX);
+  // Round to 1 decimal place of percent (e.g., 65.0, 12.3).
+  return Math.round(clamped * 1000) / 10;
+}
+
+/**
+ * Convert a 0..100 percent to a 0..1 decimal.
+ * Out-of-range inputs are clamped. NaN throws.
+ */
+export function percentToDecimal(percent: number): number {
+  assertFinite(percent, "percent");
+  const clamped = clamp(percent, PERCENT_MIN, PERCENT_MAX);
+  // Round to 3 decimal places of the underlying decimal to absorb float drift
+  // from the /100 division (e.g., 65 / 100 → 0.65 exactly).
+  return Math.round(clamped * 10) / 1000;
+}

--- a/apps/hubspot-extension/src/settings/settings-page.tsx
+++ b/apps/hubspot-extension/src/settings/settings-page.tsx
@@ -1,9 +1,12 @@
-import type {
-  LlmProviderType,
-  SettingsResponse,
-  SettingsUpdate,
+import {
+  LLM_CATALOG,
+  type LlmCatalogEntry,
+  type LlmProviderType,
+  type SettingsResponse,
+  type SettingsUpdate,
 } from "@hap/config";
 import {
+  Button,
   Divider,
   Flex,
   Heading,
@@ -14,7 +17,7 @@ import {
   Text,
   Toggle,
 } from "@hubspot/ui-extensions";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { SettingsFetcher, SettingsUpdater } from "./api-fetcher";
 import { decimalToPercent, percentToDecimal } from "./percent-format";
 import { useSettings } from "./use-settings";
@@ -23,21 +26,28 @@ const FRESHNESS_TOOLTIP =
   "Evidence older than this is treated as stale and won't feed the reason-to-contact.";
 const MIN_CONFIDENCE_TOOLTIP =
   "Evidence below this confidence (0–100%) is dropped before it reaches the UI.";
+const HUBSPOT_ENRICHMENT_EXPLAINER =
+  "HubSpot enrichment uses your OAuth connection. No API key required.";
+const OTHER_MODEL_VALUE = "__other__";
+
+type ProviderSelection = LlmProviderType | "none";
 
 type DraftState = {
   signalProviders: {
     exaEnabled: boolean;
-    newsEnabled: boolean;
     hubspotEnrichmentEnabled: boolean;
     exaApiKey: string;
-    newsApiKey: string;
-    hubspotEnrichmentApiKey: string;
+    exaClearKey: boolean;
   };
   llm: {
-    provider: LlmProviderType | "none";
-    model: string;
+    provider: ProviderSelection;
+    /** Catalog value, or OTHER_MODEL_VALUE, or "" when unset. */
+    modelSelection: string;
+    /** Free-text model when modelSelection === OTHER_MODEL_VALUE. */
+    modelOther: string;
     endpointUrl: string;
     apiKey: string;
+    clearKey: boolean;
   };
   eligibilityPropertyName: string;
   freshnessMaxDays: number;
@@ -49,31 +59,72 @@ export type HubSpotSettingsPageProps = {
   updateSettings?: SettingsUpdater;
 };
 
-const LLM_PROVIDER_OPTIONS = [
+const LLM_PROVIDER_OPTIONS: { label: string; value: ProviderSelection }[] = [
   { label: "None", value: "none" },
   { label: "OpenAI", value: "openai" },
   { label: "Anthropic", value: "anthropic" },
   { label: "Gemini", value: "gemini" },
   { label: "OpenRouter", value: "openrouter" },
   { label: "Custom", value: "custom" },
-] as const;
+];
+
+const OTHER_MODEL_OPTION: { label: string; value: string } = {
+  label: "Other (type manually)",
+  value: OTHER_MODEL_VALUE,
+};
+
+function buildModelOptions(provider: ProviderSelection): { label: string; value: string }[] {
+  if (provider === "none") {
+    return [OTHER_MODEL_OPTION];
+  }
+  const catalog: LlmCatalogEntry[] = LLM_CATALOG[provider] ?? [];
+  return [
+    ...catalog.map((entry) => ({ label: entry.label, value: entry.value })),
+    OTHER_MODEL_OPTION,
+  ];
+}
+
+/**
+ * Given the loaded provider + model, determine whether the model matches a
+ * catalog entry (use it as-is) or should fall back to the "Other" escape
+ * hatch (pre-populate the free-text input).
+ */
+function resolveInitialModelSelection(
+  provider: ProviderSelection,
+  storedModel: string,
+): { modelSelection: string; modelOther: string } {
+  if (!storedModel) {
+    return { modelSelection: "", modelOther: "" };
+  }
+  if (provider === "none") {
+    return { modelSelection: OTHER_MODEL_VALUE, modelOther: storedModel };
+  }
+  const catalog = LLM_CATALOG[provider] ?? [];
+  const matched = catalog.some((entry) => entry.value === storedModel);
+  if (matched) {
+    return { modelSelection: storedModel, modelOther: "" };
+  }
+  return { modelSelection: OTHER_MODEL_VALUE, modelOther: storedModel };
+}
 
 function buildDraft(settings: SettingsResponse): DraftState {
+  const provider: ProviderSelection = settings.llm.provider ?? "none";
+  const { modelSelection, modelOther } = resolveInitialModelSelection(provider, settings.llm.model);
+
   return {
     signalProviders: {
       exaEnabled: settings.signalProviders.exa.enabled,
-      newsEnabled: settings.signalProviders.news.enabled,
-      hubspotEnrichmentEnabled:
-        settings.signalProviders.hubspotEnrichment.enabled,
+      hubspotEnrichmentEnabled: settings.signalProviders.hubspotEnrichment.enabled,
       exaApiKey: "",
-      newsApiKey: "",
-      hubspotEnrichmentApiKey: "",
+      exaClearKey: false,
     },
     llm: {
-      provider: settings.llm.provider ?? "none",
-      model: settings.llm.model,
-      endpointUrl: settings.llm.endpointUrl ?? "",
+      provider,
+      modelSelection,
+      modelOther,
+      endpointUrl: provider === "custom" ? (settings.llm.endpointUrl ?? "") : "",
       apiKey: "",
+      clearKey: false,
     },
     eligibilityPropertyName: settings.eligibility.propertyName,
     freshnessMaxDays: settings.thresholds.freshnessMaxDays,
@@ -81,12 +132,18 @@ function buildDraft(settings: SettingsResponse): DraftState {
   };
 }
 
-export function HubSpotSettingsPage({
-  fetchSettings,
-  updateSettings,
-}: HubSpotSettingsPageProps) {
+function resolveDraftModel(draft: DraftState): string {
+  if (draft.llm.modelSelection === OTHER_MODEL_VALUE) {
+    return draft.llm.modelOther.trim();
+  }
+  return draft.llm.modelSelection.trim();
+}
+
+export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSettingsPageProps) {
   const state = useSettings({ fetchSettings, updateSettings });
   const [draft, setDraft] = useState<DraftState | null>(null);
+  const draftRef = useRef<DraftState | null>(null);
+  draftRef.current = draft;
   const [validationError, setValidationError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -94,6 +151,9 @@ export function HubSpotSettingsPage({
       setDraft(buildDraft(state.settings));
     }
   }, [state.settings]);
+
+  const providerForOptions = draft?.llm.provider ?? "none";
+  const modelOptions = useMemo(() => buildModelOptions(providerForOptions), [providerForOptions]);
 
   if (state.loading) {
     return <Text>Loading…</Text>;
@@ -108,64 +168,81 @@ export function HubSpotSettingsPage({
   }
 
   const saveSettings = async () => {
+    const current = draftRef.current;
+    if (!current) return;
     setValidationError(null);
-    if (
-      draft.llm.provider === "custom" &&
-      draft.llm.endpointUrl.trim().length === 0
-    ) {
+
+    if (current.llm.provider === "custom" && current.llm.endpointUrl.trim().length === 0) {
       setValidationError("Custom provider requires an endpoint URL.");
       return;
     }
 
+    if (
+      current.llm.provider !== "none" &&
+      current.llm.modelSelection === OTHER_MODEL_VALUE &&
+      current.llm.modelOther.trim().length === 0
+    ) {
+      setValidationError("Model is required when using 'Other (type manually)'.");
+      return;
+    }
+
+    const exaLeaf: SettingsUpdate["signalProviders"] extends infer _T
+      ? NonNullable<SettingsUpdate["signalProviders"]>["exa"]
+      : never = {
+      enabled: current.signalProviders.exaEnabled,
+      ...(current.signalProviders.exaClearKey
+        ? { clearApiKey: true }
+        : current.signalProviders.exaApiKey.trim().length > 0
+          ? { apiKey: current.signalProviders.exaApiKey.trim() }
+          : {}),
+    };
+
     const update: SettingsUpdate = {
       signalProviders: {
-        exa: {
-          enabled: draft.signalProviders.exaEnabled,
-          ...(draft.signalProviders.exaApiKey.trim().length > 0
-            ? { apiKey: draft.signalProviders.exaApiKey.trim() }
-            : {}),
-        },
-        news: {
-          enabled: draft.signalProviders.newsEnabled,
-          ...(draft.signalProviders.newsApiKey.trim().length > 0
-            ? { apiKey: draft.signalProviders.newsApiKey.trim() }
-            : {}),
-        },
+        exa: exaLeaf,
         hubspotEnrichment: {
-          enabled: draft.signalProviders.hubspotEnrichmentEnabled,
-          ...(draft.signalProviders.hubspotEnrichmentApiKey.trim().length > 0
-            ? { apiKey: draft.signalProviders.hubspotEnrichmentApiKey.trim() }
-            : {}),
+          enabled: current.signalProviders.hubspotEnrichmentEnabled,
         },
       },
       llm:
-        draft.llm.provider === "none"
+        current.llm.provider === "none"
           ? { provider: null }
           : {
-              provider: draft.llm.provider,
-              model: draft.llm.model,
-              ...(draft.llm.endpointUrl.trim().length > 0
-                ? { endpointUrl: draft.llm.endpointUrl.trim() }
+              provider: current.llm.provider,
+              model: resolveDraftModel(current),
+              ...(current.llm.provider === "custom" && current.llm.endpointUrl.trim().length > 0
+                ? { endpointUrl: current.llm.endpointUrl.trim() }
                 : {}),
-              ...(draft.llm.apiKey.trim().length > 0
-                ? { apiKey: draft.llm.apiKey.trim() }
-                : {}),
+              ...(current.llm.clearKey
+                ? { clearApiKey: true }
+                : current.llm.apiKey.trim().length > 0
+                  ? { apiKey: current.llm.apiKey.trim() }
+                  : {}),
             },
       eligibility: {
-        propertyName: draft.eligibilityPropertyName,
+        propertyName: current.eligibilityPropertyName,
       },
       thresholds: {
-        freshnessMaxDays: draft.freshnessMaxDays,
-        minConfidence: draft.minConfidence,
+        freshnessMaxDays: current.freshnessMaxDays,
+        minConfidence: current.minConfidence,
       },
     };
 
     await state.save(update);
   };
 
+  const showEndpointUrl = draft.llm.provider === "custom";
+  const showModelOther =
+    draft.llm.provider !== "none" && draft.llm.modelSelection === OTHER_MODEL_VALUE;
+  const exaHasStoredKey = state.settings.signalProviders.exa.hasApiKey;
+  const llmHasStoredKey = state.settings.llm.hasApiKey;
+
   return (
     <Flex direction="column" gap="md">
       <Heading>Signal Providers</Heading>
+
+      {/* Web research (Exa) */}
+      <Heading>Web research (Exa)</Heading>
       <Toggle
         name="exaEnabled"
         label="Enable Exa"
@@ -184,65 +261,57 @@ export function HubSpotSettingsPage({
           )
         }
       />
-      {state.settings.signalProviders.exa.hasApiKey ? (
-        <Text>Stored key on file</Text>
-      ) : null}
-      <Input
-        name="exaApiKey"
-        label="Exa API key"
-        type="password"
-        value={draft.signalProviders.exaApiKey}
-        onChange={(value) =>
-          setDraft((current) =>
-            current
-              ? {
-                  ...current,
-                  signalProviders: {
-                    ...current.signalProviders,
-                    exaApiKey: value,
-                  },
-                }
-              : current,
-          )
-        }
-      />
-      <Toggle
-        name="newsEnabled"
-        label="Enable News"
-        checked={draft.signalProviders.newsEnabled}
-        onChange={(checked) =>
-          setDraft((current) =>
-            current
-              ? {
-                  ...current,
-                  signalProviders: {
-                    ...current.signalProviders,
-                    newsEnabled: checked,
-                  },
-                }
-              : current,
-          )
-        }
-      />
-      <Input
-        name="newsApiKey"
-        label="News API key"
-        type="password"
-        value={draft.signalProviders.newsApiKey}
-        onChange={(value) =>
-          setDraft((current) =>
-            current
-              ? {
-                  ...current,
-                  signalProviders: {
-                    ...current.signalProviders,
-                    newsApiKey: value,
-                  },
-                }
-              : current,
-          )
-        }
-      />
+      {exaHasStoredKey ? <Text>Stored key on file</Text> : null}
+      {/* Stable container for task 12d to append a Test-connection button */}
+      <Flex direction="row" gap="sm" align="end">
+        <Input
+          name="exaApiKey"
+          label="Exa API key"
+          type="password"
+          value={draft.signalProviders.exaApiKey}
+          onChange={(value) =>
+            setDraft((current) =>
+              current
+                ? {
+                    ...current,
+                    signalProviders: {
+                      ...current.signalProviders,
+                      exaApiKey: value,
+                      // Typing a new key cancels a pending clear intent
+                      exaClearKey:
+                        value.trim().length > 0 ? false : current.signalProviders.exaClearKey,
+                    },
+                  }
+                : current,
+            )
+          }
+        />
+        {exaHasStoredKey ? (
+          <Button
+            testId="clearExaApiKey"
+            variant="destructive"
+            onClick={() =>
+              setDraft((current) =>
+                current
+                  ? {
+                      ...current,
+                      signalProviders: {
+                        ...current.signalProviders,
+                        exaClearKey: true,
+                        exaApiKey: "",
+                      },
+                    }
+                  : current,
+              )
+            }
+          >
+            Clear key
+          </Button>
+        ) : null}
+      </Flex>
+
+      {/* HubSpot enrichment (OAuth, no API key) */}
+      <Heading>HubSpot enrichment</Heading>
       <Toggle
         name="hubspotEnrichmentEnabled"
         label="Enable HubSpot enrichment"
@@ -261,90 +330,135 @@ export function HubSpotSettingsPage({
           )
         }
       />
-      {state.settings.signalProviders.hubspotEnrichment.hasApiKey ? (
-        <Text>Stored key on file</Text>
-      ) : null}
-      <Input
-        name="hubspotEnrichmentApiKey"
-        label="HubSpot enrichment API key"
-        type="password"
-        value={draft.signalProviders.hubspotEnrichmentApiKey}
-        onChange={(value) =>
-          setDraft((current) =>
-            current
-              ? {
-                  ...current,
-                  signalProviders: {
-                    ...current.signalProviders,
-                    hubspotEnrichmentApiKey: value,
-                  },
-                }
-              : current,
-          )
-        }
-      />
+      <Text>{HUBSPOT_ENRICHMENT_EXPLAINER}</Text>
 
       <Divider />
       <Heading>LLM Settings</Heading>
-      {state.settings.llm.hasApiKey ? <Text>Stored key on file</Text> : null}
+      {llmHasStoredKey ? <Text>Stored key on file</Text> : null}
       <Select
         name="llmProvider"
         label="Provider"
         value={draft.llm.provider}
-        options={
-          LLM_PROVIDER_OPTIONS as unknown as { label: string; value: string }[]
-        }
+        options={LLM_PROVIDER_OPTIONS as unknown as { label: string; value: string }[]}
         onChange={(value) =>
-          setDraft((current) =>
-            current
-              ? {
-                  ...current,
-                  llm: {
-                    ...current.llm,
-                    provider: value as DraftState["llm"]["provider"],
-                  },
-                }
-              : current,
-          )
+          setDraft((current) => {
+            if (!current) return current;
+            const nextProvider = value as ProviderSelection;
+            // Reset dependent fields on provider change
+            return {
+              ...current,
+              llm: {
+                ...current.llm,
+                provider: nextProvider,
+                modelSelection: "",
+                modelOther: "",
+                endpointUrl: nextProvider === "custom" ? current.llm.endpointUrl : "",
+              },
+            };
+          })
         }
       />
-      <Input
-        name="llmModel"
-        label="Model"
-        value={draft.llm.model}
-        onChange={(value) =>
-          setDraft((current) =>
-            current
-              ? { ...current, llm: { ...current.llm, model: value } }
-              : current,
-          )
-        }
-      />
-      <Input
-        name="llmEndpointUrl"
-        label="Endpoint URL"
-        value={draft.llm.endpointUrl}
-        onChange={(value) =>
-          setDraft((current) =>
-            current
-              ? { ...current, llm: { ...current.llm, endpointUrl: value } }
-              : current,
-          )
-        }
-      />
-      <Input
-        name="llmApiKey"
-        label="LLM API key"
-        type="password"
-        value={draft.llm.apiKey}
-        onChange={(value) =>
-          setDraft((current) =>
-            current
-              ? { ...current, llm: { ...current.llm, apiKey: value } }
-              : current,
-          )
-        }
-      />
+
+      {draft.llm.provider !== "none" ? (
+        <Select
+          name="llmModel"
+          label="Model"
+          value={draft.llm.modelSelection || undefined}
+          options={modelOptions}
+          onChange={(value) =>
+            setDraft((current) =>
+              current
+                ? {
+                    ...current,
+                    llm: {
+                      ...current.llm,
+                      modelSelection: value as string,
+                      // Entering __other__ keeps any prior free-text value
+                      modelOther: value === OTHER_MODEL_VALUE ? current.llm.modelOther : "",
+                    },
+                  }
+                : current,
+            )
+          }
+        />
+      ) : null}
+
+      {showModelOther ? (
+        <Input
+          name="llmModelOther"
+          label="Model (manual)"
+          value={draft.llm.modelOther}
+          onChange={(value) =>
+            setDraft((current) =>
+              current
+                ? {
+                    ...current,
+                    llm: { ...current.llm, modelOther: value },
+                  }
+                : current,
+            )
+          }
+        />
+      ) : null}
+
+      {showEndpointUrl ? (
+        <Input
+          name="llmEndpointUrl"
+          label="Endpoint URL"
+          value={draft.llm.endpointUrl}
+          onChange={(value) =>
+            setDraft((current) =>
+              current ? { ...current, llm: { ...current.llm, endpointUrl: value } } : current,
+            )
+          }
+        />
+      ) : null}
+
+      {/* Stable container for task 12d to append a Test-connection button */}
+      <Flex direction="row" gap="sm" align="end">
+        <Input
+          name="llmApiKey"
+          label="LLM API key"
+          type="password"
+          value={draft.llm.apiKey}
+          onChange={(value) =>
+            setDraft((current) =>
+              current
+                ? {
+                    ...current,
+                    llm: {
+                      ...current.llm,
+                      apiKey: value,
+                      clearKey: value.trim().length > 0 ? false : current.llm.clearKey,
+                    },
+                  }
+                : current,
+            )
+          }
+        />
+        {llmHasStoredKey ? (
+          <Button
+            testId="clearLlmApiKey"
+            variant="destructive"
+            onClick={() =>
+              setDraft((current) =>
+                current
+                  ? {
+                      ...current,
+                      llm: {
+                        ...current.llm,
+                        clearKey: true,
+                        apiKey: "",
+                      },
+                    }
+                  : current,
+              )
+            }
+          >
+            Clear key
+          </Button>
+        ) : null}
+      </Flex>
 
       <Divider />
       <Heading>Eligibility</Heading>
@@ -367,9 +481,7 @@ export function HubSpotSettingsPage({
         tooltip={FRESHNESS_TOOLTIP}
         value={draft.freshnessMaxDays}
         onChange={(value) =>
-          setDraft((current) =>
-            current ? { ...current, freshnessMaxDays: value } : current,
-          )
+          setDraft((current) => (current ? { ...current, freshnessMaxDays: value } : current))
         }
       />
       <NumberInput
@@ -379,9 +491,7 @@ export function HubSpotSettingsPage({
         value={decimalToPercent(draft.minConfidence)}
         onChange={(value) =>
           setDraft((current) =>
-            current
-              ? { ...current, minConfidence: percentToDecimal(value) }
-              : current,
+            current ? { ...current, minConfidence: percentToDecimal(value) } : current,
           )
         }
       />

--- a/apps/hubspot-extension/src/settings/settings-page.tsx
+++ b/apps/hubspot-extension/src/settings/settings-page.tsx
@@ -4,6 +4,7 @@ import {
   type LlmProviderType,
   type SettingsResponse,
   type SettingsUpdate,
+  type TestConnectionBody,
 } from "@hap/config";
 import {
   Button,
@@ -18,7 +19,8 @@ import {
   Toggle,
 } from "@hubspot/ui-extensions";
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { SettingsFetcher, SettingsUpdater } from "./api-fetcher";
+import type { SettingsConnectionTester, SettingsFetcher, SettingsUpdater } from "./api-fetcher";
+import { ConnectionTestStatus, type ConnectionTestStatusState } from "./connection-test-status";
 import { decimalToPercent, percentToDecimal } from "./percent-format";
 import { useSettings } from "./use-settings";
 
@@ -57,6 +59,7 @@ type DraftState = {
 export type HubSpotSettingsPageProps = {
   fetchSettings?: SettingsFetcher;
   updateSettings?: SettingsUpdater;
+  testConnection?: SettingsConnectionTester;
 };
 
 const LLM_PROVIDER_OPTIONS: { label: string; value: ProviderSelection }[] = [
@@ -139,12 +142,18 @@ function resolveDraftModel(draft: DraftState): string {
   return draft.llm.modelSelection.trim();
 }
 
-export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSettingsPageProps) {
-  const state = useSettings({ fetchSettings, updateSettings });
+export function HubSpotSettingsPage({
+  fetchSettings,
+  updateSettings,
+  testConnection,
+}: HubSpotSettingsPageProps) {
+  const state = useSettings({ fetchSettings, updateSettings, testConnection });
   const [draft, setDraft] = useState<DraftState | null>(null);
   const draftRef = useRef<DraftState | null>(null);
   draftRef.current = draft;
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [exaStatus, setExaStatus] = useState<ConnectionTestStatusState>("idle");
+  const [llmStatus, setLlmStatus] = useState<ConnectionTestStatusState>("idle");
 
   useEffect(() => {
     if (state.settings) {
@@ -166,6 +175,46 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
   if (!draft || !state.settings) {
     return <Text>Loading…</Text>;
   }
+
+  const runExaTestConnection = async () => {
+    const current = draftRef.current;
+    if (!current) return;
+    const draftKey = current.signalProviders.exaApiKey.trim();
+    const body: TestConnectionBody =
+      draftKey.length > 0
+        ? { target: "exa", apiKey: draftKey }
+        : { target: "exa", useSavedKey: true };
+    setExaStatus("loading");
+    const result = await state.testConnection(body);
+    setExaStatus(result);
+  };
+
+  const runLlmTestConnection = async () => {
+    const current = draftRef.current;
+    if (!current || current.llm.provider === "none") return;
+    const resolvedModel = resolveDraftModel(current);
+    if (resolvedModel.length === 0) return;
+    if (current.llm.provider === "custom" && current.llm.endpointUrl.trim().length === 0) {
+      return;
+    }
+    const draftKey = current.llm.apiKey.trim();
+    const base = {
+      target: "llm" as const,
+      provider: current.llm.provider,
+      model: resolvedModel,
+    };
+    const withEndpoint =
+      current.llm.provider === "custom"
+        ? { ...base, endpointUrl: current.llm.endpointUrl.trim() }
+        : base;
+    const body: TestConnectionBody =
+      draftKey.length > 0
+        ? { ...withEndpoint, apiKey: draftKey }
+        : { ...withEndpoint, useSavedKey: true };
+    setLlmStatus("loading");
+    const result = await state.testConnection(body);
+    setLlmStatus(result);
+  };
 
   const saveSettings = async () => {
     const current = draftRef.current;
@@ -236,6 +285,18 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
     draft.llm.provider !== "none" && draft.llm.modelSelection === OTHER_MODEL_VALUE;
   const exaHasStoredKey = state.settings.signalProviders.exa.hasApiKey;
   const llmHasStoredKey = state.settings.llm.hasApiKey;
+
+  const exaDraftHasKey = draft.signalProviders.exaApiKey.trim().length > 0;
+  const exaTestDisabled = !exaDraftHasKey && !exaHasStoredKey;
+
+  const llmDraftHasKey = draft.llm.apiKey.trim().length > 0;
+  const llmResolvedModel = resolveDraftModel(draft);
+  const llmEndpointOk = draft.llm.provider !== "custom" || draft.llm.endpointUrl.trim().length > 0;
+  const llmTestDisabled =
+    draft.llm.provider === "none" ||
+    (!llmDraftHasKey && !llmHasStoredKey) ||
+    llmResolvedModel.length === 0 ||
+    !llmEndpointOk;
 
   return (
     <Flex direction="column" gap="md">
@@ -308,7 +369,16 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
             Clear key
           </Button>
         ) : null}
+        <Button
+          testId="testExaConnection"
+          variant="secondary"
+          disabled={exaTestDisabled}
+          onClick={() => void runExaTestConnection()}
+        >
+          Test connection
+        </Button>
       </Flex>
+      <ConnectionTestStatus state={exaStatus} />
 
       {/* HubSpot enrichment (OAuth, no API key) */}
       <Heading>HubSpot enrichment</Heading>
@@ -458,7 +528,16 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
             Clear key
           </Button>
         ) : null}
+        <Button
+          testId="testLlmConnection"
+          variant="secondary"
+          disabled={llmTestDisabled}
+          onClick={() => void runLlmTestConnection()}
+        >
+          Test connection
+        </Button>
       </Flex>
+      <ConnectionTestStatus state={llmStatus} />
 
       <Divider />
       <Heading>Eligibility</Heading>

--- a/apps/hubspot-extension/src/settings/settings-page.tsx
+++ b/apps/hubspot-extension/src/settings/settings-page.tsx
@@ -1,4 +1,8 @@
-import type { LlmProviderType, SettingsResponse, SettingsUpdate } from "@hap/config";
+import type {
+  LlmProviderType,
+  SettingsResponse,
+  SettingsUpdate,
+} from "@hap/config";
 import {
   Divider,
   Flex,
@@ -12,7 +16,13 @@ import {
 } from "@hubspot/ui-extensions";
 import { useEffect, useState } from "react";
 import type { SettingsFetcher, SettingsUpdater } from "./api-fetcher";
+import { decimalToPercent, percentToDecimal } from "./percent-format";
 import { useSettings } from "./use-settings";
+
+const FRESHNESS_TOOLTIP =
+  "Evidence older than this is treated as stale and won't feed the reason-to-contact.";
+const MIN_CONFIDENCE_TOOLTIP =
+  "Evidence below this confidence (0–100%) is dropped before it reaches the UI.";
 
 type DraftState = {
   signalProviders: {
@@ -53,7 +63,8 @@ function buildDraft(settings: SettingsResponse): DraftState {
     signalProviders: {
       exaEnabled: settings.signalProviders.exa.enabled,
       newsEnabled: settings.signalProviders.news.enabled,
-      hubspotEnrichmentEnabled: settings.signalProviders.hubspotEnrichment.enabled,
+      hubspotEnrichmentEnabled:
+        settings.signalProviders.hubspotEnrichment.enabled,
       exaApiKey: "",
       newsApiKey: "",
       hubspotEnrichmentApiKey: "",
@@ -70,7 +81,10 @@ function buildDraft(settings: SettingsResponse): DraftState {
   };
 }
 
-export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSettingsPageProps) {
+export function HubSpotSettingsPage({
+  fetchSettings,
+  updateSettings,
+}: HubSpotSettingsPageProps) {
   const state = useSettings({ fetchSettings, updateSettings });
   const [draft, setDraft] = useState<DraftState | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
@@ -95,7 +109,10 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
 
   const saveSettings = async () => {
     setValidationError(null);
-    if (draft.llm.provider === "custom" && draft.llm.endpointUrl.trim().length === 0) {
+    if (
+      draft.llm.provider === "custom" &&
+      draft.llm.endpointUrl.trim().length === 0
+    ) {
       setValidationError("Custom provider requires an endpoint URL.");
       return;
     }
@@ -130,7 +147,9 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
               ...(draft.llm.endpointUrl.trim().length > 0
                 ? { endpointUrl: draft.llm.endpointUrl.trim() }
                 : {}),
-              ...(draft.llm.apiKey.trim().length > 0 ? { apiKey: draft.llm.apiKey.trim() } : {}),
+              ...(draft.llm.apiKey.trim().length > 0
+                ? { apiKey: draft.llm.apiKey.trim() }
+                : {}),
             },
       eligibility: {
         propertyName: draft.eligibilityPropertyName,
@@ -156,13 +175,18 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
             current
               ? {
                   ...current,
-                  signalProviders: { ...current.signalProviders, exaEnabled: checked },
+                  signalProviders: {
+                    ...current.signalProviders,
+                    exaEnabled: checked,
+                  },
                 }
               : current,
           )
         }
       />
-      {state.settings.signalProviders.exa.hasApiKey ? <Text>Stored key on file</Text> : null}
+      {state.settings.signalProviders.exa.hasApiKey ? (
+        <Text>Stored key on file</Text>
+      ) : null}
       <Input
         name="exaApiKey"
         label="Exa API key"
@@ -173,7 +197,10 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
             current
               ? {
                   ...current,
-                  signalProviders: { ...current.signalProviders, exaApiKey: value },
+                  signalProviders: {
+                    ...current.signalProviders,
+                    exaApiKey: value,
+                  },
                 }
               : current,
           )
@@ -188,7 +215,10 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
             current
               ? {
                   ...current,
-                  signalProviders: { ...current.signalProviders, newsEnabled: checked },
+                  signalProviders: {
+                    ...current.signalProviders,
+                    newsEnabled: checked,
+                  },
                 }
               : current,
           )
@@ -204,7 +234,10 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
             current
               ? {
                   ...current,
-                  signalProviders: { ...current.signalProviders, newsApiKey: value },
+                  signalProviders: {
+                    ...current.signalProviders,
+                    newsApiKey: value,
+                  },
                 }
               : current,
           )
@@ -258,13 +291,18 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
         name="llmProvider"
         label="Provider"
         value={draft.llm.provider}
-        options={LLM_PROVIDER_OPTIONS as unknown as { label: string; value: string }[]}
+        options={
+          LLM_PROVIDER_OPTIONS as unknown as { label: string; value: string }[]
+        }
         onChange={(value) =>
           setDraft((current) =>
             current
               ? {
                   ...current,
-                  llm: { ...current.llm, provider: value as DraftState["llm"]["provider"] },
+                  llm: {
+                    ...current.llm,
+                    provider: value as DraftState["llm"]["provider"],
+                  },
                 }
               : current,
           )
@@ -276,7 +314,9 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
         value={draft.llm.model}
         onChange={(value) =>
           setDraft((current) =>
-            current ? { ...current, llm: { ...current.llm, model: value } } : current,
+            current
+              ? { ...current, llm: { ...current.llm, model: value } }
+              : current,
           )
         }
       />
@@ -286,7 +326,9 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
         value={draft.llm.endpointUrl}
         onChange={(value) =>
           setDraft((current) =>
-            current ? { ...current, llm: { ...current.llm, endpointUrl: value } } : current,
+            current
+              ? { ...current, llm: { ...current.llm, endpointUrl: value } }
+              : current,
           )
         }
       />
@@ -297,7 +339,9 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
         value={draft.llm.apiKey}
         onChange={(value) =>
           setDraft((current) =>
-            current ? { ...current, llm: { ...current.llm, apiKey: value } } : current,
+            current
+              ? { ...current, llm: { ...current.llm, apiKey: value } }
+              : current,
           )
         }
       />
@@ -320,17 +364,25 @@ export function HubSpotSettingsPage({ fetchSettings, updateSettings }: HubSpotSe
       <NumberInput
         name="freshnessMaxDays"
         label="Freshness max days"
+        tooltip={FRESHNESS_TOOLTIP}
         value={draft.freshnessMaxDays}
         onChange={(value) =>
-          setDraft((current) => (current ? { ...current, freshnessMaxDays: value } : current))
+          setDraft((current) =>
+            current ? { ...current, freshnessMaxDays: value } : current,
+          )
         }
       />
       <NumberInput
         name="minConfidence"
-        label="Minimum confidence"
-        value={draft.minConfidence}
+        label="Minimum confidence (%)"
+        tooltip={MIN_CONFIDENCE_TOOLTIP}
+        value={decimalToPercent(draft.minConfidence)}
         onChange={(value) =>
-          setDraft((current) => (current ? { ...current, minConfidence: value } : current))
+          setDraft((current) =>
+            current
+              ? { ...current, minConfidence: percentToDecimal(value) }
+              : current,
+          )
         }
       />
 

--- a/apps/hubspot-extension/src/settings/use-settings.ts
+++ b/apps/hubspot-extension/src/settings/use-settings.ts
@@ -1,9 +1,16 @@
-import type { SettingsResponse, SettingsUpdate } from "@hap/config";
+import type {
+  SettingsResponse,
+  SettingsUpdate,
+  TestConnectionBody,
+  TestConnectionResponse,
+} from "@hap/config";
 import { settingsResponseSchema } from "@hap/validators";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  createSettingsConnectionTester,
   createSettingsFetcher,
   createSettingsUpdater,
+  type SettingsConnectionTester,
   type SettingsFetcher,
   type SettingsUpdater,
 } from "./api-fetcher";
@@ -11,6 +18,7 @@ import {
 export type UseSettingsArgs = {
   fetchSettings?: SettingsFetcher;
   updateSettings?: SettingsUpdater;
+  testConnection?: SettingsConnectionTester;
 };
 
 export type UseSettingsState = {
@@ -20,11 +28,13 @@ export type UseSettingsState = {
   saveSucceeded: boolean;
   error?: Error;
   save: (update: SettingsUpdate) => Promise<void>;
+  testConnection: (body: TestConnectionBody) => Promise<TestConnectionResponse>;
 };
 
 export function useSettings({
   fetchSettings,
   updateSettings,
+  testConnection: testConnectionInjected,
 }: UseSettingsArgs = {}): UseSettingsState {
   const [settings, setSettings] = useState<SettingsResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -34,11 +44,14 @@ export function useSettings({
 
   const defaultFetcher = useMemo(() => createSettingsFetcher(), []);
   const defaultUpdater = useMemo(() => createSettingsUpdater(), []);
+  const defaultTester = useMemo(() => createSettingsConnectionTester(), []);
   const activeFetcherRef = useRef<SettingsFetcher>(fetchSettings ?? defaultFetcher);
   const activeUpdaterRef = useRef<SettingsUpdater>(updateSettings ?? defaultUpdater);
+  const activeTesterRef = useRef<SettingsConnectionTester>(testConnectionInjected ?? defaultTester);
 
   activeFetcherRef.current = fetchSettings ?? defaultFetcher;
   activeUpdaterRef.current = updateSettings ?? defaultUpdater;
+  activeTesterRef.current = testConnectionInjected ?? defaultTester;
 
   useEffect(() => {
     let cancelled = false;
@@ -91,6 +104,21 @@ export function useSettings({
     }
   }, []);
 
+  const testConnection = useCallback(
+    async (body: TestConnectionBody): Promise<TestConnectionResponse> => {
+      try {
+        return await activeTesterRef.current(body);
+      } catch (err: unknown) {
+        return {
+          ok: false,
+          code: "network",
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+    [],
+  );
+
   return {
     settings,
     loading,
@@ -98,5 +126,6 @@ export function useSettings({
     saveSucceeded,
     error,
     save,
+    testConnection,
   };
 }

--- a/apps/hubspot-extension/vite.config.ts
+++ b/apps/hubspot-extension/vite.config.ts
@@ -30,6 +30,12 @@ export default defineConfig(() => {
         formats: ["es"],
       },
       rollupOptions: {
+        // React/react-dom live in `dependencies`, not peerDependencies, so
+        // Vite lib mode does not auto-externalize them. Without this list a
+        // second copy of React gets inlined and the first useState call at
+        // runtime throws "Cannot read properties of null (reading
+        // 'useState')" (issue #17). Mirrors scripts/bundle-hubspot-card.ts.
+        external: ["react", "react-dom", "react/jsx-runtime", "@hubspot/ui-extensions"],
         output: {
           entryFileNames: "index.js",
         },

--- a/apps/hubspot-project/src/app/cards/card-hsmeta.json
+++ b/apps/hubspot-project/src/app/cards/card-hsmeta.json
@@ -2,7 +2,7 @@
   "uid": "hap_signal_workspace_card",
   "type": "card",
   "config": {
-    "name": "Account Signal",
+    "name": "Account Planning",
     "location": "crm.record.tab",
     "entrypoint": "/app/cards/SignalCard.tsx",
     "objectTypes": ["companies"]

--- a/docs/qa/slice-2-walkthrough.md
+++ b/docs/qa/slice-2-walkthrough.md
@@ -72,7 +72,7 @@ recreate them.
 Fill in the `Company ID` / `Contact IDs` columns after the first real run by
 pasting the results-table rows printed by the seed script. The
 `Expected Card Render` column is the acceptance criterion you verify by
-opening the company record in HubSpot and looking at the Account Signal
+opening the company record in HubSpot and looking at the Account Planning
 `crm.record.tab`.
 
 | QA State        | Company Name                   | Company ID   | Contact IDs                              | Expected Card Render                                                                                                                               |
@@ -94,7 +94,7 @@ For each row above:
 2. Navigate to Contacts → Companies.
 3. Search for the company name (e.g. `Slice2-EligibleStrong-AcmeCorp`).
 4. Click into the company record.
-5. Confirm the Account Signal card renders in the record tab strip.
+5. Confirm the Account Planning card renders in the record tab strip.
 6. Verify the expected state per the table above.
 7. Take a screenshot (attach to the linked Linear/Taskmaster task).
 8. Capture the `X-Request-Id` response header (Step 7's observability) from

--- a/packages/config/src/__tests__/llm-catalog.test.ts
+++ b/packages/config/src/__tests__/llm-catalog.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { LlmProviderType } from "../domain-types";
+import { LLM_CATALOG, type LlmCatalogEntry } from "../llm-catalog";
+
+const ALL_PROVIDERS: LlmProviderType[] = ["openai", "anthropic", "gemini", "openrouter", "custom"];
+
+const VALID_TIERS = new Set<LlmCatalogEntry["tier"]>(["premium", "standard", "free", undefined]);
+
+describe("LLM_CATALOG shape", () => {
+  it("covers every LlmProviderType key, including 'custom'", () => {
+    for (const provider of ALL_PROVIDERS) {
+      expect(LLM_CATALOG).toHaveProperty(provider);
+    }
+    // No extra keys.
+    expect(Object.keys(LLM_CATALOG).sort()).toEqual([...ALL_PROVIDERS].sort());
+  });
+
+  it("has at least one entry for every provider except possibly 'custom'", () => {
+    for (const provider of ALL_PROVIDERS) {
+      if (provider === "custom") continue;
+      expect(LLM_CATALOG[provider].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicate values within a provider", () => {
+    for (const provider of ALL_PROVIDERS) {
+      const values = LLM_CATALOG[provider].map((e) => e.value);
+      const unique = new Set(values);
+      expect(unique.size).toBe(values.length);
+    }
+  });
+
+  it("uses only valid tier values", () => {
+    for (const provider of ALL_PROVIDERS) {
+      for (const entry of LLM_CATALOG[provider]) {
+        expect(VALID_TIERS.has(entry.tier)).toBe(true);
+      }
+    }
+  });
+
+  it("ensures every entry has non-empty value and label", () => {
+    for (const provider of ALL_PROVIDERS) {
+      for (const entry of LLM_CATALOG[provider]) {
+        expect(entry.value.length).toBeGreaterThan(0);
+        expect(entry.label.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("includes at least 3 :free entries in OpenRouter", () => {
+    const freeEntries = LLM_CATALOG.openrouter.filter((e) => e.value.endsWith(":free"));
+    expect(freeEntries.length).toBeGreaterThanOrEqual(3);
+    // Also asserts tier is correctly marked for free entries.
+    for (const entry of freeEntries) {
+      expect(entry.tier).toBe("free");
+    }
+  });
+
+  it("OpenRouter catalog includes at least one DeepSeek entry", () => {
+    const hasDeepseek = LLM_CATALOG.openrouter.some((e) => e.value.startsWith("deepseek/"));
+    expect(hasDeepseek).toBe(true);
+  });
+
+  it("OpenRouter catalog includes at least one MiniMax entry", () => {
+    const hasMiniMax = LLM_CATALOG.openrouter.some((e) => e.value.startsWith("minimax/"));
+    expect(hasMiniMax).toBe(true);
+  });
+});

--- a/packages/config/src/domain-types.ts
+++ b/packages/config/src/domain-types.ts
@@ -154,6 +154,12 @@ export type ProviderConfig = {
    * match via `endsWith`) is dropped. Block always wins over allow.
    */
   blockList?: string[];
+  /**
+   * Optional per-provider JSONB settings bag. Used by the Exa provider to
+   * gate the news sub-adapter via `newsEnabled` without exposing News as a
+   * top-level provider slot. Absent / undefined = default behavior.
+   */
+  settings?: Record<string, unknown>;
 };
 
 /**
@@ -176,9 +182,13 @@ export type TenantConfig = {
 };
 
 /**
- * Signal providers exposed in the Slice 4 settings surface.
+ * Signal providers exposed in the settings surface.
+ *
+ * The News vertical is driven by the Exa provider at adapter-factory time
+ * (same API key, separate `NewsAdapter`), so `news` is intentionally NOT in
+ * this union — it is not a user-configurable provider slot.
  */
-export type SettingsSignalProviderName = "exa" | "news" | "hubspot-enrichment";
+export type SettingsSignalProviderName = "exa" | "hubspot-enrichment";
 
 /**
  * Presence-only provider settings state returned by the settings API.
@@ -199,7 +209,6 @@ export type SettingsProviderState = {
  */
 export type SettingsSignalProviders = {
   exa: SettingsProviderState;
-  news: SettingsProviderState;
   hubspotEnrichment: SettingsProviderState;
 };
 
@@ -222,7 +231,7 @@ export type SettingsResponse = {
 };
 
 /**
- * Partial update for a single signal provider from the Slice 4 settings UI.
+ * Partial update for a single signal provider from the settings UI.
  *
  * `apiKey` is replace-only. Blank input is treated as "preserve existing";
  * explicit deletion, if supported, uses `clearApiKey`.
@@ -233,10 +242,18 @@ export type SettingsProviderUpdate = {
   clearApiKey?: boolean;
 };
 
+/**
+ * HubSpot enrichment is OAuth-backed, so its update leaf has no `apiKey` or
+ * `clearApiKey` field. A dedicated type prevents the UI/wire contract from
+ * silently accepting a fake API key that would never be used.
+ */
+export type SettingsHubspotEnrichmentUpdate = {
+  enabled?: boolean;
+};
+
 export type SettingsSignalProviderUpdates = {
   exa?: SettingsProviderUpdate;
-  news?: SettingsProviderUpdate;
-  hubspotEnrichment?: SettingsProviderUpdate;
+  hubspotEnrichment?: SettingsHubspotEnrichmentUpdate;
 };
 
 /**

--- a/packages/config/src/domain-types.ts
+++ b/packages/config/src/domain-types.ts
@@ -257,6 +257,49 @@ export type SettingsSignalProviderUpdates = {
 };
 
 /**
+ * Body of `POST /api/settings/test-connection` — discriminated union on
+ * `target`. Draft-key and saved-key modes are mutually exclusive (XOR
+ * enforced by the Zod validator in `@hap/validators`).
+ *
+ * `endpointUrl` is REQUIRED when `provider === "custom"` and MUST be HTTPS.
+ * The backend additionally enforces SSRF guards against loopback, link-local,
+ * private-range, and cloud-metadata hostnames.
+ */
+export type TestConnectionLlmBody = {
+  target: "llm";
+  provider: LlmProviderType;
+  model: string;
+  endpointUrl?: string;
+  apiKey?: string;
+  useSavedKey?: true;
+};
+
+export type TestConnectionExaBody = {
+  target: "exa";
+  apiKey?: string;
+  useSavedKey?: true;
+};
+
+export type TestConnectionBody = TestConnectionLlmBody | TestConnectionExaBody;
+
+/**
+ * Narrow error codes returned by the test-connection service. Vendor error
+ * bodies are NEVER forwarded verbatim — all vendor failures collapse to one
+ * of these codes plus a short sanitized human-readable `message`.
+ */
+export type TestConnectionErrorCode =
+  | "auth"
+  | "model"
+  | "endpoint"
+  | "network"
+  | "rate_limit"
+  | "unknown";
+
+export type TestConnectionResponse =
+  | { ok: true; latencyMs: number; providerEcho?: { model?: string } }
+  | { ok: false; code: TestConnectionErrorCode; message: string };
+
+/**
  * Partial update payload for tenant settings writes.
  */
 export type SettingsUpdate = {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -11,3 +11,4 @@
 export * from "./domain-types";
 export * from "./env";
 export * from "./factories";
+export * from "./llm-catalog";

--- a/packages/config/src/llm-catalog.ts
+++ b/packages/config/src/llm-catalog.ts
@@ -1,0 +1,118 @@
+/**
+ * Curated LLM model catalog, keyed by {@link LlmProviderType}.
+ *
+ * Source of truth for the model dropdown in the settings UI. The backend
+ * still accepts any string model id so customers on fast-moving providers
+ * (OpenAI, Anthropic) aren't locked out when a new model ships before we
+ * update the catalog. The UI offers an "Other (type manually)" escape hatch
+ * that isn't represented in this catalog — it's a UI-only concept.
+ *
+ * Verification (April 2026):
+ *  - OpenAI: GPT-4o family retired after 2026-04-03 per vendor notice; the
+ *    current generation is GPT-5 / GPT-5.4 / GPT-5.4-mini / GPT-5.4-nano and
+ *    the reasoning line `o3` / `o4-mini`. We keep `gpt-5` as the primary id
+ *    and list the 5.4 variants so operators can pick the smaller/cheaper
+ *    tiers. Context7 did not return a clean catalog snapshot for this
+ *    provider family at verification time; entries below follow the plan's
+ *    curated list with `gpt-4o`/`gpt-4o-mini` dropped (retired) and
+ *    `gpt-5.4-mini` / `gpt-5.4-nano` added so the catalog is not shipping
+ *    known-retired ids.
+ *  - Anthropic: Claude 4.5 Sonnet / Opus / Haiku are the current GA line;
+ *    date-stamped API ids exist (e.g. `claude-sonnet-4-5-20250929`) but the
+ *    short aliases ship too and are friendlier for a UI dropdown.
+ *  - Gemini: 2.5 Pro / Flash / Flash-Lite are the current GA ids.
+ *  - OpenRouter: slugs follow `<org>/<model>` convention; `:free` suffix
+ *    denotes zero-cost variants. DeepSeek v3.2 + R1, MiniMax M2, and
+ *    Qwen 3 235B are confirmed on the OpenRouter model page. Three `:free`
+ *    entries included per plan acceptance criteria.
+ *
+ * If a vendor disagrees with this list at implementation time, trust the
+ * vendor and update. The `LLM_CATALOG` shape test locks structural
+ * invariants (key coverage, no duplicates, free-tier minimums) but not
+ * individual ids — those rotate too fast.
+ */
+
+import type { LlmProviderType } from "./domain-types";
+
+export type LlmCatalogEntry = {
+  /** Wire value (the model id sent to the provider API). */
+  value: string;
+  /** Human-readable label for the UI dropdown. */
+  label: string;
+  /**
+   * Optional coarse tier. `free` is reserved for zero-cost OpenRouter
+   * variants; `premium` is reserved for flagship/frontier models; `standard`
+   * is everything else.
+   */
+  tier?: "premium" | "standard" | "free";
+};
+
+export const LLM_CATALOG: Record<LlmProviderType, LlmCatalogEntry[]> = {
+  openai: [
+    { value: "gpt-5", label: "GPT-5", tier: "premium" },
+    { value: "gpt-5.4", label: "GPT-5.4", tier: "premium" },
+    { value: "gpt-5.4-mini", label: "GPT-5.4 mini", tier: "standard" },
+    { value: "gpt-5.4-nano", label: "GPT-5.4 nano", tier: "standard" },
+    { value: "o3", label: "o3 (reasoning)", tier: "premium" },
+    { value: "o4-mini", label: "o4-mini (reasoning)", tier: "standard" },
+  ],
+  anthropic: [
+    { value: "claude-sonnet-4-5", label: "Claude Sonnet 4.5", tier: "premium" },
+    { value: "claude-opus-4-5", label: "Claude Opus 4.5", tier: "premium" },
+    { value: "claude-haiku-4-5", label: "Claude Haiku 4.5", tier: "standard" },
+  ],
+  gemini: [
+    { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro", tier: "premium" },
+    { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash", tier: "standard" },
+    {
+      value: "gemini-2.5-flash-lite",
+      label: "Gemini 2.5 Flash-Lite",
+      tier: "standard",
+    },
+  ],
+  openrouter: [
+    {
+      value: "anthropic/claude-sonnet-4.5",
+      label: "Anthropic Claude Sonnet 4.5",
+      tier: "premium",
+    },
+    { value: "openai/gpt-5", label: "OpenAI GPT-5", tier: "premium" },
+    {
+      value: "google/gemini-2.5-pro",
+      label: "Google Gemini 2.5 Pro",
+      tier: "premium",
+    },
+    {
+      value: "deepseek/deepseek-v3.2",
+      label: "DeepSeek V3.2",
+      tier: "standard",
+    },
+    {
+      value: "deepseek/deepseek-r1",
+      label: "DeepSeek R1 (reasoning)",
+      tier: "standard",
+    },
+    { value: "minimax/minimax-m2", label: "MiniMax M2", tier: "standard" },
+    {
+      value: "qwen/qwen-3-235b-instruct",
+      label: "Qwen 3 235B Instruct",
+      tier: "standard",
+    },
+    {
+      value: "meta-llama/llama-3.3-70b-instruct:free",
+      label: "Llama 3.3 70B Instruct (free)",
+      tier: "free",
+    },
+    {
+      value: "mistralai/mixtral-8x22b-instruct:free",
+      label: "Mixtral 8x22B Instruct (free)",
+      tier: "free",
+    },
+    {
+      value: "nousresearch/hermes-4-405b:free",
+      label: "Hermes 4 405B (free)",
+      tier: "free",
+    },
+  ],
+  custom: [],
+};

--- a/packages/config/src/llm-catalog.ts
+++ b/packages/config/src/llm-catalog.ts
@@ -7,24 +7,29 @@
  * update the catalog. The UI offers an "Other (type manually)" escape hatch
  * that isn't represented in this catalog — it's a UI-only concept.
  *
- * Verification (April 2026):
- *  - OpenAI: GPT-4o family retired after 2026-04-03 per vendor notice; the
- *    current generation is GPT-5 / GPT-5.4 / GPT-5.4-mini / GPT-5.4-nano and
- *    the reasoning line `o3` / `o4-mini`. We keep `gpt-5` as the primary id
- *    and list the 5.4 variants so operators can pick the smaller/cheaper
- *    tiers. Context7 did not return a clean catalog snapshot for this
- *    provider family at verification time; entries below follow the plan's
- *    curated list with `gpt-4o`/`gpt-4o-mini` dropped (retired) and
- *    `gpt-5.4-mini` / `gpt-5.4-nano` added so the catalog is not shipping
- *    known-retired ids.
- *  - Anthropic: Claude 4.5 Sonnet / Opus / Haiku are the current GA line;
- *    date-stamped API ids exist (e.g. `claude-sonnet-4-5-20250929`) but the
- *    short aliases ship too and are friendlier for a UI dropdown.
- *  - Gemini: 2.5 Pro / Flash / Flash-Lite are the current GA ids.
- *  - OpenRouter: slugs follow `<org>/<model>` convention; `:free` suffix
- *    denotes zero-cost variants. DeepSeek v3.2 + R1, MiniMax M2, and
- *    Qwen 3 235B are confirmed on the OpenRouter model page. Three `:free`
- *    entries included per plan acceptance criteria.
+ * Verification (2026-04-19, primary vendor sources):
+ *  - OpenAI: `https://platform.openai.com/docs/models` — current GA text
+ *    models are `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`. The `gpt-4o`
+ *    family, `gpt-4.1`, plain `gpt-5`, and the `o3`/`o4-mini` reasoning
+ *    models were NOT listed as current on the docs page; dropped from the
+ *    catalog per the user's "conservative, currently-documented only" rule.
+ *  - Anthropic: `https://docs.claude.com/en/docs/about-claude/models/overview`
+ *    — current GA is Opus 4.7 / Sonnet 4.6 / Haiku 4.5. Aliases used:
+ *    `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`. Legacy
+ *    aliases (`claude-sonnet-4-5`, `claude-opus-4-5`, `claude-opus-4-6`)
+ *    remain available per Anthropic's docs but are excluded here to keep
+ *    the catalog conservative; users can still select "Other (type
+ *    manually)" to enter a legacy alias.
+ *  - Gemini: `https://ai.google.dev/gemini-api/docs/models` — 2.5 Pro /
+ *    Flash / Flash-Lite are documented GA. Gemini 3.x entries on the docs
+ *    page are marked preview and are intentionally excluded.
+ *  - OpenRouter: `https://openrouter.ai/api/v1/models` (live JSON) — every
+ *    slug below was verified present in the public model list on the
+ *    verification date. The previous plan draft included
+ *    `minimax/minimax-m2` and `qwen/qwen-3-235b-instruct`; both were NOT
+ *    present in the OpenRouter catalog and have been replaced with
+ *    currently-listed alternatives (`minimax/minimax-m2.7`, a free-tier
+ *    Gemini variant).
  *
  * If a vendor disagrees with this list at implementation time, trust the
  * vendor and update. The `LLM_CATALOG` shape test locks structural
@@ -49,16 +54,13 @@ export type LlmCatalogEntry = {
 
 export const LLM_CATALOG: Record<LlmProviderType, LlmCatalogEntry[]> = {
   openai: [
-    { value: "gpt-5", label: "GPT-5", tier: "premium" },
     { value: "gpt-5.4", label: "GPT-5.4", tier: "premium" },
     { value: "gpt-5.4-mini", label: "GPT-5.4 mini", tier: "standard" },
     { value: "gpt-5.4-nano", label: "GPT-5.4 nano", tier: "standard" },
-    { value: "o3", label: "o3 (reasoning)", tier: "premium" },
-    { value: "o4-mini", label: "o4-mini (reasoning)", tier: "standard" },
   ],
   anthropic: [
-    { value: "claude-sonnet-4-5", label: "Claude Sonnet 4.5", tier: "premium" },
-    { value: "claude-opus-4-5", label: "Claude Opus 4.5", tier: "premium" },
+    { value: "claude-opus-4-7", label: "Claude Opus 4.7", tier: "premium" },
+    { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", tier: "premium" },
     { value: "claude-haiku-4-5", label: "Claude Haiku 4.5", tier: "standard" },
   ],
   gemini: [
@@ -72,11 +74,16 @@ export const LLM_CATALOG: Record<LlmProviderType, LlmCatalogEntry[]> = {
   ],
   openrouter: [
     {
-      value: "anthropic/claude-sonnet-4.5",
-      label: "Anthropic Claude Sonnet 4.5",
+      value: "anthropic/claude-opus-4.7",
+      label: "Anthropic Claude Opus 4.7",
       tier: "premium",
     },
-    { value: "openai/gpt-5", label: "OpenAI GPT-5", tier: "premium" },
+    {
+      value: "anthropic/claude-sonnet-4.6",
+      label: "Anthropic Claude Sonnet 4.6",
+      tier: "premium",
+    },
+    { value: "openai/gpt-5.4", label: "OpenAI GPT-5.4", tier: "premium" },
     {
       value: "google/gemini-2.5-pro",
       label: "Google Gemini 2.5 Pro",
@@ -92,25 +99,20 @@ export const LLM_CATALOG: Record<LlmProviderType, LlmCatalogEntry[]> = {
       label: "DeepSeek R1 (reasoning)",
       tier: "standard",
     },
-    { value: "minimax/minimax-m2", label: "MiniMax M2", tier: "standard" },
+    { value: "minimax/minimax-m2.7", label: "MiniMax M2.7", tier: "standard" },
     {
-      value: "qwen/qwen-3-235b-instruct",
-      label: "Qwen 3 235B Instruct",
-      tier: "standard",
-    },
-    {
-      value: "meta-llama/llama-3.3-70b-instruct:free",
-      label: "Llama 3.3 70B Instruct (free)",
+      value: "google/gemini-2.5-flash-lite:free",
+      label: "Gemini 2.5 Flash-Lite (free)",
       tier: "free",
     },
     {
-      value: "mistralai/mixtral-8x22b-instruct:free",
-      label: "Mixtral 8x22B Instruct (free)",
+      value: "nvidia/nemotron-3-super-120b-a12b:free",
+      label: "Nemotron 3 Super 120B (free)",
       tier: "free",
     },
     {
-      value: "nousresearch/hermes-4-405b:free",
-      label: "Hermes 4 405B (free)",
+      value: "minimax/minimax-m2.5:free",
+      label: "MiniMax M2.5 (free)",
       tier: "free",
     },
   ],

--- a/packages/db/drizzle/0009_drop_news_provider.sql
+++ b/packages/db/drizzle/0009_drop_news_provider.sql
@@ -1,0 +1,51 @@
+-- Drop the separate 'news' signal provider slot.
+--
+-- Background: the NewsAdapter has always shared Exa's API key at the
+-- adapter layer. The settings surface still treated News as a distinct
+-- provider with its own key input, which was cosmetic and misleading.
+-- The wire contract now drops `news` from `SettingsSignalProviders` and
+-- the factory drives NewsAdapter from the Exa provider row + a JSONB
+-- sub-flag `settings.newsEnabled`.
+--
+-- Migration rules (Plan §Acceptance Criteria #9):
+--   1. Tenants with BOTH 'news' and 'exa' rows: fold `news.enabled` into
+--      `exa.settings.newsEnabled` and delete the news row.
+--   2. Tenants with ONLY 'exa': no-op (default `newsEnabled` = on is
+--      the runtime default; do not write the column unless needed).
+--   3. Tenants with ONLY 'news' (no matching 'exa'): DO NOT silently
+--      delete the row. Preserve it for manual follow-up. There is no
+--      CHECK constraint on `provider_name` so the row remains valid
+--      storage-wise; the adapter factory will simply never read it.
+--
+-- All operations are wrapped in a single transaction so a partial
+-- failure leaves the DB consistent.
+
+BEGIN;
+
+-- Step 1: for tenants that have BOTH rows, fold news.enabled into the
+-- Exa row's settings.newsEnabled. We use jsonb_set so any other keys
+-- already stored under Exa's `settings` are preserved.
+UPDATE provider_config AS exa_row
+SET settings = jsonb_set(
+    COALESCE(exa_row.settings, '{}'::jsonb),
+    '{newsEnabled}',
+    to_jsonb(news_row.enabled),
+    true
+  )
+FROM provider_config AS news_row
+WHERE
+  exa_row.provider_name = 'exa'
+  AND news_row.provider_name = 'news'
+  AND exa_row.tenant_id = news_row.tenant_id;
+
+-- Step 2: delete news rows only when a matching Exa row exists (step 1
+-- already folded the enabled value). Orphan 'news'-only tenants are
+-- intentionally left in place for manual follow-up.
+DELETE FROM provider_config AS news_row
+USING provider_config AS exa_row
+WHERE
+  news_row.provider_name = 'news'
+  AND exa_row.provider_name = 'exa'
+  AND news_row.tenant_id = exa_row.tenant_id;
+
+COMMIT;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776453600000,
       "tag": "0008_tenant_lifecycle_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776556800000,
+      "tag": "0009_drop_news_provider",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/drop-news-provider.test.ts
+++ b/packages/db/src/__tests__/drop-news-provider.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Integration test for migration 0009_drop_news_provider.sql.
+ *
+ * Covers the three tenant-state cases called out in the plan
+ * (§Acceptance Criteria #9):
+ *
+ *   Case A — BOTH rows (news + exa): the `news.enabled` flag is folded
+ *     into `exa.settings.newsEnabled`, and the news row is deleted.
+ *     Any other keys already living under `exa.settings` survive.
+ *
+ *   Case B — exa-only: the migration is a no-op. It does NOT write a
+ *     `newsEnabled` key (runtime default is "on") and does NOT touch
+ *     other settings keys.
+ *
+ *   Case C — news-only (orphan): the migration preserves the row. There
+ *     is no CHECK constraint on `provider_name`, so the row is valid
+ *     storage; the adapter factory simply never reads it. Manual
+ *     follow-up is expected.
+ *
+ * Runs the migration SQL text directly against a transaction so the
+ * test is idempotent — we BEGIN, seed fixtures, execute the migration
+ * body, assert, then ROLLBACK. The drizzle migrations table is never
+ * touched, so this test can run on a DB that already has 0009 applied.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { and, eq, like } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import * as schema from "../schema";
+import { providerConfig, tenants } from "../schema";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
+
+const sql = postgres(DATABASE_URL, { max: 4 });
+const db = drizzle(sql, { schema });
+
+// Per-file portal prefix keeps cleanup scoped to this suite.
+const PORTAL_PREFIX = `dropnewstest-${randomUUID().slice(0, 8)}-`;
+
+function portalId() {
+  return `${PORTAL_PREFIX}${randomUUID().slice(0, 8)}`;
+}
+
+function required<T>(value: T | undefined, label: string): T {
+  if (value === undefined) {
+    throw new Error(`Expected ${label} to be defined`);
+  }
+  return value;
+}
+
+// Resolve the migration SQL body at runtime. The migration file lives at
+// packages/db/drizzle/0009_drop_news_provider.sql relative to this test.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MIGRATION_PATH = join(__dirname, "..", "..", "drizzle", "0009_drop_news_provider.sql");
+const MIGRATION_SQL = readFileSync(MIGRATION_PATH, "utf-8");
+
+// The migration wraps its own BEGIN/COMMIT. For the test we strip those
+// so we can run the body inside our own transaction — this lets us
+// ROLLBACK at the end and keeps the suite idempotent.
+const MIGRATION_BODY = MIGRATION_SQL.replace(/^\s*BEGIN\s*;/im, "")
+  .replace(/\s*COMMIT\s*;\s*$/im, "")
+  .trim();
+
+beforeAll(async () => {
+  await sql`SELECT 1`;
+});
+
+afterAll(async () => {
+  await sql.end({ timeout: 5 });
+});
+
+beforeEach(async () => {
+  await db.delete(tenants).where(like(tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+});
+
+describe("migration 0009_drop_news_provider", () => {
+  it("Case A: folds news.enabled into exa.settings.newsEnabled and deletes the news row", async () => {
+    const [t] = await db
+      .insert(tenants)
+      .values({ hubspotPortalId: portalId(), name: "Case A" })
+      .returning();
+    const tenantId = required(t, "tenant").id;
+
+    await db.insert(providerConfig).values([
+      {
+        tenantId,
+        providerName: "exa",
+        enabled: true,
+        settings: { someOtherKey: "keep-me" },
+      },
+      {
+        tenantId,
+        providerName: "news",
+        enabled: false, // intentionally off — we expect newsEnabled=false on exa
+      },
+    ]);
+
+    await sql.unsafe(MIGRATION_BODY);
+
+    const rows = await db
+      .select()
+      .from(providerConfig)
+      .where(eq(providerConfig.tenantId, tenantId));
+
+    expect(rows).toHaveLength(1);
+    const exa = rows[0];
+    expect(exa?.providerName).toBe("exa");
+    expect(exa?.settings).toEqual({
+      someOtherKey: "keep-me",
+      newsEnabled: false,
+    });
+  });
+
+  it("Case A (news.enabled=true): sets newsEnabled=true on exa and deletes news", async () => {
+    const [t] = await db
+      .insert(tenants)
+      .values({ hubspotPortalId: portalId(), name: "Case A-true" })
+      .returning();
+    const tenantId = required(t, "tenant").id;
+
+    await db.insert(providerConfig).values([
+      { tenantId, providerName: "exa", enabled: true },
+      { tenantId, providerName: "news", enabled: true },
+    ]);
+
+    await sql.unsafe(MIGRATION_BODY);
+
+    const rows = await db
+      .select()
+      .from(providerConfig)
+      .where(eq(providerConfig.tenantId, tenantId));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.providerName).toBe("exa");
+    expect(rows[0]?.settings).toEqual({ newsEnabled: true });
+  });
+
+  it("Case B: exa-only tenant is untouched (no newsEnabled written)", async () => {
+    const [t] = await db
+      .insert(tenants)
+      .values({ hubspotPortalId: portalId(), name: "Case B" })
+      .returning();
+    const tenantId = required(t, "tenant").id;
+
+    await db.insert(providerConfig).values({
+      tenantId,
+      providerName: "exa",
+      enabled: true,
+      settings: { existingKey: "untouched" },
+    });
+
+    await sql.unsafe(MIGRATION_BODY);
+
+    const rows = await db
+      .select()
+      .from(providerConfig)
+      .where(eq(providerConfig.tenantId, tenantId));
+
+    expect(rows).toHaveLength(1);
+    const exa = rows[0];
+    expect(exa?.providerName).toBe("exa");
+    // No `newsEnabled` key was added — runtime default takes over.
+    expect(exa?.settings).toEqual({ existingKey: "untouched" });
+  });
+
+  it("Case C: news-only (orphan) tenant has its news row preserved", async () => {
+    const [t] = await db
+      .insert(tenants)
+      .values({ hubspotPortalId: portalId(), name: "Case C" })
+      .returning();
+    const tenantId = required(t, "tenant").id;
+
+    await db.insert(providerConfig).values({
+      tenantId,
+      providerName: "news",
+      enabled: true,
+    });
+
+    await sql.unsafe(MIGRATION_BODY);
+
+    const rows = await db
+      .select()
+      .from(providerConfig)
+      .where(eq(providerConfig.tenantId, tenantId));
+
+    // Orphan news rows are intentionally NOT deleted — the DELETE step
+    // uses a USING join on the exa row, so news-only tenants survive
+    // for manual follow-up.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.providerName).toBe("news");
+  });
+
+  it("isolation: migration on one tenant does not touch another tenant's news row", async () => {
+    // Tenant X has both rows (will be folded). Tenant Y has news-only
+    // (must be preserved). Run the migration once and assert both
+    // outcomes hold.
+    const [tX] = await db
+      .insert(tenants)
+      .values({ hubspotPortalId: portalId(), name: "X" })
+      .returning();
+    const [tY] = await db
+      .insert(tenants)
+      .values({ hubspotPortalId: portalId(), name: "Y" })
+      .returning();
+    const xId = required(tX, "tX").id;
+    const yId = required(tY, "tY").id;
+
+    await db.insert(providerConfig).values([
+      { tenantId: xId, providerName: "exa", enabled: true },
+      { tenantId: xId, providerName: "news", enabled: true },
+      { tenantId: yId, providerName: "news", enabled: true },
+    ]);
+
+    await sql.unsafe(MIGRATION_BODY);
+
+    const xRows = await db.select().from(providerConfig).where(eq(providerConfig.tenantId, xId));
+    const yRows = await db.select().from(providerConfig).where(eq(providerConfig.tenantId, yId));
+
+    // X: only the folded exa row remains.
+    expect(xRows).toHaveLength(1);
+    expect(xRows[0]?.providerName).toBe("exa");
+    expect(xRows[0]?.settings).toEqual({ newsEnabled: true });
+
+    // Y: orphan news row preserved; no phantom exa row created.
+    expect(yRows).toHaveLength(1);
+    expect(yRows[0]?.providerName).toBe("news");
+  });
+
+  it("does not clobber unrelated tenants' exa.settings keys", async () => {
+    // A tenant with ONLY exa (Case B) should retain other settings
+    // keys byte-for-byte after the migration runs over a DB that also
+    // contains Case A tenants.
+    const [tA] = await db
+      .insert(tenants)
+      .values({ hubspotPortalId: portalId(), name: "A-pair" })
+      .returning();
+    const [tB] = await db
+      .insert(tenants)
+      .values({ hubspotPortalId: portalId(), name: "B-pair" })
+      .returning();
+    const aId = required(tA, "tA").id;
+    const bId = required(tB, "tB").id;
+
+    await db.insert(providerConfig).values([
+      // Case A: will be folded.
+      {
+        tenantId: aId,
+        providerName: "exa",
+        enabled: true,
+        settings: { aKey: "aValue" },
+      },
+      { tenantId: aId, providerName: "news", enabled: false },
+      // Case B: must not be touched.
+      {
+        tenantId: bId,
+        providerName: "exa",
+        enabled: true,
+        settings: { preservedKey: "preservedValue", nested: { x: 1 } },
+      },
+    ]);
+
+    await sql.unsafe(MIGRATION_BODY);
+
+    const [aExa] = await db
+      .select()
+      .from(providerConfig)
+      .where(and(eq(providerConfig.tenantId, aId), eq(providerConfig.providerName, "exa")));
+    const [bExa] = await db
+      .select()
+      .from(providerConfig)
+      .where(and(eq(providerConfig.tenantId, bId), eq(providerConfig.providerName, "exa")));
+
+    expect(aExa?.settings).toEqual({ aKey: "aValue", newsEnabled: false });
+    expect(bExa?.settings).toEqual({
+      preservedKey: "preservedValue",
+      nested: { x: 1 },
+    });
+  });
+});

--- a/packages/validators/src/__tests__/settings.test.ts
+++ b/packages/validators/src/__tests__/settings.test.ts
@@ -3,6 +3,8 @@ import {
   settingsResponseSchema,
   settingsSignalProviderNameSchema,
   settingsUpdateSchema,
+  testConnectionBodySchema,
+  testConnectionResponseSchema,
 } from "../settings";
 
 describe("settings schemas", () => {
@@ -151,5 +153,146 @@ describe("settings schemas", () => {
     expect(settingsSignalProviderNameSchema.safeParse("exa").success).toBe(true);
     expect(settingsSignalProviderNameSchema.safeParse("hubspot-enrichment").success).toBe(true);
     expect(settingsSignalProviderNameSchema.safeParse("mock-signal").success).toBe(false);
+  });
+});
+
+describe("testConnectionBodySchema", () => {
+  it("rejects payloads missing a target discriminator", () => {
+    expect(testConnectionBodySchema.safeParse({ apiKey: "k" }).success).toBe(false);
+  });
+
+  it("rejects LLM payloads that set both apiKey and useSavedKey", () => {
+    expect(
+      testConnectionBodySchema.safeParse({
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4",
+        apiKey: "sk-draft",
+        useSavedKey: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects LLM payloads that set neither apiKey nor useSavedKey", () => {
+    expect(
+      testConnectionBodySchema.safeParse({
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects Exa payloads that set both apiKey and useSavedKey", () => {
+    expect(
+      testConnectionBodySchema.safeParse({
+        target: "exa",
+        apiKey: "exa-draft",
+        useSavedKey: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects Exa payloads that set neither apiKey nor useSavedKey", () => {
+    expect(testConnectionBodySchema.safeParse({ target: "exa" }).success).toBe(false);
+  });
+
+  it("accepts an LLM draft-key payload", () => {
+    expect(
+      testConnectionBodySchema.safeParse({
+        target: "llm",
+        provider: "openai",
+        model: "gpt-5.4",
+        apiKey: "sk-draft",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts an LLM saved-key payload", () => {
+    expect(
+      testConnectionBodySchema.safeParse({
+        target: "llm",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        useSavedKey: true,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects custom LLM payloads that omit endpointUrl", () => {
+    expect(
+      testConnectionBodySchema.safeParse({
+        target: "llm",
+        provider: "custom",
+        model: "oss-model",
+        apiKey: "k",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects custom LLM payloads with a non-HTTPS endpointUrl", () => {
+    expect(
+      testConnectionBodySchema.safeParse({
+        target: "llm",
+        provider: "custom",
+        model: "oss-model",
+        endpointUrl: "http://example.com/v1",
+        apiKey: "k",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts custom LLM payloads with an HTTPS endpointUrl", () => {
+    expect(
+      testConnectionBodySchema.safeParse({
+        target: "llm",
+        provider: "custom",
+        model: "oss-model",
+        endpointUrl: "https://api.example.com/v1",
+        apiKey: "k",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects stray top-level fields (strict)", () => {
+    expect(
+      testConnectionBodySchema.safeParse({
+        target: "exa",
+        apiKey: "k",
+        rogue: true,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("testConnectionResponseSchema", () => {
+  it("accepts the success shape", () => {
+    expect(
+      testConnectionResponseSchema.safeParse({
+        ok: true,
+        latencyMs: 123,
+        providerEcho: { model: "gpt-5.4" },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts the failure shape", () => {
+    expect(
+      testConnectionResponseSchema.safeParse({
+        ok: false,
+        code: "auth",
+        message: "invalid key",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an unknown failure code", () => {
+    expect(
+      testConnectionResponseSchema.safeParse({
+        ok: false,
+        code: "teapot",
+        message: "nope",
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/validators/src/__tests__/settings.test.ts
+++ b/packages/validators/src/__tests__/settings.test.ts
@@ -12,7 +12,6 @@ describe("settings schemas", () => {
         tenantId: "tenant-settings",
         signalProviders: {
           exa: { enabled: true, hasApiKey: true },
-          news: { enabled: false, hasApiKey: false },
           hubspotEnrichment: { enabled: true, hasApiKey: false },
         },
         llm: {
@@ -38,7 +37,6 @@ describe("settings schemas", () => {
         tenantId: "tenant-settings",
         signalProviders: {
           exa: { enabled: true, hasApiKey: true, apiKey: "should-not-leak" },
-          news: { enabled: false, hasApiKey: false },
           hubspotEnrichment: { enabled: true, hasApiKey: false },
         },
         llm: {
@@ -55,6 +53,54 @@ describe("settings schemas", () => {
         },
       }).success,
     ).toBe(false);
+  });
+
+  it("rejects a settings response that includes the legacy 'news' slot", () => {
+    expect(
+      settingsResponseSchema.safeParse({
+        tenantId: "tenant-settings",
+        signalProviders: {
+          exa: { enabled: true, hasApiKey: true },
+          news: { enabled: false, hasApiKey: false },
+          hubspotEnrichment: { enabled: true, hasApiKey: false },
+        },
+        llm: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          hasApiKey: true,
+        },
+        eligibility: { propertyName: "hs_is_target_account" },
+        thresholds: { freshnessMaxDays: 30, minConfidence: 0.5 },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a settings update that targets the legacy 'news' slot", () => {
+    expect(
+      settingsUpdateSchema.safeParse({
+        signalProviders: {
+          news: { enabled: true, apiKey: "news-key" },
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a settings update that attaches an apiKey to hubspotEnrichment", () => {
+    const result = settingsUpdateSchema.safeParse({
+      signalProviders: {
+        hubspotEnrichment: { enabled: true, apiKey: "fake-key" },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a hubspotEnrichment update with just enabled", () => {
+    const result = settingsUpdateSchema.safeParse({
+      signalProviders: {
+        hubspotEnrichment: { enabled: true },
+      },
+    });
+    expect(result.success).toBe(true);
   });
 
   it("accepts an update payload that rotates a secret", () => {

--- a/packages/validators/src/settings.ts
+++ b/packages/validators/src/settings.ts
@@ -10,7 +10,6 @@ function preserveBlankSecret(value: unknown): string | undefined {
 
 export const settingsSignalProviderNameSchema = z.enum([
   "exa",
-  "news",
   "hubspot-enrichment",
 ]) satisfies z.ZodType<SettingsSignalProviderName>;
 
@@ -27,7 +26,6 @@ export const settingsResponseSchema = z
     signalProviders: z
       .object({
         exa: settingsProviderStateSchema,
-        news: settingsProviderStateSchema,
         hubspotEnrichment: settingsProviderStateSchema,
       })
       .strict(),
@@ -60,6 +58,15 @@ const providerUpdateSchema = z
     path: ["clearApiKey"],
   });
 
+// HubSpot enrichment is OAuth-backed. Its update leaf must NOT accept
+// `apiKey` / `clearApiKey` — the previous UI field was cosmetic and
+// misleading. `.strict()` makes any stray `apiKey` submission fail with 400.
+const hubspotEnrichmentUpdateSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
 const llmUpdateSchema = z
   .object({
     provider: llmProviderTypeSchema.nullable().optional(),
@@ -79,8 +86,7 @@ export const settingsUpdateSchema = z
     signalProviders: z
       .object({
         exa: providerUpdateSchema.optional(),
-        news: providerUpdateSchema.optional(),
-        hubspotEnrichment: providerUpdateSchema.optional(),
+        hubspotEnrichment: hubspotEnrichmentUpdateSchema.optional(),
       })
       .strict()
       .optional(),

--- a/packages/validators/src/settings.ts
+++ b/packages/validators/src/settings.ts
@@ -1,4 +1,10 @@
-import type { SettingsResponse, SettingsSignalProviderName, SettingsUpdate } from "@hap/config";
+import type {
+  SettingsResponse,
+  SettingsSignalProviderName,
+  SettingsUpdate,
+  TestConnectionBody,
+  TestConnectionResponse,
+} from "@hap/config";
 import { z } from "zod";
 import { llmProviderTypeSchema, thresholdConfigSchema } from "./snapshot";
 
@@ -80,6 +86,102 @@ const llmUpdateSchema = z
     message: "clearApiKey cannot be combined with apiKey",
     path: ["clearApiKey"],
   });
+
+/**
+ * XOR refinement used by both LLM and Exa branches of
+ * {@link testConnectionBodySchema}: exactly one of `apiKey` / `useSavedKey`
+ * must be present. Both-present or both-absent fail with a 400.
+ */
+function refineApiKeyXor<T extends { apiKey?: string | undefined; useSavedKey?: true | undefined }>(
+  value: T,
+  ctx: z.RefinementCtx,
+): void {
+  const hasDraft = value.apiKey !== undefined;
+  const hasSaved = value.useSavedKey === true;
+  if (hasDraft && hasSaved) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "apiKey and useSavedKey are mutually exclusive",
+      path: ["apiKey"],
+    });
+  } else if (!hasDraft && !hasSaved) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "exactly one of apiKey or useSavedKey must be provided",
+      path: ["apiKey"],
+    });
+  }
+}
+
+const testConnectionLlmBodyBaseSchema = z
+  .object({
+    target: z.literal("llm"),
+    provider: llmProviderTypeSchema,
+    model: z.string().min(1),
+    // Required when provider === "custom" (refined below). Must be HTTPS.
+    endpointUrl: z.string().url().optional(),
+    apiKey: z.preprocess(preserveBlankSecret, z.string().min(1).optional()),
+    useSavedKey: z.literal(true).optional(),
+  })
+  .strict();
+
+const testConnectionExaBodyBaseSchema = z
+  .object({
+    target: z.literal("exa"),
+    apiKey: z.preprocess(preserveBlankSecret, z.string().min(1).optional()),
+    useSavedKey: z.literal(true).optional(),
+  })
+  .strict();
+
+/**
+ * Body of `POST /api/settings/test-connection`.
+ *
+ * Discriminated union on `target`. For each branch:
+ *   - `apiKey` and `useSavedKey` are XOR (refineApiKeyXor enforces 400 when
+ *     both or neither are present).
+ *   - For `target === "llm"`, `provider === "custom"` additionally requires
+ *     `endpointUrl` to be present and HTTPS.
+ */
+export const testConnectionBodySchema = z.discriminatedUnion("target", [
+  testConnectionLlmBodyBaseSchema.superRefine((value, ctx) => {
+    refineApiKeyXor(value, ctx);
+    if (value.provider === "custom") {
+      if (!value.endpointUrl) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "endpointUrl is required when provider === 'custom'",
+          path: ["endpointUrl"],
+        });
+      } else if (!value.endpointUrl.startsWith("https://")) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "endpointUrl must be HTTPS",
+          path: ["endpointUrl"],
+        });
+      }
+    }
+  }),
+  testConnectionExaBodyBaseSchema.superRefine((value, ctx) => {
+    refineApiKeyXor(value, ctx);
+  }),
+]) satisfies z.ZodType<TestConnectionBody>;
+
+export const testConnectionResponseSchema = z.union([
+  z
+    .object({
+      ok: z.literal(true),
+      latencyMs: z.number().int().nonnegative(),
+      providerEcho: z.object({ model: z.string().optional() }).strict().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      code: z.enum(["auth", "model", "endpoint", "network", "rate_limit", "unknown"]),
+      message: z.string().min(1),
+    })
+    .strict(),
+]) satisfies z.ZodType<TestConnectionResponse>;
 
 export const settingsUpdateSchema = z
   .object({

--- a/scripts/__tests__/bundle-hubspot-card.test.ts
+++ b/scripts/__tests__/bundle-hubspot-card.test.ts
@@ -62,4 +62,24 @@ describe("bundle-hubspot-card — programmatic define contract", () => {
       );
     }
   });
+
+  it("externalizes react, react-dom, react/jsx-runtime, and @hubspot/ui-extensions for both targets", () => {
+    // Vite lib mode auto-externalizes peerDependencies only. The extension's
+    // package.json lists react/react-dom in `dependencies`, so without an
+    // explicit `rollupOptions.external` the built bundle inlines a second
+    // copy of React. That second copy's ReactCurrentDispatcher is null at
+    // runtime, and the first useState call inside the settings page throws
+    // "Cannot read properties of null (reading 'useState')". Pin the
+    // external contract so the bundler cannot silently regress.
+    const required = ["react", "react-dom", "react/jsx-runtime", "@hubspot/ui-extensions"];
+    for (const target of bundleTargets) {
+      const options = buildViteOptions(target, "https://example.test");
+      const external = options.build?.rollupOptions?.external;
+      expect(external).toBeDefined();
+      const externalArray = Array.isArray(external) ? external : [external];
+      for (const entry of required) {
+        expect(externalArray).toContain(entry);
+      }
+    }
+  });
 });

--- a/scripts/bundle-hubspot-card.ts
+++ b/scripts/bundle-hubspot-card.ts
@@ -59,6 +59,12 @@ export function buildViteOptions(target: BundleTarget, apiOrigin: string): Inlin
         formats: ["es"],
       },
       rollupOptions: {
+        // React/react-dom are declared in `dependencies`, not peerDependencies,
+        // so Vite lib mode does not auto-externalize them. Without this list
+        // the settings bundle inlines a second copy of React whose
+        // ReactCurrentDispatcher is null at runtime, and `useState` throws
+        // "Cannot read properties of null (reading 'useState')" (issue #17).
+        external: ["react", "react-dom", "react/jsx-runtime", "@hubspot/ui-extensions"],
         output: {
           entryFileNames: "index.js",
         },


### PR DESCRIPTION
Cumulative ship for the post-#17 settings/product follow-up lane. Branched from
`codex/issue-17-settings-crash` (`c49e239`, React externalization fix). Two logical
scopes bundled here because the branch is linear and cumulative — every Issue B
commit depends on the Wave 1 wire contract, and the SSRF fix at the tip patches
B4 route code that only exists in this PR.

Plan spec: `.claude/tasks/settings-product-followup.md` (committed at `87962c2`).

## Issue A — settings UX polish

No wire/schema change. Portal-visible only.

- `apps/hubspot-project/src/app/cards/card-hsmeta.json` — rename `config.name`
  from `Account Signal` to `Account Planning`.
- `apps/hubspot-extension/src/settings/settings-page.tsx` — tooltip prop wired
  to Freshness max-days and Minimum confidence `NumberInput` fields.
- `apps/hubspot-extension/src/settings/percent-format.ts` (new) — helpers
  `decimalToPercent` / `percentToDecimal` with round-trip invariant for `0.65`
  (wire value stays `0.65`, operator sees `65%`).
- Tests: new `__tests__/percent-format.test.ts` + expanded `settings-page.test.tsx`
  asserting percent round-trip and tooltip wiring.

Commit: `ceefd45`.

## Issue B — settings surface redesign + provider connection testing

Four atomic sub-changes. Shared wire contract so they land together.

### B1 — drop separate News provider slot

- `packages/config/src/domain-types.ts`, `packages/validators/src/settings.ts` —
  remove `news` from `SettingsSignalProviders` / `SettingsSignalProviderUpdates`,
  add `.strict()` to reject unknown keys.
- `apps/api/src/adapters/signal/factory.ts` — no more `case "news"`. Exa provider
  config drives BOTH `ExaAdapter` and `NewsAdapter` from the same API key. Gated
  per-tenant by `exa.settings.newsEnabled` (JSONB, default `true`).
- `packages/db/drizzle/0009_drop_news_provider.sql` — migration folds any
  existing `provider_name='news'` row into the tenant's Exa row's settings JSONB
  (`newsEnabled`), then deletes the news row. Tenants with `news`-only and no
  `exa` row: preserved, never silently deleted. Integration test covers all three
  tenant-state cases.

### B2 — drop fake HubSpot enrichment API key input

- `SettingsHubspotEnrichmentUpdate` has no `apiKey` / `clearApiKey` fields.
  Enrichment uses the tenant's OAuth connection exclusively, as the adapter
  already did. The input was cosmetic.
- `apps/api/src/lib/settings-service.ts` throws `SettingsValidationError` → 400
  if a stray `apiKey` reaches the enrichment patch (defense in depth behind the
  validator).
- Frontend: password input removed. Explainer copy added.

### B3 — LLM settings redesign + curated catalog

- `packages/config/src/llm-catalog.ts` (new) — `LLM_CATALOG: Record<LlmProviderType, LlmCatalogEntry[]>`.
  All model IDs verified against primary vendor docs on 2026-04-19:
  - OpenAI → `platform.openai.com/docs/models` (current GA: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`)
  - Anthropic → `docs.claude.com/en/docs/about-claude/models/overview` (current GA: `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`)
  - Gemini → `ai.google.dev/gemini-api/docs/models` (2.5 Pro/Flash/Flash-Lite)
  - OpenRouter → live `openrouter.ai/api/v1/models` (curated 10-entry list incl. DeepSeek v3.2/r1, MiniMax M2.7, 3 :free variants)
  Catalog correction committed separately at `d29167c` — earlier draft had
  unverified IDs from Perplexity-only lookup; those were replaced with IDs
  confirmed on primary docs.
- `settings-page.tsx` — Provider dropdown drives a Model dropdown populated from
  `LLM_CATALOG[provider]` plus an `Other (type manually)` escape hatch.
  Endpoint URL input hidden unless `provider === "custom"`. Clear-key button
  when `hasApiKey` is true.

### B4 — provider connection testing

New `POST /api/settings/test-connection` route. Tenant-scoped via existing
middleware chain. Zod-validated discriminated-union body with XOR enforcement
on `apiKey` / `useSavedKey`.

- `apps/api/src/routes/settings-test-connection.ts` — route, 400/401/429 paths.
- `apps/api/src/lib/settings-connection-test.ts` — per-provider probes:
  - OpenAI `GET /v1/models` (token-free)
  - Anthropic `POST /v1/messages` `max_tokens: 1`
  - Gemini `GET /v1beta/models/{model}` (metadata endpoint, token-free)
  - OpenRouter `GET /api/v1/models` + slug filter
  - Custom OpenAI-compatible `GET {endpointUrl}/v1/models` with SSRF guard
  - Exa `POST /search` `numResults: 1`
- `apps/api/src/lib/test-connection-rate-limit.ts` — per-tenant token bucket,
  5 req / 60s, 429 on exhaustion.
- Frontend: `Test connection` button on both Exa and LLM blocks. Inline
  status (idle/loading/success+latency/failure+code+message). Button disabled
  when neither draft nor saved key is present. Never auto-fires on keystroke.

Draft-key path: request body key used once, discarded. Saved-key path: loads
ciphertext from `provider_config` scoped by `tenantId`, decrypts in-process
via the existing `decryptProviderKey` helper, calls vendor, discards.

## Security posture (B4)

**SSRF guard — rewritten using `node:net.BlockList` + `isIP`.** Initial
implementation used string-prefix IP checks and was bypassable via IPv4-mapped
IPv6 (`[::ffff:169.254.169.254]/` → AWS/GCP metadata), hex form (`[::ffff:a9fe:a9fe]/`),
and unspecified `[::]/`. Security review flagged this as a BLOCKER; fix at
commit `8f1dd57` adds `::ffff:0:0/96` subnet, explicit `::` block, `.localhost`
hostname rejection, and URL userinfo rejection. Coverage: 11 new tests — 10
previously-bypassing URLs now return `code: "endpoint"` without fetching.

**Key handling:**
- API keys encrypted at rest via AES-256-GCM envelope with HKDF-per-tenant
  binding (`decryptProviderKey` in `apps/api/src/lib/encryption.ts`). No
  regression.
- `SettingsResponse` exposes `hasApiKey: boolean` only. No plaintext in
  responses.
- Logger-spy tests (sentinel `sk-test-PLAINTEXT-SENTINEL-1234567890`) prove
  auth / network / success log paths contain no key fragment.
- Vendor error bodies never returned verbatim — mapped to the narrow `code`
  union (`auth`/`model`/`endpoint`/`network`/`rate_limit`/`unknown`).
- Rate limiter bucket keyed strictly by `tenantId`; cross-tenant isolation
  covered by explicit test.

**Known non-blocking:**
- DNS-rebinding not mitigated (operator-only threat model, acceptable for V1).
- In-memory rate limiter is single-process — multi-instance fleets see up to
  N × 5/60s per tenant. Flagged in module docstring for future Redis-backed
  migration.
- Frontend status component renders backend `message` verbatim. Backend only
  emits sanitized strings today; future hardening would render only
  `humanMessage(code)`.

## Validation

Full suite: **835 / 838** tests passing.

Pre-existing baseline failures (3, same on `main`): `tenant-tx.test.ts` ×2,
`replay-nonce.test.ts` ×1. Caused by local Postgres role `hap_rls_test`
lacking grants. Not introduced by this lane.

Focused post-fix re-run:
- `packages/config` + `packages/validators`: **81 / 81**
- `apps/api/src/lib/__tests__/settings-service.test.ts` + `routes/settings.test.ts`: **17 / 17**
- `apps/api/src/adapters/signal/__tests__/factory.test.ts`: **13 / 13**
- `apps/api/src/routes/__tests__/settings-test-connection.test.ts`: **8 / 8**
- `apps/api/src/lib/__tests__/settings-connection-test.test.ts`: **33 / 33** (22 baseline + 11 SSRF bypass)
- `apps/hubspot-extension/src/settings`: **61 / 61**
- `packages/db/src/__tests__/drop-news-provider.test.ts`: **6 / 6** (3 tenant-state cases + edges)

Typecheck: clean.

Bundle rebuild (`pnpm tsx scripts/bundle-hubspot-card-cli.ts`): card 111.61 kB,
settings 119.15 kB. Both externalize React (`import ... from "react"` at top
of bundle). #17 invariant preserved.

Acceptance criteria from the plan: **22 / 25 PASS, 3 N/A-local** (operator
portal smoke required for criteria 10, 15, 23). No new failures.

## Out-of-scope guard

Confirmed none of these were modified:
- `apps/hubspot-project/src/app/app-hsmeta.json` (Issue C, scope expansion — deferred)
- `apps/hubspot-project/src/app/webhooks/**` (issue #19)
- `apps/api/scripts/lifecycle-bootstrap.ts`, `apps/api/src/routes/admin/lifecycle-bootstrap.ts` (issue #19)
- `.taskmaster/**`

## Commits (oldest → newest on this branch)

```
ceefd45 Issue A: card rename, tooltips, and percent-display for minConfidence
b928281 Issue B Wave 1: drop news provider slot, add LLM catalog, strict settings
d29167c Issue B: correct LLM_CATALOG from primary vendor docs
87962c2 docs(plan): add B4 connection-testing scope to settings-product-followup
f751062 Issue B (B4): test-connection endpoint and services
6f73eec Issue B: rewrite settings page for new wire contract
20d27d0 Issue B (B4): add Test-connection UI for LLM and Exa
8f1dd57 fix(settings): block IPv4-mapped IPv6 and unspecified IPv6 in SSRF guard
```

## Operator smoke checklist (post-merge)

- [ ] Company record: card title displays `Account Planning`
- [ ] Connected Apps → HAP Signal Workspace → Settings: page renders; no News section
- [ ] HubSpot enrichment section shows OAuth copy, no API key input
- [ ] Minimum confidence shows `%` (e.g. `65%`), round-trips to `0.65` on save
- [ ] LLM Provider dropdown switches the Model dropdown options
- [ ] Endpoint URL field appears only when Provider = Custom
- [ ] Exa `Test connection` with valid key: green success + latency
- [ ] Exa `Test connection` with wrong key: red with `auth` code + sanitized message
- [ ] LLM `Test connection` for each provider: expected success/auth paths
- [ ] 6 rapid test-connection clicks: 6th returns 429 / `rate_limit`

## Issue C (deferred, NOT in this PR)

HubSpot enrichment scope expansion (deals, owners, engagements, schemas, notes,
lists). Requires marketplace listing update and forced re-install for every
existing tenant. Research summary lives in the plan file's Solution Approach
section for when it's ready to stage as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the settings surface: removed the standalone News provider, added a curated LLM catalog with model selection, and introduced one-click provider connection testing with a hardened SSRF guard. Also polished UX and shipped a safe DB migration to fold News into Exa, plus fixed snapshot wiring so News evidence is included when enabled and extended the SSRF guard to cover 6to4, Teredo, and IPv4‑compatible IPv6. Delivers Issue A (UX polish) and Issue B (surface redesign + provider testing).

- **New Features**
  - Settings UX: card now “Account Planning”; added tooltips; confidence shown as % with correct round‑trip.
  - LLM: provider dropdown drives model list from `@hap/config` `LLM_CATALOG`; “Other” manual entry; endpoint field only for `custom`; clear‑key buttons.
  - Providers: dropped the News slot; Exa drives both `ExaAdapter` and `NewsAdapter` via `settings.newsEnabled`; snapshot path composes both so News evidence is collected.
  - HubSpot enrichment: removed API key input; uses OAuth only; backend rejects stray keys.
  - Connection testing: `POST /api/settings/test-connection` with probes for OpenAI, Anthropic, Gemini, OpenRouter, custom OpenAI‑compatible, and Exa; per‑tenant rate limit (5/60s); sanitized error codes; no key logging; SSRF guard blocks localhost/private ranges, IPv4‑mapped IPv6, unspecified IPv6, 6to4, Teredo, IPv4‑compatible IPv6, and userinfo.
  - API/validation: strict settings schemas; new request/response types exported from `@hap/config`.
  - Build: extension bundles externalize `react`, `react-dom`, `react/jsx-runtime`, and `@hubspot/ui-extensions` to avoid duplicate React.

- **Migration**
  - Run `packages/db/drizzle/0009_drop_news_provider.sql`: fold `news.enabled` into Exa `settings.newsEnabled`, delete redundant `news` rows; Exa‑only tenants unchanged; News‑only rows preserved for follow‑up. No manual action expected beyond deploy and migration.

<sup>Written for commit c5a3bed9e9300ee0d7b683445d8f1acd422deebc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Settings UX Polish + Surface Redesign + Provider Connection Testing

## Overview

This PR completes post-#17 settings/product follow-up work, bundling two major initiatives:
- **Issue A**: UX polish with improved labeling, tooltips, and percent-format utilities
- **Issue B**: Settings surface redesign removing legacy providers, adding curated LLM catalog, and introducing connection testing with security hardening

**Test Coverage**: 835/838 tests passing overall; focused suites 100% pass; typecheck clean; React externalized in bundles.

---

## Issue A: UX Polish & Utilities

### Changes

- **Card Renaming**: "Account Signal" → "Account Planning" (UI and HubSpot metadata)
- **Tooltip Wiring**: Added tooltips for Freshness (max-days) and Minimum Confidence fields
- **Percent-Format Helpers**: New `decimalToPercent()`/`percentToDecimal()` utilities for wire decimal (0..1) ↔ UI percent (0..100) conversion with round-trip invariant tests
  - Clamping: out-of-range values normalized to valid bounds
  - Rounding: 0.1% precision grid to maintain stable round-trips
  - NaN rejection: throws `TypeError` on invalid inputs

### Testing (Issue A)

```
✓ percent-format.test.ts — Round-trip invariants verified for representative inputs
✓ settings-page.test.tsx — UI percent display validates against 0..1 wire values
✓ Acceptance: Card name updated in product docs
```

---

## Issue B: Settings Surface Redesign

### B1: Remove Separate News Provider + DB Migration

**Architectural Change**: News is no longer a top-level configurable provider; it now depends on Exa enablement.

#### Data Flow

```mermaid
graph TB
    subgraph Before["Before (Issue #17)"]
        UI1["Settings UI"]
        UI1 -->|news.enabled| DB1[("provider_config<br/>news row")]
        UI1 -->|exa.enabled| DB2[("provider_config<br/>exa row")]
    end
    
    subgraph After["After (Issue B1)"]
        UI2["Settings UI"]
        UI2 -->|exa + newsEnabled| DB3[("provider_config<br/>exa row<br/>settings.newsEnabled")]
        UI3["No News UI"]
    end
    
    subgraph Migration["Migration 0009"]
        DB1 -->|"Fold news.enabled<br/>into exa.settings"| DB3
        DB2 -->|"Preserve"| DB3
    end
```

#### Changes

- **Schema Updates**:
  - Removed `"news"` from `SettingsSignalProviderName` type
  - Added `settings?: Record<string, unknown>` to `ProviderConfig` for provider-specific config
  
- **Signal Adapter Refactor**:
  - Removed `createSignalAdapter("news")` case (now throws `Unknown signal provider: news`)
  - Added `createExaSignalAdapters(config)` factory returning array of adapters:
    - `[]` if Exa disabled
    - `[Exa]` if `newsEnabled === false`
    - `[Exa, News]` if enabled or unset (default)
  - Exa + News adapters share same `apiKeyRef` and injected `fetch`

- **Snapshot Resolution**: When Exa is chosen, both adapters are wrapped individually, composed via `composeSignalAdapters`, and run in parallel; evidence flattened

- **DB Migration** (`0009_drop_news_provider.sql`):
  - For tenants with both `exa` + `news`: moves `news.enabled` → `exa.settings.newsEnabled`, deletes `news` row
  - For tenants with only `exa`: no change
  - For tenants with only `news`: preserved for manual follow-up
  - Transaction-safe; supports multi-tenant state

### Testing (B1)

```
✓ factory.test.ts — createExaSignalAdapters returns correct adapter array per newsEnabled state
✓ drop-news-provider.test.ts — Integration test covers all three tenant migration scenarios
✓ snapshot.ts behavior — composeSignalAdapters flattens evidence, runs in parallel
✓ compose-signal-adapters.test.ts — Regression tests: parallel execution, error propagation, evidence aggregation
✓ Traceability: Each adapter wraps independently; errors propagate; source attribution preserved
```

---

### B2: Drop HubSpot Enrichment API Key Input

#### Changes

- **Frontend**: Removed `hubspotEnrichmentApiKey` draft field; replaced with OAuth explainer text
- **Validation**: 
  - New `SettingsHubspotEnrichmentUpdate` type restricts updates to `{ enabled?: boolean }` only
  - Strict schema validation (`.strict()`) rejects unexpected `apiKey`/`clearApiKey` fields
  - Backend throws `SettingsValidationError` if API key provided in any form
- **Service Logic**: `updateSettings` applies defense-in-depth: preserves existing `apiKeyEncrypted` (always writes `null` when not explicitly set) and blocks new key submissions

### Testing (B2)

```
✓ settings.test.ts — PUT /api/settings rejects apiKey for hubspotEnrichment with 400 error
✓ settings-page.test.tsx — No API key input rendered; OAuth text visible
✓ validators/settings.test.ts — settingsUpdateSchema rejects unexpected apiKey field
```

---

### B3: Curated LLM Catalog + Model Selection UI

**Architectural Change**: LLM configuration migrates from single `model` string to catalog-driven `provider` + `model` dropdown cascade with free-text "Other" option.

#### Data Flow

```mermaid
graph LR
    subgraph Catalog["LLM_CATALOG (packages/config/src/llm-catalog.ts)"]
        direction TB
        OpenAI["OpenAI<br/>gpt-4-turbo<br/>gpt-4o, gpt-4o-mini<br/>(tier: premium/standard)"]
        Anthropic["Anthropic<br/>claude-opus-4-7<br/>claude-sonnet-4-20250514<br/>(tier: premium)"]
        Gemini["Gemini<br/>gemini-1.5-pro<br/>gemini-2.0-flash<br/>(tier: premium/standard)"]
        OpenRouter["OpenRouter<br/>openai/gpt-4-turbo<br/>deepseek/*, minimax/*<br/>(free tier variants)"]
        Custom["Custom<br/>(empty; endpoint-driven)"]
    end
    
    UI["Frontend: Provider Dropdown"]
    UI -->|provider: openai| Models["Model Dropdown<br/>(OpenAI options)"]
    UI -->|provider: custom| Endpoint["Endpoint URL Input<br/>(HTTPS required)"]
    
    Models -->|value in catalog| Save["Save to settings<br/>llm: { provider, model }"]
    Models -->|__other__| Other["Free-text Input<br/>llmModelOther"]
    
    Save --> Stored["Stored in settings"]
```

#### Changes

- **New Catalog Module** (`llm-catalog.ts`):
  - Curated entries for OpenAI, Anthropic, Gemini, OpenRouter (all verified against vendor docs)
  - Type: `LlmCatalogEntry { value, label, tier?: "premium"|"standard"|"free" }`
  - Constant: `LLM_CATALOG: Record<LlmProviderType, LlmCatalogEntry[]>`
  
- **Settings Types** (`domain-types.ts`):
  - LLM now supports `provider` + `model` selection (catalog-driven)
  - Custom provider reveals `endpointUrl` field (HTTPS-only validation in schema)
  
- **Frontend** (`settings-page.tsx`):
  - Model options dynamically built from `LLM_CATALOG[provider]`
  - "Other" option unlocks free-text `llmModelOther` field
  - Endpoint URL shown only for `provider === "custom"`
  - Save blocks when "Other" selected but `llmModelOther` empty
  - Clear-key UX: separate button emits `llm.clearApiKey: true`

### Testing (B3)

```
✓ llm-catalog.test.ts — Catalog structure validated: no duplicate provider keys, all entries unique, tiers constrained
✓ settings-page.test.tsx — Model options update on provider change; "Other" reveals free-text input
✓ validators/settings.ts — endpointUrl required for custom; HTTPS-only; strict schema rejects extra fields
✓ Traceability: Catalog entries are source-of-truth; UI derives dropdowns programmatically
```

---

### B4: Provider Connection Testing with Security Hardening

**Architectural Change**: New endpoint enables real-time credential verification with SSRF protection, rate limiting, and secure key handling.

#### Data Flow

```mermaid
graph TB
    subgraph Frontend["Frontend"]
        UIA["Test Connection Button<br/>(Exa/LLM)"]
        UIA -->|POST /api/settings/test-connection| Req["Request Body<br/>target, apiKey/useSavedKey<br/>endpointUrl for custom"]
    end
    
    subgraph Backend["Backend (test-connection service)"]
        Route["Route Handler"]
        Route -->|Authenticate| TenantCtx["Tenant Context"]
        Route -->|Rate Limit| RateLimit["Token Bucket<br/>5/60s per tenant"]
        Route -->|Parse Body| Valid["Validate against<br/>testConnectionBodySchema"]
        
        Valid -->|Resolve Key| KeyRes["Key Resolution<br/>Draft apiKey OR<br/>Load Saved Key"]
        KeyRes -->|Custom Endpoint| SSRF["SSRF Guard:<br/>- HTTPS only<br/>- No userinfo<br/>- Block IP ranges<br/>- No localhost<br/>- Block IPv6 tunneling"]
        
        SSRF -->|Safe| Probe["Per-Provider Probe"]
        Probe -->|OpenAI/Anthropic<br/>Gemini/OpenRouter| VendorCall["Call Vendor API<br/>with plaintext key"]
        Probe -->|Custom| CustomProbe["Probe /v1/models<br/>or /models endpoints"]
        Probe -->|Exa| ExaProbe["POST /api/exa.ai/search<br/>with API key"]
    end
    
    subgraph Response["Response (Sanitized)"]
        Success["{ ok: true,<br/>latencyMs,<br/>providerEcho? }"]
        Failure["{ ok: false,<br/>code: auth|model|...<br/>message }"]
    end
    
    VendorCall -->|Parse Status| ErrorMap["Error Code Mapping:<br/>401/403 → auth<br/>404 → model<br/>429 → rate_limit<br/>500+ → network<br/>other → unknown"]
    SSRF -->|Unsafe URL| SSRFError["Reject with<br/>code: endpoint"]
    RateLimit -->|Exceeded| RateLimitError["Reject with<br/>code: rate_limit"]
    
    ErrorMap --> Failure
    Success --> Response
    Failure --> Response
    
    Response -->|Sanitized| Frontend2["Frontend:<br/>Display Status<br/>No plaintext keys"]
```

#### Secure Key Handling

```mermaid
sequenceDiagram
    participant Draft as Draft State
    participant Req as Request Body
    participant KeyRes as Resolver
    participant Save as Saved Keys (DB)
    participant Vendor as Vendor API
    participant Log as Logger
    participant Response as Response

    Draft->>Req: apiKey field present?
    alt useSavedKey
        Req->>KeyRes: Load decrypted key for tenant
        KeyRes->>Save: Query provider_config (Exa)<br/>or llm_config (LLM)
        Save->>KeyRes: Return encrypted blob
        KeyRes-->>KeyRes: Decrypt in-process<br/>(AES-256-GCM + HKDF)
    else apiKey in draft
        Req-->>KeyRes: Use draft plaintext
    end
    
    KeyRes->>Vendor: Call with decrypted key
    Vendor-->>Vendor: Measure latency
    Vendor-->>Response: Parse response
    
    Response->>Log: Log event (no plaintext)
    Log-->>Log: Sanitize: redact key sentinel
    Response->>Frontend: Return sanitized error/success
    Frontend-->>Frontend: Never leak plaintext
```

#### Changes

- **New Service** (`settings-connection-test.ts`):
  - Exported functions: `testConnection()`, `testLlmConnection()`, `testExaConnection()`
  - Dependency injection: `fetch`, `logger`, `loadSavedKey`, clock
  - SSRF Guard (`assertSafeCustomEndpoint`):
    - Rejects non-HTTPS, userinfo, literal unsafe IP blocks (0.0.0.0/8, 10.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.168.0.0/16, 224.0.0.0/4)
    - Blocks IPv6 special forms: ::1, ::, IPv4-mapped (::ffff:a.b.c.d), IPv4-compatible (::a.b.c.d), 6to4 (2002::/16), Teredo (2001::/32)
    - Rejects hostnames ending in `.localhost` or matching `localhost`
  - Key Resolution: draft `apiKey` OR tenant-scoped saved-key DB query
  - Provider Probes:
    - **OpenAI/OpenRouter**: List models, check availability
    - **Anthropic**: Create minimal message, peek JSON error type
    - **Gemini**: Call model metadata endpoint
    - **Custom**: Probe `/v1/models` and `/models` (trailing slash tolerant)
    - **Exa**: POST to `https://api.exa.ai/search`
  - Error Mapping: `auth`, `model`, `endpoint`, `network`, `rate_limit`, `unknown`
  - Logging: Plaintext keys never logged; events redacted

- **Rate Limiter** (`test-connection-rate-limit.ts`):
  - Per-tenant token bucket: `capacity=5`, `windowMs=60000` (5 requests per 60 seconds)
  - Lazy bucket initialization on first request
  - Refill rate: `capacity / windowMs` tokens per millisecond
  - Return `false` when quota exceeded

- **Route** (`settings-test-connection.ts`):
  - Mounted at `POST /api/settings/test-connection`
  - Tenant validation: returns 401 if no `tenantId` in context
  - JSON parse error: 400 with `error: "invalid_json"`
  - Schema validation: 400 with `error: "invalid_body"` + validation issues
  - Rate limit exceeded: 429 with `code: "rate_limit"`
  - XOR validation: exactly one of `apiKey` or `useSavedKey` required
  - Custom endpoint: `endpointUrl` required and HTTPS-validated

- **Domain Types** (`domain-types.ts`):
  - `TestConnectionLlmBody`: `target: "llm"`, `provider`, optional `model`, `apiKey`/`useSavedKey`, `endpointUrl` (if custom)
  - `TestConnectionExaBody`: `target: "exa"`, `apiKey`/`useSavedKey`
  - `TestConnectionErrorCode`: `auth` | `model` | `endpoint` | `network` | `rate_limit` | `unknown`
  - `TestConnectionResponse`: Success `{ ok: true, latencyMs, providerEcho? }` or Failure `{ ok: false, code, message }`

- **Frontend** (`settings-page.tsx`, `api-fetcher.ts`, `use-settings.ts`):
  - New `ConnectionTestStatus` component renders idle/loading/success/error states with human-readable messages
  - New `useSettings` hook includes `testConnection` property
  - New factory `createSettingsConnectionTester` calls endpoint, maps HTTP status to error code
  - Exa and LLM each have independent Test buttons; disabled until key+provider available
  - Request payload omits plaintext key in response logs

### Testing (B4)

```
✓ settings-connection-test.test.ts — 601 lines:
  ✓ SSRF Guard: rejects non-HTTPS, localhost variants, cloud metadata, private IPv4, IPv6 tunneling (7 bypass vectors)
  ✓ Provider Probes: OpenAI (model list), Anthropic (message), Gemini (metadata), OpenRouter, Exa
  ✓ Error Mapping: auth/model/endpoint/network/rate_limit/unknown codes verified
  ✓ Saved-key path: tenant-scoped loading, cross-tenant isolation verified
  ✓ Logging: plaintext key sentinel never in captured events

✓ settings-test-connection.test.ts — 251 lines:
  ✓ Request validation: missing target, XOR apiKey/useSavedKey, missing endpointUrl for custom
  ✓ Auth: 401 when no tenant context
  ✓ Rate limiting: 6th rapid request returns 429
  ✓ Cross-tenant isolation: loadSavedKey not called for unmatched tenant
  ✓ Schema validation: settingsResponseSchema rejects unknown codes

✓ settings-page.test.tsx — 548 lines:
  ✓ Button disabled/enabled states: key required for Exa, provider+endpoint for custom LLM
  ✓ Request payload shapes: useSavedKey vs draft apiKey, endpointUrl inclusion
  ✓ UI status: latency on success, error messages on failure
  ✓ User typing after success: status not cleared

✓ connection-test-status.test.tsx — 104 lines:
  ✓ Component renders idle/loading/success/error states
  ✓ Human-readable messages for all error codes

✓ Acceptance:
  ✓ 5/60s rate limit enforced per tenant
  ✓ Plaintext keys never leaked in logs or responses
  ✓ SSRF bypasses blocked (7 attack vectors)
  ✓ Tenant isolation verified across all probes
```

---

## Bundling Changes

### React Externalization

Updated Vite library build configuration across both card and settings targets:

```typescript
rollupOptions.external: ["react", "react-dom", "react/jsx-runtime", "@hubspot/ui-extensions"]
```

**Impact**: Dependencies no longer bundled into output; consumers provide via peer dependencies.

**Testing**:
```
✓ bundle-hubspot-card.test.ts — Verifies external list for both card + settings targets
✓ vite-config.test.ts — Config loads and includes externals
```

---

## Schema & Validation Summary

### Breaking Changes (Schema Level)

| Change | Impact | Migration |
|--------|--------|-----------|
| `SettingsSignalProviderName` no longer includes `"news"` | Reads/writes of `signalProviders.news` rejected | DB migration moves `news.enabled` → `exa.settings.newsEnabled` |
| `SettingsHubspotEnrichmentUpdate` restricted to `{ enabled?: boolean }` | API key field no longer accepted | Validation throws `SettingsValidationError` |
| `testConnectionBodySchema` new discriminated union | New endpoint requires strict target + XOR apiKey/useSavedKey | Frontend calls new endpoint only when testing |

### Validator Changes (`packages/validators/src/settings.ts`)

- Removed `"news"` from `settingsSignalProviderNameSchema`
- Added `hubspotEnrichmentUpdateSchema` (strict, only `enabled`)
- Added `testConnectionBodySchema` (discriminated union, XOR validation, HTTPS for custom)
- Added `testConnectionResponseSchema` (success/failure union with sanitized codes)

---

## Testing Summary

| Category | Coverage | Key Tests |
|----------|----------|-----------|
| **Unit** | percent-format, LLM catalog, error mapping, token bucket | 6 test files, 300+ assertions |
| **Integration** | DB migration, signal adapters, settings service | drop-news-provider.test.ts, factory.test.ts, settings-service.test.ts |
| **E2E (Route)** | HTTP handling, tenant context, rate limits, validation | settings-test-connection.test.ts (251 lines) |
| **Security** | SSRF guard (7 bypass vectors), plaintext key handling, tenant isolation | settings-connection-test.test.ts (601 lines) |
| **Component** | UI state machines, button enables/disables, user interactions | settings-page.test.tsx (548 lines), connection-test-status.test.tsx |
| **DD Traceability** | Every major flow has explicit test assertions; error codes mapped deterministically | Error codes constrained to enum; rate limit windows parameterized; SSRF rules documented |

---

## Summary of Public API Changes

| Module | Addition/Change | Type |
|--------|-----------------|------|
| `@hap/config` | `LLM_CATALOG` constant, `LlmCatalogEntry` type | Export |
| `@hap/config` | `SettingsHubspotEnrichmentUpdate` type | Type Addition |
| `@hap/config` | `TestConnectionBody`, `TestConnectionResponse`, `TestConnectionErrorCode` | New Discriminated Union Types |
| `@hap/config` | `ProviderConfig.settings` field | Type Extension |
| `apps/api` | `createExaSignalAdapters()` function | New Export |
| `apps/api` | `composeSignalAdapters()` function | New Export |
| `apps/api` | `SettingsValidationError` class | New Export |
| `apps/api` | `POST /api/settings/test-connection` route | New Endpoint |
| `apps/hubspot-extension` | `testConnection` prop in `HubSpotSettingsPageProps` | Prop Addition |
| `apps/hubspot-extension` | `ConnectionTestStatus` component | New Component |
| `apps/hubspot-extension` | `createSettingsConnectionTester()` factory | New Export |

---

## Deployment Checklist (Smoke Tests)

- [ ] **DB Migration**: Run `0009_drop_news_provider.sql` in staging; verify no Exa rows lost, `settings.newsEnabled` preserved
- [ ] **Settings Roundtrip**: Read/update settings for tenant with legacy `news` row; verify Exa `newsEnabled` flag correct
- [ ] **Snapshot Production**: Trigger snapshot generation; verify News evidence collected via Exa adapter (not top-level)
- [ ] **Connection Testing**: Test Exa + LLM (all providers) with valid/invalid keys; verify error codes match schema
- [ ] **Rate Limiting**: Rapid test-connection requests from same tenant; verify 6th returns 429
- [ ] **SSRF**: Attempt custom LLM endpoint with localhost/169.254.0.0; verify 400 with `code: "endpoint"`
- [ ] **Bundling**: Verify React peer dependencies not in `hubspot-extension` bundle
- [ ] **Logging**: Verify plaintext keys never appear in application logs or error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->