### PR TITLE
chore(seed): wire seed:test-portal scripts and publish seed plan

### DIFF
--- a/docs/qa/test-portal-seed-plan.md
+++ b/docs/qa/test-portal-seed-plan.md
@@ -1,0 +1,137 @@
+# Test Portal Seed Plan — V1 MVP Validation
+
+This is the canonical reference for how the V1 HubSpot test portal is seeded
+to validate the eight QA states the `crm.record.tab` extension must render.
+For the operator-facing run procedure, see the per-slice walkthroughs:
+
+- `docs/qa/slice-2-walkthrough.md` (Slice 2 live integration)
+- `docs/qa/slice-5-pilot-walkthrough.md` (Slice 5 pilot smoke)
+
+## Why this exists
+
+The CLAUDE.md root rule:
+
+> Use a separate HubSpot developer or configurable test account for the first
+> real validation. Populate it with mock CRM company/contact data before
+> claiming the extension works end-to-end. Include at least one target account
+> using `hs_is_target_account` and records that exercise strong-evidence,
+> fewer-than-3-contacts, empty, stale, degraded, and ineligible states.
+
+This plan operationalizes that rule: a single `pnpm seed:test-portal` run
+materializes one company plus 0–3 contacts per QA state in the configured
+test portal, idempotently, with no fabricated evidence.
+
+## Dataset (eight states, eight companies)
+
+Source of truth: `buildSeedTargets()` in
+`scripts/seed-hubspot-test-portal.ts`. Property shapes intentionally mirror
+the in-memory fixtures in `packages/config/src/factories.ts` so the rendered
+state-semantics match the unit-test fixture semantics 1:1.
+
+| QA State        | Company Name (idempotency key)   | Domain                       | `hs_is_target_account` | Contacts | Expected card render                                           |
+| --------------- | -------------------------------- | ---------------------------- | ---------------------- | -------- | -------------------------------------------------------------- |
+| eligible-strong | `Slice2-EligibleStrong-AcmeCorp` | `slice2-acme.example.com`    | `true`                 | 3        | Reason-to-contact + 3 people cards + full evidence drill-in    |
+| fewer-contacts  | `Slice2-FewerContacts-BetaInc`   | `slice2-beta.example.com`    | `true`                 | 1        | Reason-to-contact + 1 person + explicit "fewer contacts" note  |
+| empty           | `Slice2-Empty-GammaCo`           | `slice2-gamma.example.com`   | `true`                 | 0        | "No credible reason to contact this account now" empty state   |
+| stale           | `Slice2-Stale-DeltaLLC`          | `slice2-delta.example.com`   | `true`                 | 1        | Stale-warning alert; reason rendered but annotated stale       |
+| degraded        | `Slice2-Degraded-EpsilonGmbH`    | `slice2-epsilon.example.com` | `true`                 | 1        | Degraded-source badge; partial evidence allowed                |
+| low-confidence  | `Slice2-LowConfidence-ZetaSA`    | `slice2-zeta.example.com`    | `true`                 | 1        | Caution alert + confidence score in trust breakdown            |
+| ineligible      | `Slice2-Ineligible-EtaPLC`       | `slice2-eta.example.com`     | `false`                | 1        | "Not a target account" suppression — reason NOT rendered       |
+| restricted      | `Slice2-Restricted-ThetaInc`     | `slice2-theta.example.com`   | `true`                 | 1        | Empty-with-zero-leakage — NO evidence text, NO reason rendered |
+
+Idempotency marker: every company name starts with `Slice2-`. The seed
+searches `name CONTAINS_TOKEN "Slice2*"` on rerun and updates rather than
+duplicates. Contacts are deduplicated by email (HubSpot enforces email
+uniqueness server-side).
+
+### What the dataset deliberately does NOT do
+
+- **No evidence is written.** The seed touches only Companies and Contacts.
+  Evidence rows live in app Postgres and are produced by adapters
+  (`apps/api/src/adapters/signal/`) at runtime. The seed never calls Exa,
+  Firecrawl, or any LLM.
+- **No custom company/contact properties are created.** Idempotency uses the
+  standard `name` property prefix so the dev token does not need
+  `crm.schemas.companies.write`.
+- **No filler people.** When a state expects 0 or 1 contact, the seed never
+  pads to 3 — fabricated contacts would violate the V1 wedge rule.
+- **No tenant or LLM config seeding.** Those are tenant-isolated and come
+  from the OAuth install flow + per-tenant settings UI.
+
+## Seeding surface
+
+The seed talks directly to the HubSpot CRM v3/v4 REST API via the existing
+`HubSpotClient` (`apps/api/src/lib/hubspot-client.ts`). Auth resolves a
+per-tenant OAuth token from the local `tenant_hubspot_oauth` table:
+
+1. Operator runs `hs auth` (or completes the in-app OAuth install flow)
+   against the test portal so a tenant row exists.
+2. Operator runs `pnpm seed:test-portal --portal <portalId>`.
+3. The script reads `tenants` by `hubspotPortalId`, instantiates a tenant-
+   bound client, and issues `companies/search` + `companies` + `contacts`
+   - `associations/default/contacts/{id}` calls.
+
+The script is a no-op without `--portal` / `HUBSPOT_TEST_PORTAL_ID` unless
+`--dry-run` is passed; dry-run mode runs entirely offline (no DB, no HTTP)
+and just prints the planned operations.
+
+## How to run
+
+### Prerequisites
+
+- Test portal installed via the dev OAuth callback (a row exists in
+  `tenants` with the matching `hubspot_portal_id`).
+- `DATABASE_URL` set in `.env` (or `.env.test`) so the script can resolve
+  the per-tenant token.
+- `pnpm install` has been run at the repo root.
+
+### Commands
+
+```bash
+# 1. Verify the plan offline (no token, no DB, no HTTP).
+pnpm seed:test-portal:dry
+
+# 2. Authenticate the HubSpot CLI against the test portal.
+hs auth
+hs accounts list   # confirm the test portal id is listed
+
+# 3. Run the live seed (idempotent).
+pnpm seed:test-portal --portal <testPortalId>
+# or, with HUBSPOT_TEST_PORTAL_ID set in .env:
+pnpm seed:test-portal
+```
+
+The dry-run prints eight `[seed] create ...` lines. The live run prints a
+pipe-delimited `| QA State | Company Name | Company ID | Contact IDs |`
+table that you paste into `docs/qa/slice-2-walkthrough.md` for the
+per-state checklist.
+
+### Re-running
+
+Safe. Re-run flips every row from `create` to `update` (matched by name).
+Contacts dedupe by email server-side. To force a clean reset, archive the
+eight `Slice2-*` companies in the HubSpot UI first.
+
+## Tests
+
+Pure helpers (`buildSeedTargets`, `buildSeedPlan`, `executeSeedPlan`,
+`parseArgs`, `runSeed`) are covered by
+`scripts/__tests__/seed-hubspot-test-portal.test.ts`. The tests stub the
+`SeedHubSpotClient` interface — no network calls during `pnpm test`.
+
+Run:
+
+```bash
+pnpm test scripts/__tests__/seed-hubspot-test-portal.test.ts
+```
+
+Acceptance asserts in the suite:
+
+- exactly 8 targets, one per QA state (covers the CLAUDE.md rule)
+- every name carries the `Slice2-` idempotency prefix
+- ineligible target sets `hs_is_target_account=false`
+- empty target has zero contacts, eligible-strong has three
+- `buildSeedPlan` flips rows to `update` when the marker search returns them
+- `executeSeedPlan` does not call `createCompany` on the update path
+- `runSeed --dry-run` constructs no client and tolerates a missing token
+- `runSeed` without `--portal` and without `--dry-run` throws clearly

--- a/docs/qa/test-portal-seed-plan.md
+++ b/docs/qa/test-portal-seed-plan.md
@@ -102,7 +102,8 @@ hs accounts list   # confirm the test portal id is listed
 
 # 3. Run the live seed (idempotent).
 pnpm seed:test-portal --portal <testPortalId>
-# or, with HUBSPOT_TEST_PORTAL_ID set in .env:
+# or, with HUBSPOT_TEST_PORTAL_ID exported in your shell
+# (or wrapped via `pnpm dlx dotenv-cli -e .env --` per the prereqs above):
 pnpm seed:test-portal
 ```
 

--- a/docs/qa/test-portal-seed-plan.md
+++ b/docs/qa/test-portal-seed-plan.md
@@ -68,8 +68,8 @@ per-tenant OAuth token from the local `tenant_hubspot_oauth` table:
    against the test portal so a tenant row exists.
 2. Operator runs `pnpm seed:test-portal --portal <portalId>`.
 3. The script reads `tenants` by `hubspotPortalId`, instantiates a tenant-
-   bound client, and issues `companies/search` + `companies` + `contacts`
-   - `associations/default/contacts/{id}` calls.
+   bound client, and issues calls to `companies/search`, `companies`,
+   `contacts`, and `associations/default/contacts/{id}`.
 
 The script is a no-op without `--portal` / `HUBSPOT_TEST_PORTAL_ID` unless
 `--dry-run` is passed; dry-run mode runs entirely offline (no DB, no HTTP)
@@ -81,8 +81,13 @@ and just prints the planned operations.
 
 - Test portal installed via the dev OAuth callback (a row exists in
   `tenants` with the matching `hubspot_portal_id`).
-- `DATABASE_URL` set in `.env` (or `.env.test`) so the script can resolve
-  the per-tenant token.
+- `DATABASE_URL` exported in your shell so the script can resolve the
+  per-tenant token. The seed script reads `process.env` directly and does
+  NOT load `.env` files automatically. Either:
+  - export the variables in your shell:
+    `export DATABASE_URL=...` (and any other vars), or
+  - prefix the command with a dotenv loader, e.g.:
+    `pnpm dlx dotenv-cli -e .env -- pnpm seed:test-portal --portal <id>`.
 - `pnpm install` has been run at the repo root.
 
 ### Commands

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "db:generate": "pnpm --filter @hap/db run generate",
     "db:migrate": "pnpm --filter @hap/db run migrate",
     "db:studio": "pnpm --filter @hap/db run studio",
+    "seed:test-portal": "tsx scripts/seed-hubspot-test-portal.ts",
+    "seed:test-portal:dry": "tsx scripts/seed-hubspot-test-portal.ts --dry-run",
     "typecheck": "tsc --build",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary

Wires the previously-drafted `seed:test-portal` scripts into `package.json` and publishes the canonical 8-state seed plan doc. Implements Task 2 / Wave A of `.claude/tasks/2026-05-10-mvp-deployment-readiness.md`.

The seed implementation (`scripts/seed-hubspot-test-portal.ts`) and its helper tests (`scripts/__tests__/seed-hubspot-test-portal.test.ts`) already exist on `main` — this PR only adds workspace command-surface wiring and the operator-facing doc.

## Files changed

`git diff origin/main..HEAD --name-only` shows **exactly 2 files**:

```
docs/qa/test-portal-seed-plan.md
package.json
```

Diff: `+139, -0` (137 new lines for the doc + 2 new lines for the scripts).

## Verification

### `pnpm test scripts/__tests__/seed-hubspot-test-portal.test.ts`

```
 RUN  v4.1.4 /Users/romeoman/Documents/Dev/HubSpot/Account Plan App/.claude/worktrees/seed-test-portal-wiring

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  20:28:47
   Duration  382ms (transform 79ms, setup 20ms, import 281ms, tests 6ms, environment 0ms)
```

15/15 green. No regression on the existing seed helpers.

### `pnpm seed:test-portal:dry`

```
> tsx scripts/seed-hubspot-test-portal.ts --dry-run

[seed] dry-run: planned operations
[seed] create eligible-strong  Slice2-EligibleStrong-AcmeCorp contacts=3
[seed] create fewer-contacts   Slice2-FewerContacts-BetaInc contacts=1
[seed] create empty            Slice2-Empty-GammaCo contacts=0
[seed] create stale            Slice2-Stale-DeltaLLC contacts=1
[seed] create degraded         Slice2-Degraded-EpsilonGmbH contacts=1
[seed] create low-confidence   Slice2-LowConfidence-ZetaSA contacts=1
[seed] create ineligible       Slice2-Ineligible-EtaPLC contacts=1
[seed] create restricted       Slice2-Restricted-ThetaInc contacts=1
```

Exit 0. All 8 QA states printed. No HTTP traffic (offline).

### `pnpm typecheck`

```
> tsc --build
```

Exit 0, no errors.

### `pnpm lint`

```
Checked 231 files in 44ms. No fixes applied.
Found 5 warnings.
```

Exit 0. The 5 warnings are pre-existing on `main` (non-null assertions in `apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts`) and are not introduced by this PR.

## Plan reference

Task 2 / Wave A of `.claude/tasks/2026-05-10-mvp-deployment-readiness.md`. Companion Wave A PR is the lifecycle observability fix (#19) on `chore/lifecycle-observability-19`.

## Test plan

- [x] `pnpm test scripts/__tests__/seed-hubspot-test-portal.test.ts` — 15/15 green
- [x] `pnpm seed:test-portal:dry` — 8 planned ops, exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm lint` — exit 0 (no new warnings)
- [x] `git diff origin/main..HEAD --name-only` — exactly 2 files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `seed:test-portal` and `seed:test-portal:dry` scripts for idempotent HubSpot test portal seeding (live or dry-run) and publishes the canonical 8‑state seed plan for QA. The doc clarifies the script reads `process.env` only—export `DATABASE_URL` or use `dotenv-cli`—and updates the run-commands example to match that requirement.

<sup>Written for commit 3485a35601aa2558e6a76864431b8d9b35ccd3f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Test Portal Seed Plan Wiring & Documentation

## Release Notes

- Added workspace scripts to run HubSpot test-portal seeding:
  - pnpm seed:test-portal — live seeding (requires DATABASE_URL + portal id / auth)
  - pnpm seed:test-portal:dry — offline dry-run (no DB, no HTTP, exit 0)
- Added canonical operator-facing seed plan:
  - docs/qa/test-portal-seed-plan.md — "Test Portal Seed Plan — V1 MVP Validation"
  - Documents the canonical 8 QA states, idempotency rules, operator workflow, run examples, and acceptance assertions
- Clarified operator prerequisites and environment handling:
  - Script reads process.env directly (export DATABASE_URL or prefix with dotenv-cli); it does NOT auto-load .env files
- No code-functional changes to seeding logic in this PR — only package.json wiring + documentation

## Key bullets — what this provides (concise)
- Canonical dataset: eight companies (Slice2- prefix) mapping to QA states:
  - eligible-strong, fewer-contacts, empty, stale, degraded, low-confidence, ineligible, restricted
- Company/contact shapes and expected UI render behavior documented per-state
- Idempotency:
  - Company discovery via name CONTAINS "Slice2*" marker
  - Contacts deduplicated by email (HubSpot server-side)
  - Re-runs perform update (create→update); archive Slice2-* companies to force clean reset
- Operator workflow:
  - 1) pnpm seed:test-portal:dry — offline verification (prints planned operations)
  - 2) hs auth / confirm portal in tenants table
  - 3) pnpm seed:test-portal --portal <id> (or export HUBSPOT_TEST_PORTAL_ID)
- Boundaries:
  - Seed touches only Companies & Contacts; no evidence writes, no custom property creation, no filler contacts, no tenant/LLM config seeding

## Seeding Data Flow (Mermaid)
```mermaid
graph LR
  Op["Operator<br/>pnpm seed:test-portal<br/>(--portal / HUBSPOT_TEST_PORTAL_ID)"] -->|env: DATABASE_URL<br/>optional HUBSPOT token| Script["seed-hubspot-test-portal.ts<br/>(reads process.env)"]
  Script -->|read tenant| DB["DB: tenants table (hubspot_portal_id match)"]
  Script -->|--dry-run (no client)| Dry["Offline: construct plan, print slices, exit 0"]
  DB -->|fetch token| Hub["HubSpotClient (CRM REST)"]
  Hub -->|companies/search| Search["Check for Slice2- prefix"]
  Search -->|not found| Create["Create 8 companies & contacts"]
  Search -->|found| Update["Update existing companies (idempotent)"]
  Create --> End["Test Portal State: 8 QA slices"]
  Update --> End

  style Op fill:#e6f7ff
  style Script fill:#fff7e6
  style DB fill:#f3e5f5
  style Hub fill:#e8f5e9
  style End fill:#fff0f6
```

## Testing Guarantees & Traceability (sacred DD)
- Automated coverage:
  - scripts/__tests__/seed-hubspot-test-portal.test.ts — 15 unit tests (helpers stubbed; no network)
  - Acceptance asserts: 8 targets; name prefix presence; contact cardinalities; create→update behavior; dry-run=no-HTTP; missing token tolerated in dry-run
- Operator & audit traceability:
  - Deterministic idempotency marker: company names = Slice2-<State>-<Marker>
  - Live-run prints a pipe-delimited table: QA State | Company Name | Company ID | Contact IDs for pasting into walkthrough docs
  - Tests assert core property values (e.g., hs_is_target_account) to map seed ↔ expected UI behavior

## Verification performed (before merge)
- pnpm test scripts/__tests__/seed-hubspot-test-portal.test.ts — 15/15 passed
- pnpm seed:test-portal:dry — printed 8 QA states; exit 0; no HTTP traffic
- pnpm typecheck — tsc build exit 0
- pnpm lint — exit 0 (5 pre-existing warnings on main)
- git diff origin/main..HEAD --name-only — exactly two files changed

## Design & operational rationale (traceable)
- Separate dry-run and live-run to minimize accidental live changes and allow offline verification.
- Limit scope to Companies & Contacts to minimize permission surface and avoid side-effects (no evidence or schema writes).
- Use name-prefix + email dedupe for reliable, auditable idempotency across runs.
- Require explicit env exports (no implicit .env loading) so environment provenance is clear in operator logs and CI.

## Impact Summary
- Files changed: 2 (docs/qa/test-portal-seed-plan.md, package.json)
- Lines added: +139 (doc + package.json wiring)
- Tests affected: none; 15 seed helper tests remain green
- Code review effort: Low — documentation + script wiring only
- Breaking changes: None

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romeoman/hubspot-account-plan-app/pull/32)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->