### PR TITLE
fix(deploy): exclude local artifacts from Vercel uploads

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,36 @@
+# Vercel CLI ignore rules
+#
+# `vercel deploy` from this repo's root or from `apps/api/` (the configured
+# rootDirectory) does NOT reliably honor every entry in .gitignore — most
+# notably, the anchored `/.worktrees/` rule and per-package `dist/` rules
+# can leak into uploads when the CLI is invoked from a non-root cwd. That
+# leak shipped a stale, pre-PR-#21 `packages/config/dist/index.js` (with
+# extensionless ESM specifiers) in deploy `irc4g8y8q`, crashing cold-start
+# with `ERR_MODULE_NOT_FOUND` for `./domain-types`.
+#
+# This file makes the intent explicit and CLI-honored.
+
+# Local git worktrees (each contains its own checkout + built dist/)
+.worktrees/
+
+# Build output across all workspace packages and apps
+**/dist/
+**/build/
+**/.next/
+**/out/
+**/*.tsbuildinfo
+
+# Vercel CLI link directory (per PR #25 — also covered by apps/api/.gitignore)
+.vercel/
+
+# macOS Finder duplicate artifacts (e.g. `domain-types 2.js`,
+# `domain-types.d 2.ts`) that occasionally appear after copy/sync events
+# and got uploaded alongside real dist files in the failing deploy.
+**/* 2
+**/* 2.*
+
+# Local env files (defense in depth — should never be uploaded)
+.env
+.env.*
+!.env.example
+!.env.test.example


### PR DESCRIPTION
## Summary
Adds a root `.vercelignore` so Vercel CLI deploys do not upload local worktrees, stale build outputs, TypeScript build-info files, `.vercel` link state, macOS duplicate files, or local env files.

## Root cause
Production verification of PR #26 was blocked because a Vercel CLI deploy uploaded local untracked artifacts. The failing deploy uploaded 5,714 files, including 3,815 files from `.worktrees/`, plus stale `packages/config/dist` output and macOS duplicate files. The deployed `/var/task/packages/config/dist/index.js` contained pre-PR #21 extensionless ESM imports, causing Node to fail module resolution at cold start.

## What changed
Added a root `.vercelignore` excluding:
- `.worktrees/`
- `**/dist/`
- `**/build/`
- `**/.next/`
- `**/out/`
- `**/*.tsbuildinfo`
- `.vercel/`
- macOS duplicate patterns `**/* 2` and `**/* 2.*`
- local `.env` files, while preserving `.env.example` and `.env.test.example`

## Verification
- Verified the ignore patterns with the same `ignore` npm package semantics used by Vercel CLI.
- 24/24 assertions passed against the exact artifact paths observed in the failing deployment.
- Confirmed required source/config files are not ignored.
- `git status --short` was clean after commit.

## Scope / non-goals
This PR does not change auth/signature code.
This PR does not modify `apps/api/vercel.json`.
This PR does not redeploy or repoint `hap.mandigital.dev`.
This PR does not by itself prove issue #24 fixed in production; it removes the deploy artifact blocker that prevented PR #26 from being safely verified.

## Remaining risks or follow-ups
A live Vercel deploy is still needed after merge to confirm the upload payload is clean.
A separate hardening PR may add `tsc -b --force` or artifact cleanup to the Vercel build command.
After a clean deploy is available, rerun the 4-cell HubSpot HMAC matrix and then verify portal 1969772 settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Exclude Local Artifacts from Vercel Uploads

## Problem

**Deployment Issue (irc4g8y8q):** 5,714 files were uploaded to Vercel, including:
- 3,815 local files from `.worktrees/` (development branches)
- Stale build artifacts from `packages/config/dist/` with pre-change ESM import syntax

**Runtime Failure:** Node cold-start module resolution failed with `ERR_MODULE_NOT_FOUND` due to extensionless ESM imports in the deployed package.

## Solution

Added root `.vercelignore` configuration to exclude local and stale artifacts from Vercel CLI uploads.

### Excluded Patterns

| Category | Patterns | Rationale |
|----------|----------|-----------|
| **Development** | `.worktrees/` | Local Git worktree directories |
| **Build Artifacts** | `**/dist/`, `**/build/`, `**/.next/`, `**/out/`, `**/*.tsbuildinfo` | Per-workspace and app build outputs |
| **Vercel Internal** | `.vercel/` | Vercel CLI metadata and build cache |
| **macOS Duplicates** | `**/* 2`, `**/* 2.*` | Finder duplicate file artifacts |
| **Local Secrets** | `.env`, `.env.local`, `.env.*.local` | Local environment variables |
| **Preserved** | `.env.example`, `.env.test.example` | Reference/test environment templates |

## Verification & Testing

✅ **Ignore Pattern Validation:** Tested using `ignore@5` (the same npm package used by Vercel CLI internally)
- **24/24 assertions passed** against exact artifact paths from the failing deployment
- **Verified source/config files not excluded** — required files remain uploadable
- **Git status clean** after commit

## Data Flow & Impact

```mermaid
graph TD
    A["Vercel Deploy Command"] -->|reads .vercelignore| B["File Filter"]
    B -->|excludes: .worktrees, dist, build, .env| C["Upload to Vercel"]
    C -->|clean file set| D["Deployment Success"]
    
    E["Local Development"] -->|creates artifacts| F[".worktrees, dist, build, .env files"]
    F -->|now filtered out| B
    
    style A fill:#e1f5ff
    style D fill:#c8e6c9
    style B fill:#fff9c4
```

## Traceability & Scope

| Item | Status | Notes |
|------|--------|-------|
| **Root Cause Fixed** | ✅ | Vercel CLI gitignore handling now respects anchored `/.worktrees/` and per-package patterns |
| **Code Changes** | ❌ None | No authentication, signature, or `apps/api/vercel.json` modifications |
| **Production Redeployment** | ⏳ Pending | Requires separate manual Vercel deploy after merge |
| **Issue #24 Closure** | ⏳ Pending | Live deployment will confirm cold-start fix in production |

## Follow-Up Actions (Post-Merge)

1. **Immediate:** Execute live Vercel deploy to validate clean artifact set
2. **Parallel:** Potential hardening PR (e.g., `tsc -b --force` to prevent stale artifacts)
3. **Validation:** Re-run HubSpot HMAC matrix tests and verify portal settings after clean deployment

## Lines Changed
- **+36 lines** (configuration only)
- **Code review effort:** Low

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a root `.vercelignore` so Vercel CLI stops uploading local worktrees, stale build outputs, macOS duplicates, and env files. This fixes the broken deploy caused by shipping stale `packages/config/dist` with extensionless ESM imports and unblocks safe verification.

- **Bug Fixes**
  - Excludes: `.worktrees/`, `**/dist/`, `**/build/`, `**/.next/`, `**/out/`, `**/*.tsbuildinfo`, `.vercel/`, `**/* 2`, `**/* 2.*`, `.env` (keeps `.env.example`, `.env.test.example`).
  - Verified patterns with `ignore` semantics; all checks passed and required sources remain included.

<sup>Written for commit 70155733a3e210db8a28c675cc44233f3e65914e. Summary will update on new commits. <a href="https://cubic.dev/pr/romeoman/hubspot-account-plan-app/pull/27?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

