### PR TITLE
fix(lifecycle): emit request-arrival and applied/ignored logs (closes #19)

### DIFF
--- a/apps/api/src/__tests__/lifecycle-logging.test.ts
+++ b/apps/api/src/__tests__/lifecycle-logging.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for lifecycle observability logs (issue #19).
+ *
+ * Contract: docs/slice-12-preflight-notes.md §1. The receiver MUST emit:
+ *   1. `console.log("hubspot-lifecycle-webhook: request received")` at
+ *      handler entry, before signature/timestamp header reads.
+ *   2. `console.log(`hubspot-lifecycle-webhook: applied=N ignored=N
+ *      portalIds=<comma-joined>`)` after the for-loop close, before the
+ *      return.
+ *
+ * portalIds are collected only on the applied path. Ignored events
+ * (unknown eventTypeId, missing portalId) MUST NOT contribute to the list.
+ *
+ * Order MUST be request-arrival first, summary second.
+ *
+ * Intentionally DB-free: `applyHubSpotLifecycleEvent` is mocked so the
+ * receiver's log-emission contract can be verified independently of the
+ * Postgres pool that the broader test suite depends on. This keeps the log
+ * assertions fast and deterministic, and avoids coupling observability
+ * coverage to a reachable database.
+ */
+import { createHmac } from "node:crypto";
+import { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/tenant-lifecycle.js", () => ({
+  applyHubSpotLifecycleEvent: vi.fn(async () => {}),
+}));
+
+// Import AFTER the mock so the receiver picks up the mocked function.
+const { lifecycleWebhookRoutes } = await import("../routes/lifecycle");
+
+const LIFECYCLE_EVENT_TYPE_INSTALL = "4-1909196";
+
+const TEST_CLIENT_SECRET = process.env.HUBSPOT_CLIENT_SECRET ?? "";
+if (TEST_CLIENT_SECRET.length === 0) {
+  throw new Error(
+    "lifecycle-logging.test.ts requires HUBSPOT_CLIENT_SECRET (seeded by vitest.setup.ts)",
+  );
+}
+
+function buildApp() {
+  const app = new Hono();
+  // The receiver only touches `deps.db` indirectly via the (now mocked)
+  // applyHubSpotLifecycleEvent, so an empty object is a sufficient stand-in.
+  app.route(
+    "/webhooks/hubspot/lifecycle",
+    // biome-ignore lint/suspicious/noExplicitAny: db is unused due to module mock
+    lifecycleWebhookRoutes({ db: {} as any }),
+  );
+  return app;
+}
+
+function signV3(params: {
+  clientSecret: string;
+  method: string;
+  url: string;
+  body: string;
+  timestamp: number;
+}): string {
+  const raw = `${params.method}${decodeURIComponent(params.url)}${params.body}${params.timestamp}`;
+  return createHmac("sha256", params.clientSecret).update(raw, "utf8").digest("base64");
+}
+
+async function postLifecycleRequest(events: Array<Record<string, unknown>>) {
+  const app = buildApp();
+  const url = "http://localhost/webhooks/hubspot/lifecycle";
+  const body = JSON.stringify(events);
+  const timestamp = Date.now();
+  const signature = signV3({
+    clientSecret: TEST_CLIENT_SECRET,
+    method: "POST",
+    url,
+    body,
+    timestamp,
+  });
+
+  return app.request(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-hubspot-signature-v3": signature,
+      "x-hubspot-request-timestamp": String(timestamp),
+    },
+    body,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST /webhooks/hubspot/lifecycle — observability logs (issue #19)", () => {
+  it("emits a request-arrival log and an applied/ignored summary log for an applied event", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const pid = "146425426";
+
+    const res = await postLifecycleRequest([
+      {
+        eventId: 1,
+        subscriptionId: 123,
+        portalId: pid,
+        appId: 12345,
+        occurredAt: Date.now(),
+        subscriptionType: "APP_LIFECYCLE_EVENT",
+        attemptNumber: 0,
+        eventTypeId: LIFECYCLE_EVENT_TYPE_INSTALL,
+        sourceId: "source-1",
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    expect(spy.mock.calls[0]?.[0]).toBe("hubspot-lifecycle-webhook: request received");
+
+    const summary = spy.mock.calls[1]?.[0] as string;
+    expect(summary).toMatch(
+      /^hubspot-lifecycle-webhook: applied=\d+ ignored=\d+ portalIds=[\d,]*$/,
+    );
+    expect(summary).toBe(`hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=${pid}`);
+  });
+
+  it("emits the summary log with empty portalIds when the event is ignored (missing portalId)", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const res = await postLifecycleRequest([
+      {
+        eventId: 2,
+        subscriptionId: 123,
+        // No portalId — receiver MUST count as ignored and MUST NOT push
+        // anything to portalIds.
+        appId: 12345,
+        occurredAt: Date.now(),
+        subscriptionType: "APP_LIFECYCLE_EVENT",
+        attemptNumber: 0,
+        eventTypeId: LIFECYCLE_EVENT_TYPE_INSTALL,
+        sourceId: "source-1",
+      },
+    ]);
+
+    expect(res.status).toBe(200);
+    // Two console.log calls (arrival + summary). The existing
+    // `event missing portalId` warning goes through `console.warn`, not
+    // `console.log`, so it does not show up in this spy.
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    expect(spy.mock.calls[0]?.[0]).toBe("hubspot-lifecycle-webhook: request received");
+
+    const summary = spy.mock.calls[1]?.[0] as string;
+    expect(summary).toBe("hubspot-lifecycle-webhook: applied=0 ignored=1 portalIds=");
+  });
+});

--- a/apps/api/src/routes/lifecycle.ts
+++ b/apps/api/src/routes/lifecycle.ts
@@ -92,6 +92,8 @@ export function lifecycleWebhookRoutes(deps: LifecycleWebhookDeps): Hono {
   const app = new Hono();
 
   app.post("/", async (c) => {
+    console.log("hubspot-lifecycle-webhook: request received");
+
     const signature = c.req.header(SIGNATURE_HEADER);
     const timestampRaw = c.req.header(TIMESTAMP_HEADER);
 
@@ -132,6 +134,7 @@ export function lifecycleWebhookRoutes(deps: LifecycleWebhookDeps): Hono {
 
     let applied = 0;
     let ignored = 0;
+    const portalIds: string[] = [];
 
     for (const event of events) {
       const eventType = mapEventTypeId(event?.eventTypeId);
@@ -162,7 +165,12 @@ export function lifecycleWebhookRoutes(deps: LifecycleWebhookDeps): Hono {
       });
 
       applied += 1;
+      portalIds.push(portalId);
     }
+
+    console.log(
+      `hubspot-lifecycle-webhook: applied=${applied} ignored=${ignored} portalIds=${portalIds.join(",")}`,
+    );
 
     return c.json({ received: events.length, applied, ignored }, 200);
   });

--- a/docs/runbooks/slice-11-dev-quickstart.md
+++ b/docs/runbooks/slice-11-dev-quickstart.md
@@ -132,27 +132,31 @@ subscriptions are registered.
 1. In the HubSpot developer UI, open the app's "Install URL" for your dev
    test portal (a non-production portal you own).
 2. Approve the requested scopes.
-3. Tail your receiver logs. You should see, within a few seconds, a line
-   like:
+3. Tail your receiver logs. You should see, within a few seconds, two
+   lines per delivery — one as the request arrives and one summarising
+   what was applied vs. ignored:
 
    ```
-   [lifecycle] APP_INSTALL received portalId=<id> timestamp=<iso>
+   hubspot-lifecycle-webhook: request received
+   hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=<id>
    ```
 
-4. Record that log line (redact nothing — `portalId` and timestamp are
-   safe to share; no secrets are emitted by the Slice 7 receiver).
+4. Record both lines (redact nothing — `portalId` and the applied/ignored
+   counts are safe to share; no secrets are emitted by the Slice 7
+   receiver).
 
 ### 4.3 Uninstall
 
 1. In the dev test portal, go to Settings → Connected apps → your app →
    Uninstall.
-2. Tail the receiver logs. Expect:
+2. Tail the receiver logs. Expect the same two-line pattern as install:
 
    ```
-   [lifecycle] APP_UNINSTALL received portalId=<id> timestamp=<iso>
+   hubspot-lifecycle-webhook: request received
+   hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=<id>
    ```
 
-3. Record that log line.
+3. Record both lines.
 
 Two bootstrap reports + two receiver log lines = verification evidence
 called for in the Slice 11 dev operationalization plan, acceptance

--- a/docs/runbooks/slice-11-dev-quickstart.md
+++ b/docs/runbooks/slice-11-dev-quickstart.md
@@ -136,7 +136,7 @@ subscriptions are registered.
    lines per delivery — one as the request arrives and one summarising
    what was applied vs. ignored:
 
-   ```
+   ```text
    hubspot-lifecycle-webhook: request received
    hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=<id>
    ```
@@ -151,7 +151,7 @@ subscriptions are registered.
    Uninstall.
 2. Tail the receiver logs. Expect the same two-line pattern as install:
 
-   ```
+   ```text
    hubspot-lifecycle-webhook: request received
    hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=<id>
    ```


### PR DESCRIPTION
## Summary

Implements Wave A / Task 1 from `.claude/tasks/2026-05-10-mvp-deployment-readiness.md`. Closes the observability gap behind issue #19 by emitting two `console.log` lines from the lifecycle webhook receiver so operators can disambiguate "HubSpot didn't deliver" from "HubSpot delivered and we silently 200'd" in Vercel function logs.

## Contract

Binding shape from `docs/slice-12-preflight-notes.md` §1 (already on `main`):

- Request-arrival log at handler entry (literal): `hubspot-lifecycle-webhook: request received`
- Applied/ignored summary log after the for-loop closes (template): `hubspot-lifecycle-webhook: applied=N ignored=N portalIds=<comma-joined>`

`portalIds` is collected only on the applied path. Ignored events (unknown `eventTypeId`, missing `portalId`) MUST NOT contribute to the list. Order MUST be arrival → summary.

## Redaction posture

Per `docs/slice-12-preflight-notes.md` §2: INCLUDE `portalId`, `applied`, `ignored`. EXCLUDE timestamp, `eventTypeId`, per-event detail. NEVER LOG raw body, `x-hubspot-signature-v3`, tokens, or `client_secret`.

## Worked example (one APP_INSTALL delivery)

```
hubspot-lifecycle-webhook: request received
hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=146425426
```

## Files changed

Exactly 3 files (no scope creep):

- `apps/api/src/routes/lifecycle.ts` — adds the two `console.log` lines and the `portalIds: string[]` accumulator. No other behavior change.
- `apps/api/src/__tests__/lifecycle-logging.test.ts` — new failing-test-first Vitest covering both the applied path (1/0/`<pid>`) and the missing-portalId ignored path (0/1/empty). DB-free via `vi.mock` on `applyHubSpotLifecycleEvent`, so the log contract holds even without a reachable Postgres pool.
- `docs/runbooks/slice-11-dev-quickstart.md` — replaces the never-emitted `[lifecycle] APP_INSTALL received portalId=<id> timestamp=<iso>` example at line 139 with the actual two-line shape; same fix for APP_UNINSTALL at line 152.

## TDD evidence

Failing-test-first cycle followed. The initial run of `pnpm test apps/api/src/__tests__/lifecycle-logging.test.ts` against the unmodified receiver produced:

```
AssertionError: expected "log" to be called 2 times, but got 0 times
 ❯ apps/api/src/__tests__/lifecycle-logging.test.ts:115:17  (test 1)
 ❯ apps/api/src/__tests__/lifecycle-logging.test.ts:152:17  (test 2)
```

After adding the two `console.log` lines to `apps/api/src/routes/lifecycle.ts`, the same test run reports:

```
Test Files  1 passed (1)
     Tests  2 passed (2)
```

## Verification

All three commands run from worktree root, all green:

- `pnpm test apps/api` → `Test Files 53 passed (53)`, `Tests 533 passed (533)` (full backend suite)
- `pnpm typecheck` → `tsc --build` exits 0, no output
- `pnpm lint` → exits 0; 5 pre-existing warnings in unrelated test files (`factory.test.ts`, `hubspot-subscription-bootstrap.test.ts`) are untouched by this change

## Runbook sweep

`grep -rn "lifecycle] APP_INSTALL received\|lifecycle] APP_UNINSTALL received" docs apps packages scripts` → zero hits. The only orphan references remaining are inside `.claude/tasks/2026-05-10-mvp-deployment-readiness.md`, which describes the change descriptively (not as live runbook guidance).

## Test plan

- [x] `pnpm test apps/api` green (533/533)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new errors/warnings introduced)
- [x] Failing-test-first cycle documented above
- [x] Runbook line numbers verified before edit; new shape matches receiver output exactly
- [ ] Operator confirms live Vercel logs show the two lines per delivery (Phase 2 walkthrough, post-merge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit two logs from the HubSpot lifecycle webhook so operators can tell “no delivery” vs “delivered and applied” in Vercel logs. Closes #19.

- Bug Fixes
  - Log on request arrival: "hubspot-lifecycle-webhook: request received".
  - Log summary after processing: "hubspot-lifecycle-webhook: applied=N ignored=N portalIds=<comma-joined>"; only applied events contribute; order is arrival → summary.
  - Added apps/api/src/__tests__/lifecycle-logging.test.ts to verify both logs and ordering via a mocked apply function.
  - Updated docs/runbooks/slice-11-dev-quickstart.md to show the two-line pattern and mark log blocks as "text" (markdownlint MD040).

<sup>Written for commit 54155ec13278c33d7d56f3d36124a4ebba413ec6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Release Notes: HubSpot Lifecycle Webhook Observability Logging

## Overview
This PR implements observability logging in the HubSpot lifecycle webhook receiver (`POST /webhooks/hubspot/lifecycle`) to close the observability gap described in issue #19. The change enables operators to distinguish between "HubSpot did not deliver" and "HubSpot delivered and we returned HTTP 200" by emitting two structured console.log lines per webhook delivery.

## Changes at a Glance

### Files Modified: 3
- `apps/api/src/routes/lifecycle.ts` — Core logging implementation (+8 lines)
- `apps/api/src/__tests__/lifecycle-logging.test.ts` — New test suite (+153 lines)
- `docs/runbooks/slice-11-dev-quickstart.md` — Documentation updates (+14/-10 lines)

---

## Key Features

### ✅ Two-Line Logging Contract
Every webhook delivery now produces exactly two console.log entries in strict order:

1. **Entry Log** (on request arrival):
   ```
   hubspot-lifecycle-webhook: request received
   ```

2. **Summary Log** (after event processing loop):
   ```
   hubspot-lifecycle-webhook: applied=N ignored=N portalIds=<comma-joined>
   ```

**Example Live Output:**
```
hubspot-lifecycle-webhook: request received
hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=146425426
```

### 🔍 Redaction Posture
- **Safe to log**: `portalId`, `applied` count, `ignored` count
- **Never logged**: raw body, signatures, tokens, `client_secret`, timestamp, `eventTypeId`, per-event detail

### 🎯 Portal ID Tracking
- `portalIds` array is populated **only for applied events** (successful install/uninstall processing)
- **Ignored events** (missing portalId or unknown eventTypeId) do NOT contribute to the list
- Output is comma-joined, empty string if no events were applied

---

## Data Flow Diagram

```mermaid
flowchart TD
    A["POST /webhooks/hubspot/lifecycle<br/>(HubSpot delivery)"] -->|HMAC-SHA256 verify| B["Signature valid?"]
    B -->|❌ No| C["log: unauthorized<br/>return 401"]
    B -->|✅ Yes| D["<strong>LOG 1:</strong><br/>request received"]
    
    D --> E["Parse JSON payload<br/>iterate events"]
    E --> F{"mapEventTypeId<br/>in 4-1909196,<br/>4-1916193?"}
    
    F -->|❌ No| G["ignored++"]
    F -->|✅ Yes| H{"coercePortalId<br/>present?"}
    
    H -->|❌ No| I["ignored++<br/>warn: missing portalId"]
    H -->|✅ Yes| J["applied++<br/>portalIds.push<br/>applyHubSpotLifecycleEvent"]
    
    G --> K{"Loop<br/>done?"}
    I --> K
    J --> K
    
    K -->|❌ More events| E
    K -->|✅ Done| L["<strong>LOG 2:</strong><br/>applied=X<br/>ignored=Y<br/>portalIds=..."]
    
    L --> M["return 200<br/>{received, applied,<br/>ignored}"]
    
    style D fill:#90EE90
    style L fill:#90EE90
    style C fill:#FFB6C6
    style M fill:#87CEEB
```

---

## Testing Strategy: DB-Free Observability Verification

### Why Mocking `applyHubSpotLifecycleEvent`?
The test suite **mocks** the database-dependent service to keep logging verification **independent of database connectivity**, ensuring:
- ✅ Fast, deterministic test execution
- ✅ No Postgres pool dependency
- ✅ Pure focus on log emission contract (not tenant lifecycle side effects)
- ✅ Decoupled observability from storage behavior

### Test Cases (Vitest)

#### Test 1: Applied Event with PortalId
```typescript
// Given: Valid APP_INSTALL event with portalId="146425426"
// When: POST valid, signed request
// Then:
//   - HTTP 200
//   - console.log called exactly 2 times
//   - Call[0]: "hubspot-lifecycle-webhook: request received"
//   - Call[1]: "hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=146425426"
```

**Traceability**: Verifies successful event path → portalIds populated

#### Test 2: Ignored Event (Missing PortalId)
```typescript
// Given: Valid APP_INSTALL event WITHOUT portalId
// When: POST valid, signed request
// Then:
//   - HTTP 200
//   - console.log called exactly 2 times (no warn in this spy)
//   - Call[0]: "hubspot-lifecycle-webhook: request received"
//   - Call[1]: "hubspot-lifecycle-webhook: applied=0 ignored=1 portalIds="
```

**Traceability**: Verifies missing-portalId path → empty portalIds list, event counted as ignored

### Signature Testing
Both tests exercise HMAC-SHA256 (v3) signature verification with:
- Valid timestamp header
- Correct signature calculation per HubSpot spec
- Failure modes rejected at authentication layer (before logging)

---

## Operator Verification (Post-Merge)

Operators should verify live logs by:

1. **Trigger an install** on a test portal
2. **Tail receiver logs** (Vercel, Cloudflare, ngrok, etc.)
3. **Confirm output pattern**:
   ```
   hubspot-lifecycle-webhook: request received
   hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=<your_test_portal_id>
   ```
4. **Repeat for uninstall** — expect same two-line pattern

---

## Documentation Updates

### slice-11-dev-quickstart.md §4.2 & §4.3
Updated **install** and **uninstall** verification instructions to show the new two-line receiver output:

**Before:**
```
[lifecycle] APP_INSTALL ... timestamp=<iso>
```

**After:**
```
hubspot-lifecycle-webhook: request received
hubspot-lifecycle-webhook: applied=1 ignored=0 portalIds=<id>
```

This aligns developer expectations with the actual Slice 7 logging contract.

---

## Event Type Mapping (Unchanged)

| eventTypeId | Mapped Type | Action |
|---|---|---|
| `4-1909196` | `app_install` | Call `applyHubSpotLifecycleEvent`, increment applied |
| `4-1916193` | `app_uninstall` | Call `applyHubSpotLifecycleEvent`, increment applied |
| *(other)* | N/A | Increment ignored, no-op |

---

## Idempotency (Unchanged)

The receiver remains idempotent by construction:
- Unknown portalIds → no-op at database level, 200 returned (prevents HubSpot retry hammer)
- Duplicate uninstall → re-applies same update (idempotent `isActive=false`) without error

---

## Validation Checklist

- ✅ Local test suite passes (Vitest + mocked `applyHubSpotLifecycleEvent`)
- ✅ TypeScript type-checking passes
- ✅ Linter passes (Biome)
- ⏳ **Post-merge step**: Operator verification of live Vercel logs (install + uninstall)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romeoman/hubspot-account-plan-app/pull/33)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->