### PR TITLE
test(settings): guard against legacy news provider response drift

### DIFF
--- a/apps/api/src/routes/__tests__/settings.test.ts
+++ b/apps/api/src/routes/__tests__/settings.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createDatabase, llmConfig, providerConfig, tenants } from "@hap/db";
+import { settingsResponseSchema } from "@hap/validators";
 import { and, eq, like } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -135,6 +136,42 @@ describe("GET /api/settings", () => {
         minConfidence: 0.5,
       },
     });
+  });
+
+  // Issue #17 regression guard: simulates the live failure surface where a
+  // tenant's provider_config table still carries a legacy `news` row from
+  // before Issue B Wave 1 dropped the slot. The GET response must (a) omit
+  // the `news` key entirely, and (b) parse cleanly against the strict
+  // frontend schema in `@hap/validators`. If either invariant ever
+  // regresses, the deployed settings extension will render
+  // `settings-validation-failed: unrecognized_keys ["news"]`.
+  it("omits legacy 'news' provider rows from the GET /api/settings response", async () => {
+    const tenant = await seedTenant("Legacy News Tenant");
+    const app = await loadApp();
+
+    await db.insert(providerConfig).values({
+      tenantId: tenant.id,
+      providerName: "news",
+      enabled: true,
+      apiKeyEncrypted: null,
+      thresholds: {},
+      settings: {},
+    });
+
+    const res = await app.request("/api/settings", {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer anything",
+        "x-test-portal-id": tenant.hubspotPortalId,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect((body.signalProviders as Record<string, unknown>).news).toBeUndefined();
+
+    const parsed = settingsResponseSchema.safeParse(body);
+    expect(parsed.success).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a route-level regression test that locks in the issue #17 fix shape: the `GET /api/settings` response must omit `signalProviders.news` and parse cleanly against the strict `@hap/validators.settingsResponseSchema`, even if a legacy `news` row remains in `provider_config`.

Closes #17 (regression-guard half).

## Root cause (issue #17)

Production `https://hap.mandigital.dev` was emitting `signalProviders.news` while the deployed HubSpot bundle (build #7) carried the post-Issue-B-Wave-1 strict Zod schema that rejects unknown keys. Settings extension rendered:

```
settings-validation-failed: [ { "code": "unrecognized_keys", "keys": [ "news" ], "path": [ "signalProviders" ], "message": "Invalid input" } ]
```

The backend code at HEAD already omitted `news` (commit [b928281](https://github.com/romeoman/hubspot-account-plan-app/commit/b928281), shipped via PR #20). The live failure was a deploy-lag — production hadn't been redeployed since. PR #22 (codex/vercel-pnpm-install-command) restored the deploy path and produced a fresh production build that no longer emits `news`.

This PR is the regression-guard half — the test that prevents reintroduction.

## What changed

- [apps/api/src/routes/__tests__/settings.test.ts](apps/api/src/routes/__tests__/settings.test.ts) (+37 lines): one new test, `omits legacy 'news' provider rows from the GET /api/settings response`. The test:
  1. Pre-seeds a legacy `news` row directly in `provider_config` for a fresh tenant.
  2. Issues `GET /api/settings`.
  3. Asserts `200` status.
  4. Asserts `signalProviders.news` is absent from the body.
  5. Re-parses the body against `settingsResponseSchema` from `@hap/validators` and asserts `success === true` — proving the response shape matches the strict frontend schema.

No production code changed.

## Verification

- **RED** verified by injecting a temporary `news` field into `readSettings()` return. Test failed: `expected 500 to be 200` (route's own strict `settingsResponseSchema.safeParse` returned 500 \`invalid_settings_response\`). Regression reverted.
- **GREEN** after revert: `pnpm vitest run apps/api/src/routes/__tests__/settings.test.ts apps/api/src/lib/__tests__/settings-service.test.ts` → 18/18 passed.
- `pnpm typecheck` → pass.
- `pnpm exec biome check apps/api/src/routes/__tests__/settings.test.ts` → clean.
- Live HubSpot test portal `1969772` after PR #22 deployed:
  - `settings-validation-failed` gone
  - `unrecognized_keys [\"news\"]` gone
  - HubSpot generic error gone
  - React `useState` crash gone

## Scope / non-goals

- Test-only. No production code touched.
- Does not address the new `settings-fetch-failed: 401` symptom now visible on the same surface — that's a separate auth/tenant lane.
- Does not modify the existing news-related tests at `settings-service.test.ts:133, :350` or `settings.test.ts:404` — those continue to cover write-path and PUT-rejection.

## Remaining risks / follow-ups

- New `settings-fetch-failed: 401` from the HubSpot proxied call to `/api/settings` — needs a separate investigation (tenant resolution / signature validation under the new function path from PR #22).
- The Issue B settings-page rewrite (commit [6f73eec](https://github.com/romeoman/hubspot-account-plan-app/commit/6f73eec)) is live in build #7 of the HubSpot project — once the 401 issue is resolved, the rest of the new wire contract should also light up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test to lock in the Issue #17 fix: GET /api/settings must omit `signalProviders.news` and pass the strict `@hap/validators` `settingsResponseSchema`, even if a legacy `news` row exists in `provider_config`. Test-only; seeds a legacy row, expects 200, verifies `news` is absent, and schema parse succeeds to guard the settings UI.

<sup>Written for commit 468ad916d0b86b3a5d13852d70aa6ff5bc3a3a96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary: Regression Test for Legacy Settings Provider Filtering

## Release notes (important)
- Adds a regression test that prevents legacy provider rows (specifically `news`) from appearing in GET /api/settings responses.
- Ensures the settings response strictly conforms to the frontend Zod schema (settingsResponseSchema) to avoid runtime HubSpot extension failures.
- Test-only change — no production code or API contract changes.
- Location: apps/api/src/routes/__tests__/settings.test.ts (+37 lines).

## What changed
- New integration-level test: "omits legacy 'news' provider rows from the GET /api/settings response".
  - Seeds a tenant and inserts a legacy provider_config row with providerName: "news".
  - Calls GET /api/settings.
  - Asserts HTTP 200.
  - Asserts response.signalProviders.news is undefined.
  - Validates the full response with settingsResponseSchema.safeParse(...) and asserts success.

## Why this matters (problem & risk)
- Issue #17: Backend emitted signalProviders.news while the frontend used a strict schema; unknown keys caused zod rejection and HubSpot extension render failures (unrecognized_keys ["news"]).
- Although production HEAD already omits news, deployment/rollout lag previously caused the client/frontend to see the invalid response.
- This test prevents regressions that would reintroduce the legacy key and break the settings UI on install or upgrade.

## Data flow (how the test exercises the system)
```mermaid
graph TD
  DB["Database: provider_config (may contain legacy 'news')"] --> READ["readSettings()/config resolver"]
  READ --> FILTER["filter legacy providers ('news')"]
  FILTER --> ROUTE["GET /api/settings handler"]
  ROUTE --> RESPONSE["HTTP 200 + JSON body"]
  RESPONSE --> SCHEMA["settingsResponseSchema.safeParse(body)"]
  SCHEMA --> PASS{"parsed.success === true?"}
  PASS -->|yes| OK["Frontend schema-compatible response sent"]
  PASS -->|no| FAIL["Test fails -> regression detected"]
```

## Test traceability & verification steps
- File: apps/api/src/routes/__tests__/settings.test.ts — test name and assertions are explicit and map to the acceptance criteria:
  - Seed legacy data: db.insert(providerConfig) with providerName "news".
  - Trigger: app.request("/api/settings", method: "GET").
  - Assert status 200: ensures route didn't error.
  - Assert signalProviders.news is undefined: verifies filtering logic.
  - Parse with settingsResponseSchema.safeParse(body) and assert parsed.success === true: verifies the strict frontend contract.
- Local verification performed by author: test failed when news was injected; passing after revert. All vitest suites pass; typecheck and biome lint clean.

## Acceptance criteria mapping (from Issue #17 objectives)
- Prevent unknown keys in GET /api/settings (mapped to schema validation assertion).
- Provide traceable test that reproduces the legacy-data scenario (seeded provider_config row).
- Ensure settings route returns a shape that the frontend will accept (safeParse success).
- Test is scoped: test-only, no changes to write paths or unrelated 401 symptom.

## Impact
- Production behavior unchanged when tests pass.
- Prevents future regressions that would reintroduce legacy provider keys leading to frontend validation failures and HubSpot extension render errors.

## How this supports traceability and testing discipline (DD)
- Deterministic regression guard: seeds explicit legacy DB state, exercises full HTTP route, and validates contract with the same strict schema used by the frontend.
- One-to-one mapping between seeded legacy row → endpoint behavior → schema parse assertion provides clear provenance when the test fails.
- Test failure surface directly points to: (a) filtering logic in readSettings/config resolver, or (b) route-level response shaping — making root-cause localization straightforward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->