### PR TITLE
fix(auth): honor forwarded protocol for HubSpot signatures (#24)

### DIFF
--- a/apps/api/src/middleware/__tests__/hubspot-signature.test.ts
+++ b/apps/api/src/middleware/__tests__/hubspot-signature.test.ts
@@ -176,6 +176,106 @@ describe("hubspotSignatureMiddleware — valid signatures", () => {
   });
 });
 
+describe("hubspotSignatureMiddleware — x-forwarded-proto canonicalization", () => {
+  // Issue #24: on Vercel TLS terminates at the edge, so the function's
+  // socket is plain TCP and @hono/node-server/vercel reconstructs c.req.url
+  // with scheme "http://". HubSpot signs the public "https://" URL via
+  // hubspot.fetch, so the HMAC payload diverges and every signed request
+  // fails with "signature mismatch" -> 401. The middleware must honor
+  // `x-forwarded-proto` (which Vercel always sets to "https") when
+  // canonicalizing the URL it hashes.
+  it("accepts a request signed against https when x-forwarded-proto: https is set and req.url is http", async () => {
+    const portal = portalId();
+    await db.insert(tenants).values({ hubspotPortalId: portal, name: "XfpHttps" }).returning();
+
+    const secret = process.env.HUBSPOT_CLIENT_SECRET ?? "";
+    const path = `/probe?portalId=${encodeURIComponent(portal)}&userId=u-xfp`;
+    // HubSpot signs the public HTTPS URL.
+    const signedUrl = `https://localhost${path}`;
+    const timestamp = Date.now();
+    const signature = signV3({
+      clientSecret: secret,
+      method: "GET",
+      uri: signedUrl,
+      body: "",
+      timestamp,
+    });
+
+    // Hono's app.request() defaults to http://localhost for relative URLs,
+    // matching the Vercel behavior where the function sees scheme=http.
+    const app = buildApp();
+    const res = await app.request(path, {
+      method: "GET",
+      headers: {
+        "X-HubSpot-Signature-v3": signature,
+        "X-HubSpot-Request-Timestamp": String(timestamp),
+        "x-forwarded-proto": "https",
+      },
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { portalId: string; userId: string };
+    expect(json.portalId).toBe(portal);
+    expect(json.userId).toBe("u-xfp");
+  });
+
+  it("ignores a missing x-forwarded-proto and verifies against the request scheme as before", async () => {
+    // Regression guard: the existing GET test (above) already exercises this
+    // path implicitly. Re-asserting here keeps the contract explicit so a
+    // future refactor of canonicalization cannot silently change the no-XFP
+    // behavior.
+    const portal = portalId();
+    await db.insert(tenants).values({ hubspotPortalId: portal, name: "NoXfp" }).returning();
+    const secret = process.env.HUBSPOT_CLIENT_SECRET ?? "";
+    const path = `/probe?portalId=${encodeURIComponent(portal)}&userId=u-noxfp`;
+    const fullUrl = `http://localhost${path}`;
+    const timestamp = Date.now();
+    const signature = signV3({
+      clientSecret: secret,
+      method: "GET",
+      uri: fullUrl,
+      body: "",
+      timestamp,
+    });
+
+    const app = buildApp();
+    const res = await app.request(path, {
+      method: "GET",
+      headers: {
+        "X-HubSpot-Signature-v3": signature,
+        "X-HubSpot-Request-Timestamp": String(timestamp),
+      },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an invalid x-forwarded-proto value (not http/https) with 401", async () => {
+    const portal = portalId();
+    await db.insert(tenants).values({ hubspotPortalId: portal, name: "XfpBad" }).returning();
+    const secret = process.env.HUBSPOT_CLIENT_SECRET ?? "";
+    const path = `/probe?portalId=${encodeURIComponent(portal)}&userId=u-bad`;
+    const signedUrl = `https://localhost${path}`;
+    const timestamp = Date.now();
+    const signature = signV3({
+      clientSecret: secret,
+      method: "GET",
+      uri: signedUrl,
+      body: "",
+      timestamp,
+    });
+
+    const app = buildApp();
+    const res = await app.request(path, {
+      method: "GET",
+      headers: {
+        "X-HubSpot-Signature-v3": signature,
+        "X-HubSpot-Request-Timestamp": String(timestamp),
+        "x-forwarded-proto": "javascript",
+      },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
 describe("hubspotSignatureMiddleware — rejection paths", () => {
   it("rejects a missing signature header with 401", async () => {
     const app = buildApp();

--- a/apps/api/src/middleware/__tests__/hubspot-signature.test.ts
+++ b/apps/api/src/middleware/__tests__/hubspot-signature.test.ts
@@ -274,6 +274,33 @@ describe("hubspotSignatureMiddleware — x-forwarded-proto canonicalization", ()
     });
     expect(res.status).toBe(401);
   });
+
+  it("uses the first x-forwarded-proto entry when a proxy chain is present", async () => {
+    const portal = portalId();
+    await db.insert(tenants).values({ hubspotPortalId: portal, name: "XfpChain" }).returning();
+    const secret = process.env.HUBSPOT_CLIENT_SECRET ?? "";
+    const path = `/probe?portalId=${encodeURIComponent(portal)}&userId=u-chain`;
+    const signedUrl = `https://localhost${path}`;
+    const timestamp = Date.now();
+    const signature = signV3({
+      clientSecret: secret,
+      method: "GET",
+      uri: signedUrl,
+      body: "",
+      timestamp,
+    });
+
+    const app = buildApp();
+    const res = await app.request(path, {
+      method: "GET",
+      headers: {
+        "X-HubSpot-Signature-v3": signature,
+        "X-HubSpot-Request-Timestamp": String(timestamp),
+        "x-forwarded-proto": "https, http",
+      },
+    });
+    expect(res.status).toBe(200);
+  });
 });
 
 describe("hubspotSignatureMiddleware — rejection paths", () => {

--- a/apps/api/src/middleware/hubspot-signature.ts
+++ b/apps/api/src/middleware/hubspot-signature.ts
@@ -240,9 +240,30 @@ function extractPrincipals(
  * Reconstruct the URL HubSpot signed. Hono's `c.req.url` already includes
  * protocol + host + path + query, which matches HubSpot's reference
  * implementation (`${protocol}://${hostname}${url}`).
+ *
+ * On Vercel TLS terminates at the edge and the function's underlying socket
+ * is plain TCP, so `@hono/node-server/vercel` reconstructs `c.req.url` with
+ * scheme `http://`. HubSpot's `hubspot.fetch` proxy signs the public HTTPS
+ * URL, which would otherwise produce an HMAC mismatch (issue #24). When the
+ * platform sets `x-forwarded-proto`, honor it as the canonical scheme so the
+ * payload matches what HubSpot signed. Only `http`/`https` are accepted; any
+ * other value is ignored (defensive — a forged header cannot redirect us to
+ * an unknown scheme).
  */
-function requestUrl(rawUrl: string): string {
-  return rawUrl;
+function requestUrl(rawUrl: string, forwardedProto: string | null): string {
+  if (!forwardedProto) return rawUrl;
+  // `x-forwarded-proto` may be a comma-separated list (proxy chain). Take the
+  // first entry, which is the original client-facing scheme.
+  const proto = forwardedProto.split(",")[0]?.trim().toLowerCase();
+  if (proto !== "http" && proto !== "https") return rawUrl;
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol === `${proto}:`) return rawUrl;
+    parsed.protocol = `${proto}:`;
+    return parsed.toString();
+  } catch {
+    return rawUrl;
+  }
 }
 
 /**
@@ -302,7 +323,7 @@ export function hubspotSignatureMiddleware(): MiddlewareHandler<{
     }
 
     const method = c.req.method.toUpperCase();
-    const url = requestUrl(c.req.url);
+    const url = requestUrl(c.req.url, c.req.header("x-forwarded-proto") ?? null);
 
     // Read the raw body text exactly once. For GET/DELETE, this is an empty
     // string. For JSON POST/PUT/PATCH, Hono's `c.req.text()` returns the raw

--- a/apps/api/src/middleware/hubspot-signature.ts
+++ b/apps/api/src/middleware/hubspot-signature.ts
@@ -250,7 +250,7 @@ function extractPrincipals(
  * other value is ignored (defensive — a forged header cannot redirect us to
  * an unknown scheme).
  */
-function requestUrl(rawUrl: string, forwardedProto: string | null): string {
+export function canonicalizeRequestUrl(rawUrl: string, forwardedProto: string | null): string {
   if (!forwardedProto) return rawUrl;
   // `x-forwarded-proto` may be a comma-separated list (proxy chain). Take the
   // first entry, which is the original client-facing scheme.
@@ -323,7 +323,7 @@ export function hubspotSignatureMiddleware(): MiddlewareHandler<{
     }
 
     const method = c.req.method.toUpperCase();
-    const url = requestUrl(c.req.url, c.req.header("x-forwarded-proto") ?? null);
+    const url = canonicalizeRequestUrl(c.req.url, c.req.header("x-forwarded-proto") ?? null);
 
     // Read the raw body text exactly once. For GET/DELETE, this is an empty
     // string. For JSON POST/PUT/PATCH, Hono's `c.req.text()` returns the raw

--- a/apps/api/src/routes/__tests__/lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/lifecycle.test.ts
@@ -171,6 +171,53 @@ describe("POST /webhooks/hubspot/lifecycle — auth", () => {
     expect(row?.isActive).toBe(true);
     expect(row?.deactivatedAt).toBeNull();
   });
+
+  it("accepts a webhook signed against https when x-forwarded-proto: https is set on a http-scheme request (issue #24)", async () => {
+    // On Vercel TLS terminates at the edge so the function's req.url is
+    // http://..., but HubSpot signs the public https URL. The lifecycle
+    // route must canonicalize via x-forwarded-proto for the same reason
+    // the middleware does.
+    const tenant = await seedTenant();
+    const app = buildApp();
+    const httpUrl = "http://localhost/webhooks/hubspot/lifecycle";
+    const httpsUrl = "https://localhost/webhooks/hubspot/lifecycle";
+    const events = [
+      {
+        eventId: 1,
+        subscriptionId: 123,
+        portalId: Number.isNaN(Number(tenant.hubspotPortalId))
+          ? tenant.hubspotPortalId
+          : Number(tenant.hubspotPortalId),
+        appId: 12345,
+        occurredAt: Date.now(),
+        subscriptionType: "APP_LIFECYCLE_EVENT",
+        attemptNumber: 0,
+        eventTypeId: LIFECYCLE_EVENT_TYPE_UNINSTALL,
+        sourceId: "source-1",
+      },
+    ];
+    const body = JSON.stringify(events);
+    const timestamp = Date.now();
+    const signature = signV3({
+      clientSecret: TEST_CLIENT_SECRET,
+      method: "POST",
+      url: httpsUrl,
+      body,
+      timestamp,
+    });
+
+    const res = await app.request(httpUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-hubspot-signature-v3": signature,
+        "x-hubspot-request-timestamp": String(timestamp),
+        "x-forwarded-proto": "https",
+      },
+      body,
+    });
+    expect(res.status).toBe(200);
+  });
 });
 
 describe("POST /webhooks/hubspot/lifecycle — app_uninstall (4-1916193)", () => {

--- a/apps/api/src/routes/lifecycle.ts
+++ b/apps/api/src/routes/lifecycle.ts
@@ -32,7 +32,10 @@ import {
   applyHubSpotLifecycleEvent,
   type HubSpotLifecycleEventType,
 } from "../lib/tenant-lifecycle.js";
-import { verifyHubSpotSignatureV3 } from "../middleware/hubspot-signature.js";
+import {
+  canonicalizeRequestUrl,
+  verifyHubSpotSignatureV3,
+} from "../middleware/hubspot-signature.js";
 
 /**
  * HubSpot's documented event-type IDs for APP_LIFECYCLE_EVENT webhooks.
@@ -101,7 +104,10 @@ export function lifecycleWebhookRoutes(deps: LifecycleWebhookDeps): Hono {
 
     const verdict = verifyHubSpotSignatureV3({
       method: "POST",
-      url: c.req.url,
+      // Canonicalize via x-forwarded-proto so TLS-terminating proxies (Vercel
+      // edge -> Node function plain-TCP socket) match HubSpot's HTTPS-signed
+      // URL. Same fix as the middleware (issue #24).
+      url: canonicalizeRequestUrl(c.req.url, c.req.header("x-forwarded-proto") ?? null),
       body,
       timestamp,
       signature,


### PR DESCRIPTION
## Summary
- Fixes HubSpot-proxied `/api/settings` requests returning 401 on Vercel after the Node adapter deploy-path rebuild (issue #24).

## Root cause
- HubSpot's `hubspot.fetch` proxy signs the **public HTTPS URL** with `X-HubSpot-Signature-v3`.
- Vercel terminates TLS at the edge; the Node function's underlying socket is plain TCP.
- `@hono/node-server/vercel` derives scheme from `socket.encrypted`, so it reconstructs `c.req.url` as `http://...`.
- The signature middleware hashed `http://hap.mandigital.dev/...` while HubSpot signed `https://hap.mandigital.dev/...` → HMAC mismatch → 401.
- Surface masked by issue #17 until PR #22 restored the deploy path; with strict settings shape live, every signed call from the settings extension failed.

## What changed
- `requestUrl()` in `apps/api/src/middleware/hubspot-signature.ts` now honors `x-forwarded-proto` when canonicalizing the URL used for HMAC verification AND principal extraction.
- Only `http` / `https` are accepted; first comma-separated entry wins (proxy chain).
- Header absent → behavior unchanged.

## Verification
- **RED:** new test `accepts a request signed against https when x-forwarded-proto: https is set and req.url is http` failed `expected 401 to be 200` with `hubspot-signature: signature mismatch` (matches root-cause hypothesis).
- **GREEN:** `pnpm exec vitest run apps/api/src/middleware/__tests__/hubspot-signature.test.ts` → 17/17 pass.
- Combined signature + settings tests → 27/27 pass.
- `pnpm typecheck` clean.
- `biome check` on both touched files clean.

## Test plan
- [ ] CI green.
- [ ] After production deploy, hard-refresh portal 1969772 settings page (`https://app.hubspot.com/integrations-settings/1969772/installed/framework/37116835/general-settings`) and confirm `/api/settings` returns 200, no `settings-fetch-failed: 401`.
- [ ] Open a company record card; snapshot should still load (same auth path benefits).

## Scope / non-goals
- No Vercel config changes.
- No settings UI changes.
- Does not touch issue #17 / news provider contract.

## Remaining risks / follow-ups
- Requires production deploy after merge.
- If 401 persists, capture Vercel function logs and grep for `hubspot-signature:` to inspect the precise reason string (may indicate a separate canonicalization edge case e.g. trailing slash, port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 401s on HubSpot‑proxied `/api/settings` and lifecycle webhooks on Vercel by honoring the forwarded protocol when verifying `X-HubSpot-Signature-v3`. The hashed URL now matches the public HTTPS URL HubSpot signs, addressing issue #24.

- **Bug Fixes**
  - Canonicalize the request URL with `x-forwarded-proto` (first value; only http/https) for HMAC verification and principal extraction; exported as `canonicalizeRequestUrl`.
  - Apply the same canonicalization in `/webhooks/hubspot/lifecycle` before signature verification.
  - Preserve behavior when the header is absent; reject invalid protocols with 401.
  - Tests cover forwarded HTTPS, no header, invalid proto, proxy-chain precedence, and the lifecycle webhook scenario.

<sup>Written for commit 037f9a6e4073ee4d1e5b927bdb63bd6ab7f234c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Fix HubSpot Signature Verification for Forwarded HTTPS Protocol

## Overview
Fixes a critical 401 authentication failure on Vercel deployments caused by TLS termination at the edge. HubSpot signs requests with HTTPS URLs, but the Node function receives plain TCP connections and reconstructed URLs with HTTP scheme, causing HMAC signature mismatches.

---

## Problem: The HTTPS-to-HTTP Mismatch

```mermaid
sequenceDiagram
    actor Client
    participant HubSpot as HubSpot<br/>(Proxy)
    participant Vercel as Vercel Edge<br/>(TLS Termination)
    participant Function as Node Function<br/>(Plain TCP)
    participant Middleware as Signature<br/>Verification

    HubSpot->>HubSpot: Sign payload using<br/>HTTPS URL:<br/>https://app.example.com/api/...
    HubSpot->>HubSpot: Compute HMAC over<br/>HTTPS URL + body + timestamp
    HubSpot->>Vercel: Forward signed request<br/>X-HubSpot-Signature-v3: [base64]<br/>x-forwarded-proto: https
    Vercel->>Vercel: Decrypt TLS<br/>Terminate connection
    Vercel->>Function: Pass plain TCP<br/>Reconstruct URL as<br/>http://... ❌

    Function->>Middleware: Request arrives<br/>c.req.url = http://app.example.com/api/...
    Middleware->>Middleware: Compute HMAC over<br/>HTTP URL + body + timestamp ❌
    Middleware->>Middleware: Compare HMACs:<br/>Signed(HTTPS) ≠ Computed(HTTP)<br/>→ 401 Unauthorized
```

**Root Cause:** The middleware was using the literal `c.req.url` from the reconstructed request, which contained `http://` instead of the HTTPS scheme HubSpot actually signed.

---

## Solution: Honor x-forwarded-proto Header

```mermaid
sequenceDiagram
    participant Request as Incoming Request<br/>(Vercel)
    participant Canonicalize as canonicalizeRequestUrl()<br/>Function
    participant Verify as verifyHubSpotSignatureV3()
    participant Result as Response

    Request->>Canonicalize: url: "http://..."<br/>x-forwarded-proto: "https"
    Canonicalize->>Canonicalize: Parse forwarded-proto<br/>Extract first value from<br/>comma-separated list
    Canonicalize->>Canonicalize: Validate scheme<br/>(only http/https allowed)
    Canonicalize->>Canonicalize: Rewrite URL protocol<br/>http://... → https://...
    Canonicalize-->>Verify: Canonicalized URL: "https://..."
    Verify->>Verify: Compute HMAC over<br/>HTTPS URL + body + timestamp ✓
    Verify->>Verify: Compare with<br/>X-HubSpot-Signature-v3<br/>Match! ✓
    Verify-->>Result: 200 OK (or process request)
```

### Implementation Details

**New exported function** in `apps/api/src/middleware/hubspot-signature.ts`:

```typescript
export function canonicalizeRequestUrl(rawUrl: string, forwardedProto: string | null): string
```

- **Input:** The raw URL from the request and the optional `x-forwarded-proto` header
- **Logic:**
  - If no `x-forwarded-proto` header, return the raw URL unchanged (backward compatible)
  - Parse comma-separated header (proxy chains) and use the **first entry** (original client-facing scheme)
  - Accept only `http` or `https` as valid schemes (defensive validation)
  - Rewrite the URL's protocol to match the forwarded proto
  - If URL parsing fails, gracefully return the original URL

- **Why this works:**
  - Hono's `@hono/node-server/vercel` adapter sets `x-forwarded-proto: https` because it knows the original TLS connection was HTTPS
  - By rewriting the URL's scheme before computing the HMAC, we match what HubSpot signed
  - The payload (body, timestamp, method) remain unchanged—only the protocol scheme is corrected

---

## Changes Applied

### 1. **API Settings Middleware** → `apps/api/src/middleware/hubspot-signature.ts`

**Line 253–267:** Added `canonicalizeRequestUrl()` function  
**Line 326:** Updated middleware to call the function

```
Changes: +24 lines / -3 lines
```

- Middleware now calls `canonicalizeRequestUrl(c.req.url, c.req.header("x-forwarded-proto") ?? null)` before HMAC verification
- The canonicalized URL is used for both signature verification and principal extraction
- Backward compatible: requests without the header behave identically to before

**Impact:** Signed requests from HubSpot's proxy now verify correctly on Vercel even when TLS is terminated at the edge.

---

### 2. **Lifecycle Webhook Route** → `apps/api/src/routes/lifecycle.ts`

**Line 36–37:** Imported `canonicalizeRequestUrl`  
**Line 110:** Updated webhook signature verification to use the function

```
Changes: +8 lines / -2 lines
```

- Lifecycle webhook events (install/uninstall) also come through HubSpot's proxy
- Same HTTPS-to-HTTP issue affected lifecycle deliveries
- Now both settings requests and lifecycle webhooks canonicalize the URL before signature verification

**Impact:** Lifecycle events are no longer rejected due to forwarded-proto mismatches.

---

## Testing & Verification

### Middleware Tests → `apps/api/src/middleware/__tests__/hubspot-signature.test.ts`

```
Changes: +127 lines
Test Coverage: 17/17 passing
```

**New test cases added:**

| Test | Scenario | Verification |
|------|----------|--------------|
| **Forwarded HTTPS** | Request URL is `http://...` but header `x-forwarded-proto: https` | Signature matches; 200 OK ✓ |
| **No forwarded header** | Request URL `http://...`, no forwarded-proto header | Uses raw URL; behavior unchanged ✓ |
| **Invalid proto** | `x-forwarded-proto: ftp` or other invalid value | Ignored; returns raw URL; HMAC fails as expected ✓ |
| **Proxy chain** | `x-forwarded-proto: https, http` (comma-separated) | Uses first value `https`; signature matches ✓ |

**Key design decision:** Only the **first comma-separated value** is used because it represents the original client-facing scheme. Intermediate proxies (if any) append their own schemes to the right, so parsing from left to right ensures we get the original HTTPS connection.

---

### Lifecycle Webhook Tests → `apps/api/src/routes/__tests__/lifecycle.test.ts`

```
Changes: +47 lines
Test Coverage: 27/27 passing (combined with middleware tests)
```

**New test case:**

| Test | Details |
|------|---------|
| **Signed HTTPS / Received HTTP** | Webhook signed with HTTPS URL; request received as HTTP; header `x-forwarded-proto: https` set; verifies 200 OK ✓ |

---

## Defensive Design Features

1. **Scheme Validation:** Only `http` and `https` are accepted as forwarded schemes. Unknown schemes (e.g., `ftp`, `gopher`) are silently ignored, preventing header injection attacks.

2. **Graceful Fallback:** If URL parsing fails at any step, the original URL is returned unchanged. Signature verification will still fail if the URL is truly malformed, but we don't crash.

3. **Constant-Time HMAC Comparison:** All signature verification uses `safeEquals()` to prevent timing attacks, regardless of the URL canonicalization path.

4. **No Changes to Secret Handling:** The client secret loading and caching remain unchanged; all crypto operations are identical.

5. **Audit Trail:** Failure logs remain redacted (no secrets, signatures, or bodies), but include diagnostic reason strings for debugging.

---

## Data Flow Diagram: Complete Request Lifecycle

```mermaid
graph TD
    A["HubSpot Proxy<br/>(HTTPS Signed)"] -->|"POST /api/settings<br/>X-HubSpot-Signature-v3: ...<br/>x-forwarded-proto: https"| B["Vercel Edge"]
    B -->|"Decrypt TLS<br/>Reconstruct as http://..."| C["Node Function"]
    C -->|"request arrives<br/>c.req.url = http://..."| D["hubspotSignatureMiddleware()"]
    D -->|"canonicalizeRequestUrl()<br/>rewrites http → https"| E["canonicalized url<br/>https://..."]
    E -->|"pass to HMAC<br/>verification"| F["verifyHubSpotSignatureV3()"]
    F -->|"method + decoded-url +<br/>body + timestamp"| G["createHmac<br/>sha256"]
    G -->|"compare against<br/>X-HubSpot-Signature-v3"| H{HMAC<br/>Match?}
    H -->|"Yes"| I["extractPrincipals()<br/>portalId/userId"]
    H -->|"No"| J["❌ 401 Unauthorized"]
    I -->|"Hono Variables:<br/>portalId, userId, rawBody"| K["tenantMiddleware"]
    K -->|"→ tenantId<br/>(resolved from portalId)"| L["✓ Request Proceeds"]
    style D fill:#4a90e2
    style E fill:#90ee90
    style F fill:#4a90e2
    style L fill:#90ee90
```

---

## Backwards Compatibility

- ✅ **Fully backward compatible:** Requests without `x-forwarded-proto` header use the raw URL, preserving existing behavior
- ✅ **No changes to public exports** (except the new `canonicalizeRequestUrl` function, which is an addition)
- ✅ **No changes to secret handling, HMAC algorithm, or freshness window**
- ✅ **Test bypass logic (`x-test-portal-id`) unchanged**

---

## Deployment Requirements

1. **Environment Variables:** No new env vars required. Existing `HUBSPOT_CLIENT_SECRET` remains the only secret.

2. **Vercel Behavior:** Vercel automatically sets `x-forwarded-proto: https` for all edge requests, so this fix activates automatically on deploy.

3. **Diagnostic Logging:** Existing console.warn() logs include the failure reason. If 401s persist post-deploy, check logs for:
   - `"hubspot-signature: signature mismatch"` → HMAC verification failed (indicates URL scheme issue)
   - `"hubspot-signature: missing signature or timestamp header"` → Header validation failed
   - `"hubspot-signature: stale timestamp"` → Request outside 5-minute freshness window

4. **Production Validation:** Full validation requires:
   - CI passing (all tests green)
   - Deployed to production
   - Monitor Vercel logs for 401 rates to drop
   - HubSpot Settings requests and lifecycle events both processing without auth errors

---

## Testing Checklist

- [x] Unit tests for `canonicalizeRequestUrl()` (proxy chains, invalid schemes, missing header)
- [x] Middleware integration tests (signature verification with/without forwarded-proto)
- [x] Lifecycle webhook tests (signed HTTPS / received HTTP scenario)
- [x] Typecheck passes (no TS errors)
- [x] Biome linter clean
- [x] All 27 combined tests passing (17 middleware + 10 existing + new)
- [ ] *Requires production deploy:* Monitor real HubSpot traffic for 401 elimination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->