### PR TITLE
fix(settings): normalize blank LLM endpoint URL on read

### DIFF
--- a/apps/api/src/lib/__tests__/settings-service.test.ts
+++ b/apps/api/src/lib/__tests__/settings-service.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createDatabase, llmConfig, providerConfig, tenants } from "@hap/db";
+import { settingsResponseSchema } from "@hap/validators";
 import { and, eq, like } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { __resetEncryptionCacheForTests, decryptProviderKey } from "../encryption";
@@ -76,6 +77,23 @@ describe("readSettings", () => {
         minConfidence: 0.5,
       },
     });
+  });
+
+  it("normalizes a blank endpoint_url so the response schema accepts it", async () => {
+    const tenant = await seedTenant();
+
+    await db.insert(llmConfig).values({
+      tenantId: tenant.id,
+      providerName: "openai",
+      modelName: "gpt-5.4-mini",
+      apiKeyEncrypted: null,
+      endpointUrl: "",
+    });
+
+    const settings = await readSettings({ db, tenantId: tenant.id });
+
+    expect(settings.llm.endpointUrl).toBeUndefined();
+    expect(() => settingsResponseSchema.parse(settings)).not.toThrow();
   });
 });
 

--- a/apps/api/src/lib/settings-service.ts
+++ b/apps/api/src/lib/settings-service.ts
@@ -163,7 +163,7 @@ export async function readSettings(deps: SettingsServiceDeps): Promise<SettingsR
     llm: {
       provider: (llmRow?.providerName as LlmProviderType | undefined) ?? null,
       model: llmRow?.modelName ?? "",
-      endpointUrl: llmRow?.endpointUrl ?? undefined,
+      endpointUrl: llmRow?.endpointUrl || undefined,
       hasApiKey: !!llmRow?.apiKeyEncrypted,
     },
     eligibility: {


### PR DESCRIPTION
## Summary

- Normalizes blank stored LLM endpoint URLs on settings reads.
- Adds a regression test proving the read model remains compatible with `settingsResponseSchema`.

## Root cause

`readSettings` used `llmRow?.endpointUrl ?? undefined`, which allowed `""` from legacy / out-of-band `llm_config` rows to pass through unchanged. `settingsResponseSchema` requires `endpointUrl` to be either omitted/`undefined` or a valid URL (`z.string().url().optional()`), so a stored empty string rejects an otherwise valid settings response at the route layer.

## What changed

- `apps/api/src/lib/settings-service.ts:166` — `readSettings` now returns `undefined` for blank `endpointUrl` values (`?? undefined` → `|| undefined`). Single-operator change inside the existing return shape.
- `apps/api/src/lib/__tests__/settings-service.test.ts` — DB-backed regression test that seeds `llm_config.endpoint_url = ""` directly, calls `readSettings`, asserts `endpointUrl` is `undefined`, and parses the response through `settingsResponseSchema` to confirm acceptance.

Diff: `2 files changed, 19 insertions(+), 1 deletion(-)`.

## Verification

- `pnpm vitest run apps/api/src/lib/__tests__/settings-service.test.ts` → **9/9 passed**
- `pnpm vitest run apps/api/src/routes/__tests__/settings.test.ts` → **10/10 passed**
- `pnpm typecheck` → passed
- `git diff --check` → clean
- Code review: **zero Critical / Important findings** (independent reviewer confirmed correctness, narrow scope, no tenant-isolation or schema-contract risk)

TDD red → green cycle was honored: the regression test was written first, watched fail with `expected '' to be undefined`, then fixed.

## Scope / non-goals

- Does not change `updateSettings` write behavior.
- Does not add DB constraints for non-empty invalid endpoint URLs.
- Does not touch issue #17 lanes or HubSpot registration / runtime code.

## Remaining risks or follow-ups

- Non-empty but invalid `endpoint_url` values would still fail schema validation; out of scope for this narrow read-side hardening.
- DB-level cleanup or a `CHECK` constraint can be considered separately if such values are observed in practice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes blank LLM endpoint URLs to undefined in `readSettings` so responses pass `settingsResponseSchema` and avoid route validation errors. Adds a DB-backed regression test that seeds `llm_config.endpoint_url = ""` and asserts `undefined` is returned.

<sup>Written for commit 5fd8b1a299c82ea46abe562f07432b55acaff985. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Normalize Blank LLM Endpoint URLs on Read

## Release Notes

### Breaking Changes
None

### New Features
None

### Bug Fixes
- **Fixed schema validation failure when reading settings with blank LLM endpoint URLs**
  - Legacy `llm_config` rows stored with empty string (`""`) for `endpointUrl` now normalize to `undefined` when read
  - Prevents HTTP 500 errors from invalid settings responses at the API layer
  - Restores compatibility with existing stored configurations

### How It Works

**Problem:** Empty string values in database weren't being converted to `undefined`, causing schema validation failures
- **Before:** `llmRow?.endpointUrl ?? undefined` → passes `""` through (nullish coalescing only checks `null`/`undefined`)
- **After:** `llmRow?.endpointUrl || undefined` → converts `""` to `undefined` (logical OR treats all falsy values)

---

## Data Flow & Architecture

### Settings Read Path (Before vs. After)

```mermaid
graph TD
    A["llm_config row<br/>endpointUrl = ''"] -->|readSettings| B{"Before: ?? operator"}
    B -->|passes '' through| C["Response: endpointUrl = ''"]
    C -->|settingsResponseSchema.parse| D["❌ Validation Error<br/>z.string().url().optional<br/>rejects empty string"]
    
    A -->|readSettings| E{"After: || operator"}
    E -->|converts '' to undefined| F["Response: endpointUrl = undefined"]
    F -->|settingsResponseSchema.parse| G["✅ Validation Pass<br/>optional() accepts undefined"]
    
    style D fill:#ffcccc
    style G fill:#ccffcc
```

### Key Code Change

```
File: apps/api/src/lib/settings-service.ts (1 line)

BEFORE:
  endpointUrl: llmRow?.endpointUrl ?? undefined

AFTER:
  endpointUrl: llmRow?.endpointUrl || undefined
```

---

## Testing & Verification

### Test Coverage (Key to Quality Assurance)

**✅ New Regression Test Added** (`apps/api/src/lib/__tests__/settings-service.test.ts`)
- **Test Name:** "normalizes a blank endpoint_url so the response schema accepts it"
- **Database-Backed:** Seeds actual `llm_config` row with `endpointUrl: ""`
- **Coverage:**
  - ✓ Inserts legacy blank endpoint URL into database
  - ✓ Calls `readSettings()` to simulate real read path
  - ✓ Asserts `settings.llm.endpointUrl === undefined` (normalization)
  - ✓ Validates response against `settingsResponseSchema` (schema compliance)

### Validation Points

| Layer | Validation | Status |
|-------|-----------|--------|
| **Unit Tests** | `apps/api` test suite | 9/9 ✅ |
| **Integration** | Settings route tests | 10/10 ✅ |
| **Schema** | `settingsResponseSchema.parse()` | ✅ |
| **Type Check** | TypeScript compilation | ✅ |
| **Lint** | `git diff --check` | ✅ |
| **Code Review** | Independent review | ✅ |

---

## Impact & Scope

### Changes Made
- **Modified:** 1 operator in `readSettings()` (1 line changed)
- **Added:** 1 regression test with schema validation (18 lines)
- **Total:** 2 files, 19 insertions, 1 deletion

### What This Does NOT Change
- ❌ Does NOT affect `updateSettings()` write behavior
- ❌ Does NOT add database constraints
- ❌ Does NOT validate non-empty invalid URLs (separate follow-up)
- ❌ Does NOT modify schema definitions

### Backwards Compatibility
✅ **Fully Compatible**
- Existing API contracts unchanged
- Settings read responses remain same shape
- Only blank URLs normalized to `undefined` (valid per schema)
- Non-blank values unaffected

---

## Follow-Up Work (Out of Scope)
- Database cleanup for existing blank `endpointUrl` values
- Database constraint to prevent empty strings on `llm_config.endpoint_url`
- Validation of non-empty invalid URL formats (e.g., malformed strings)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->