### PR TITLE
feat(oauth): polish install success page with htmlSuccess helper (closes #16)

### DIFF
--- a/apps/api/src/__tests__/oauth-success-page.test.ts
+++ b/apps/api/src/__tests__/oauth-success-page.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Issue #16 / slice-12 Wave B — OAuth install success page.
+ *
+ * Verifies the polished `htmlSuccess(...)` helper introduced alongside
+ * `htmlError(...)` in apps/api/src/routes/oauth.ts:
+ *   1. `htmlSuccess(...)` returns a CSP-compliant HTML document with a
+ *      user-initiated CTA back to HubSpot.
+ *   2. The /oauth/callback success path (no returnUrl) renders that page
+ *      and not the previous htmlError-as-success fallback.
+ *   3. The /oauth/callback success path with a valid `returnUrl` still
+ *      302-redirects unchanged.
+ *
+ * Contract reference: docs/slice-12-preflight-notes.md §3.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as schema from "@hap/db";
+import { createDatabase, createTestClient } from "@hap/db";
+import { eq, like } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { signState } from "../lib/oauth.js";
+import { createOAuthRoutes, htmlSuccess } from "../routes/oauth.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cassettesDir = join(here, "..", "lib", "__tests__", "cassettes");
+
+function loadCassette(name: string) {
+  return JSON.parse(readFileSync(join(cassettesDir, name), "utf8")) as {
+    response: { status: number; body: unknown };
+  };
+}
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
+const sqlClient = createTestClient(DATABASE_URL);
+const db = createDatabase(DATABASE_URL);
+
+const PORTAL_PREFIX = `slice12success-${randomUUID().slice(0, 8)}-`;
+
+const CONFIG = {
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  redirectUri: "http://localhost:3000/oauth/callback",
+  scopes: ["oauth", "crm.objects.companies.read", "crm.objects.contacts.read"],
+  stateTtlSeconds: 600,
+};
+
+const ROOT_KEK_BASE64 = Buffer.alloc(32, 7).toString("base64");
+let savedRootKek: string | undefined;
+
+beforeAll(async () => {
+  await sqlClient`SELECT 1`;
+  savedRootKek = process.env.ROOT_KEK;
+  process.env.ROOT_KEK = ROOT_KEK_BASE64;
+});
+
+afterAll(async () => {
+  if (savedRootKek !== undefined) {
+    process.env.ROOT_KEK = savedRootKek;
+  } else {
+    delete process.env.ROOT_KEK;
+  }
+  await sqlClient.end({ timeout: 5 });
+});
+
+beforeEach(async () => {
+  await db.delete(schema.tenants).where(like(schema.tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+});
+
+function fakeFetchSequence(responses: Array<{ status: number; body: unknown }>): typeof fetch {
+  let i = 0;
+  return vi.fn(async () => {
+    const r = responses[i++];
+    if (!r) throw new Error("fakeFetchSequence exhausted");
+    return new Response(JSON.stringify(r.body), {
+      status: r.status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+function identityResponseForPortal(portalId: string) {
+  const identity = loadCassette("oauth-token-identity.json");
+  const body = { ...(identity.response.body as Record<string, unknown>) };
+  body.hub_id = Number.parseInt(portalId.replace(/\D/g, "").slice(0, 9) || "146425426", 10);
+  return {
+    status: identity.response.status,
+    body,
+    portalIdAsText: String(body.hub_id),
+  };
+}
+
+describe("htmlSuccess helper", () => {
+  it("returns a CSP-compliant HTML document with a user-initiated CTA to HubSpot", () => {
+    const html = htmlSuccess(
+      "Install successful",
+      "Signal-First Account Workspace is now connected to portal qa-account.example.com.",
+    );
+
+    expect(html.startsWith("<!doctype html>")).toBe(true);
+    expect(html).toMatch(/<a[^>]*href="https:\/\/app\.hubspot\.com\/"/);
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("<iframe");
+    expect(html).not.toMatch(/<meta\s+http-equiv=["']?refresh["']?/i);
+  });
+
+  it("escapes interpolated values to prevent HTML injection", () => {
+    const html = htmlSuccess('Install <script>alert(1)</script> "ok"', "portal & domain <hack>");
+    expect(html).not.toContain("<script>alert(1)");
+    expect(html).not.toContain("<hack>");
+    expect(html).not.toContain('"ok"');
+    expect(html).toContain("&#60;");
+    expect(html).toContain("&#62;");
+    expect(html).toContain("&#38;");
+  });
+
+  it("never echoes a region-specific HubSpot domain in the primary CTA", () => {
+    const html = htmlSuccess("Install successful", "portal abc");
+    expect(html).not.toContain("app-eu1.hubspot.com");
+    expect(html).not.toContain("app-na1.hubspot.com");
+  });
+});
+
+describe("GET /oauth/callback — polished success page (no returnUrl)", () => {
+  it("renders htmlSuccess (not htmlError) and includes the CTA back to HubSpot", async () => {
+    const ident = identityResponseForPortal(`${PORTAL_PREFIX}${randomUUID().slice(0, 4)}`);
+    const exchange = loadCassette("oauth-token-exchange.json");
+
+    const state = signState({
+      secret: CONFIG.clientSecret,
+      ttlSeconds: CONFIG.stateTtlSeconds,
+    });
+
+    const routes = createOAuthRoutes({
+      config: CONFIG,
+      db,
+      fetch: fakeFetchSequence([
+        { status: exchange.response.status, body: exchange.response.body },
+        { status: ident.status, body: ident.body },
+      ]),
+    });
+
+    const res = await routes.request(`/callback?code=auth-code&state=${encodeURIComponent(state)}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toMatch(/text\/html/);
+
+    const body = await res.text();
+    expect(body).toMatch(/<a[^>]*href="https:\/\/app\.hubspot\.com\/"/);
+    expect(body).toContain("qa-account.example.com");
+    // No meta-refresh — the 302-to-returnUrl branch handles auto-redirect.
+    expect(body).not.toMatch(/<meta\s+http-equiv=["']?refresh["']?/i);
+    // No inline script or third-party assets.
+    expect(body).not.toContain("<script");
+    expect(body).not.toContain("<iframe");
+
+    // Cleanup
+    const tenantRows = await db
+      .select()
+      .from(schema.tenants)
+      .where(eq(schema.tenants.hubspotPortalId, ident.portalIdAsText));
+    const tenantId = tenantRows[0]?.id;
+    if (tenantId) {
+      await db.delete(schema.tenants).where(eq(schema.tenants.id, tenantId));
+    }
+  });
+});
+
+describe("GET /oauth/callback — returnUrl regression guard", () => {
+  it("still 302-redirects when HubSpot supplies a valid returnUrl (no HTML body)", async () => {
+    const ident = identityResponseForPortal(`${PORTAL_PREFIX}${randomUUID().slice(0, 4)}`);
+    const exchange = loadCassette("oauth-token-exchange.json");
+
+    const state = signState({
+      secret: CONFIG.clientSecret,
+      ttlSeconds: CONFIG.stateTtlSeconds,
+    });
+
+    const routes = createOAuthRoutes({
+      config: CONFIG,
+      db,
+      fetch: fakeFetchSequence([
+        { status: exchange.response.status, body: exchange.response.body },
+        { status: ident.status, body: ident.body },
+      ]),
+    });
+
+    const returnUrl = "https://app.hubspot.com/some-marketplace-finalize-page";
+    const res = await routes.request(
+      `/callback?code=auth-code&state=${encodeURIComponent(state)}&returnUrl=${encodeURIComponent(returnUrl)}`,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(returnUrl);
+
+    // Cleanup
+    const tenantRows = await db
+      .select()
+      .from(schema.tenants)
+      .where(eq(schema.tenants.hubspotPortalId, ident.portalIdAsText));
+    const tenantId = tenantRows[0]?.id;
+    if (tenantId) {
+      await db.delete(schema.tenants).where(eq(schema.tenants.id, tenantId));
+    }
+  });
+});

--- a/apps/api/src/__tests__/oauth-success-page.test.ts
+++ b/apps/api/src/__tests__/oauth-success-page.test.ts
@@ -166,6 +166,52 @@ describe("GET /oauth/callback — polished success page (no returnUrl)", () => {
       await db.delete(schema.tenants).where(eq(schema.tenants.id, tenantId));
     }
   });
+
+  it("falls back to portalIdAsText in success copy when hub_domain is empty", async () => {
+    // Locks the documented `identity.hubDomain || portalIdAsText` fallback
+    // (oauth.ts success path). If hub_domain comes back empty from
+    // HubSpot, the success page MUST identify the connection by portal id,
+    // not by an empty string. Addresses CodeRabbit coverage nit on PR #34.
+    const ident = identityResponseForPortal(`${PORTAL_PREFIX}${randomUUID().slice(0, 4)}`);
+    const identBodyEmptyDomain = {
+      ...(ident.body as Record<string, unknown>),
+      hub_domain: "",
+    };
+    const exchange = loadCassette("oauth-token-exchange.json");
+
+    const state = signState({
+      secret: CONFIG.clientSecret,
+      ttlSeconds: CONFIG.stateTtlSeconds,
+    });
+
+    const routes = createOAuthRoutes({
+      config: CONFIG,
+      db,
+      fetch: fakeFetchSequence([
+        { status: exchange.response.status, body: exchange.response.body },
+        { status: ident.status, body: identBodyEmptyDomain },
+      ]),
+    });
+
+    const res = await routes.request(`/callback?code=auth-code&state=${encodeURIComponent(state)}`);
+    expect(res.status).toBe(200);
+
+    const body = await res.text();
+    // Must NOT mention the (now empty) hub_domain.
+    expect(body).not.toContain("qa-account.example.com");
+    // MUST identify the connection by numeric portal id instead.
+    expect(body).toContain(ident.portalIdAsText);
+
+    // Cleanup
+    const tenantRows = await db
+      .select()
+      .from(schema.tenants)
+      .where(eq(schema.tenants.hubspotPortalId, ident.portalIdAsText));
+    const tenantId = tenantRows[0]?.id;
+    if (tenantId) {
+      await db.delete(schema.tenants).where(eq(schema.tenants.id, tenantId));
+    }
+  });
 });
 
 describe("GET /oauth/callback — returnUrl regression guard", () => {

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -101,6 +101,31 @@ function htmlError(title: string, detail: string): string {
   return `<!doctype html><html><head><meta charset="utf-8"><title>${safeTitle}</title></head><body><h1>${safeTitle}</h1><p>${safeDetail}</p></body></html>`;
 }
 
+/**
+ * Polished post-install success page (slice-12 / Issue #16).
+ *
+ * Rendered when the HubSpot install completes without a `returnUrl` query
+ * parameter (or with one that fails the `isAllowedReturnUrl` open-redirect
+ * guard). When HubSpot DOES supply a valid `returnUrl`, the route uses a
+ * 302 redirect upstream of this helper — by the time `htmlSuccess` is
+ * called, that path has already been proven unavailable, which is why
+ * there is intentionally no `<meta http-equiv="refresh">` tag here (would
+ * be dead code; see docs/slice-12-preflight-notes.md §3).
+ *
+ * CSP guarantees by construction:
+ *   - No inline `<script>`, no `<iframe>`, no third-party assets, no web
+ *     fonts, no remote images.
+ *   - All interpolated values flow through `escapeHtml(...)`.
+ *   - Primary CTA is a plain `<a>` to the region-agnostic
+ *     https://app.hubspot.com/ root — never an `app-eu1.hubspot.com` or
+ *     other region-specific origin (would mis-route US installs).
+ */
+export function htmlSuccess(title: string, detail: string): string {
+  const safeTitle = escapeHtml(title);
+  const safeDetail = escapeHtml(detail);
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${safeTitle}</title><style>:root{color-scheme:light dark}body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;line-height:1.5;margin:0;padding:48px 24px;display:flex;justify-content:center;background:#f6f8fb;color:#1f2937}main{max-width:520px;width:100%;background:#fff;border-radius:12px;box-shadow:0 1px 3px rgba(16,24,40,.08),0 1px 2px rgba(16,24,40,.04);padding:40px 32px;text-align:center}.badge{display:inline-flex;align-items:center;justify-content:center;width:48px;height:48px;border-radius:999px;background:#e8f5ee;color:#0a7a3b;font-size:24px;font-weight:600;margin-bottom:16px}h1{font-size:22px;font-weight:600;margin:0 0 12px}p{font-size:15px;color:#4b5563;margin:0 0 24px}.cta{display:inline-block;padding:10px 20px;border-radius:8px;background:#ff7a59;color:#fff;text-decoration:none;font-weight:600;font-size:15px}.cta:hover{background:#e8623f}@media (prefers-color-scheme:dark){body{background:#0f172a;color:#e5e7eb}main{background:#1e293b;box-shadow:0 1px 3px rgba(0,0,0,.4)}p{color:#cbd5e1}.badge{background:#0a7a3b;color:#e8f5ee}}</style></head><body><main><div class="badge" aria-hidden="true">&#10003;</div><h1>${safeTitle}</h1><p>${safeDetail}</p><a class="cta" href="https://app.hubspot.com/">Return to HubSpot</a></main></body></html>`;
+}
+
 export function createOAuthRoutes(deps: OAuthDeps) {
   const { config } = deps;
   const db = deps.db as OAuthDb;
@@ -266,9 +291,9 @@ export function createOAuthRoutes(deps: OAuthDeps) {
       return c.redirect(returnUrl, 302);
     }
     return c.html(
-      htmlError(
+      htmlSuccess(
         "Install successful",
-        `Signal-First Account Workspace is now installed on portal ${identity.hubDomain}. Next, open the app settings in HubSpot to finish setup. You can close this tab when you are done.`,
+        `Signal-First Account Workspace is now connected to portal ${identity.hubDomain || portalIdAsText}. Next, open the app settings in HubSpot to finish setup. You can close this tab when you are done, or return to HubSpot to continue.`,
       ),
       200,
     );


### PR DESCRIPTION
## Summary

Implements the binding contract from `docs/slice-12-preflight-notes.md` §3 (slice-12 Wave B / Issue #16).

Replaces the `htmlError("Install successful", ...)` misuse at the post-callback fallback in `apps/api/src/routes/oauth.ts:268-274` with a polished `htmlSuccess(...)` helper. The existing 302-to-`returnUrl` branch (oauth.ts:264-267) is **unchanged** — HubSpot's marketplace install flow still gets the snappy redirect when it supplies a valid `returnUrl`; the new page is only the fallback path.

### Scope

- **Exactly 2 files changed**: `apps/api/src/routes/oauth.ts` + new test file `apps/api/src/__tests__/oauth-success-page.test.ts`.
- **No change to** `apps/hubspot-project/src/app/app-hsmeta.json` — the `redirectUrls` whitelist already covers `/oauth/callback`.
- **No change to** tenant insert at oauth.ts:209-227 (Wave C territory).
- **No change to** `apps/api/src/lib/oauth.ts` helpers.

### htmlSuccess contract (§3)

- CSP-compliant by construction: no inline `<script>`, no `<iframe>`, no third-party assets, no remote fonts/images.
- All interpolated values flow through the existing `escapeHtml(...)` helper at oauth.ts:94.
- Primary CTA is a region-agnostic `<a href=\"https://app.hubspot.com/\">Return to HubSpot</a>` — never `app-eu1.hubspot.com` or other region-specific origin.
- **No `<meta http-equiv=\"refresh\">` tag.** By the time control reaches `htmlSuccess`, the 302-to-`returnUrl` branch has already been proven unavailable — a meta-refresh here would be dead code per preflight §3.
- Inline `<style>` for visual polish only (CSP-compatible same-document; no remote stylesheet).
- No new `console.log`.

### Secondary copy

> Signal-First Account Workspace is now connected to portal `<escaped portal>`. Next, open the app settings in HubSpot to finish setup. You can close this tab when you are done, or return to HubSpot to continue.

Portal interpolation falls back to the numeric `portalIdAsText` when `identity.hubDomain` is empty.

## TDD discipline (failing-first cycle)

Wrote tests **before** the helper existed and confirmed they failed for the expected reasons:

```
$ DATABASE_URL=... pnpm vitest run apps/api/src/__tests__/oauth-success-page.test.ts
 Test Files  1 failed (1)
      Tests  4 failed | 1 passed (5)
```

The 4 failures broke down as:

1. `TypeError: htmlSuccess is not a function` — helper did not yet exist (3 tests).
2. `expected '<!doctype html><html><head>...' to contain '<a [...]href=\"https://app.hubspot.com/\"'` — the route was still using `htmlError(...)` for the success path; no CTA was rendered.

The 5th test (returnUrl regression) passed both before and after because the 302 branch was already correct; it serves as a guard that the polished page doesn't regress that behavior.

After implementing `htmlSuccess` and swapping the call site, all 5 tests pass.

### Test cases

1. `htmlSuccess` returns a CSP-compliant HTML document with the user-initiated CTA back to HubSpot (no `<script>`, no `<iframe>`, no meta-refresh).
2. `htmlSuccess` escapes interpolated values to prevent HTML injection (verified `<script>alert(1)</script>` and `&`, `<`, `>` characters are escaped via `escapeHtml`).
3. `htmlSuccess` never echoes a region-specific HubSpot domain (`app-eu1.hubspot.com` / `app-na1.hubspot.com`) in the CTA.
4. `/oauth/callback` success path (no `returnUrl`) renders `htmlSuccess` with status 200, `Content-Type: text/html`, contains the CTA, contains the escaped portal hub_domain.
5. `/oauth/callback` success path **with** valid `returnUrl` still 302-redirects (no HTML body) — regression guard for the unchanged 302 branch.

## Verification

```
$ pnpm vitest run apps/api
 Test Files  54 passed (54)
      Tests  538 passed (538)
   Duration  12.24s

$ pnpm typecheck
> tsc --build
(clean)

$ pnpm lint
Checked 233 files in 43ms. No fixes applied.
Found 5 warnings.
EXIT=0
```

The 5 lint warnings are pre-existing `noNonNullAssertion` warnings in `apps/api/src/adapters/signal/__tests__/factory.test.ts` and `apps/api/src/lib/__tests__/hubspot-subscription-bootstrap.test.ts` — unrelated to this PR and inherited from `main`.

538 tests pass, up from 533 on main by the +5 tests this PR adds (one of which — \"renders setup guidance on the success page\" — is the existing route test that I kept passing by preserving the \"open the app settings in HubSpot\" phrasing in the new copy).

## References

- Contract: `docs/slice-12-preflight-notes.md` §3 (binding)
- Plan: `.claude/tasks/2026-05-10-mvp-deployment-readiness.md` — Task 4 / Wave B
- Closes: #16

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a polished OAuth install success page via a new `htmlSuccess` helper. The 302 redirect to `returnUrl` remains unchanged; the page renders only as a fallback. Closes #16.

- **New Features**
  - Added `htmlSuccess(title, detail)` for a CSP-safe, escaped success page with a clear CTA to HubSpot.
  - Updated `/oauth/callback` to render the new page only when `returnUrl` is missing or rejected; the 302 `returnUrl` path is unchanged.
  - Expanded tests to cover HTML escaping, fallback rendering, redirect regression, and the empty `hub_domain` case (falls back to numeric portal id).

<sup>Written for commit 437b5d8109968e63fc78e4f18358c86176c72cb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# OAuth Install Success Page Polish — Release Notes

## Overview
This PR replaces an error-styled fallback page with a purpose-built, CSP-compliant success page for OAuth installs by adding an htmlSuccess(...) helper and using it when no safe returnUrl is provided. Implementation is TDD-first, traceable, and preserves existing 302 redirect behavior. Closes Issue #16.

Files changed
- apps/api/src/routes/oauth.ts (new htmlSuccess helper; fallback now uses htmlSuccess)
- apps/api/src/__tests__/oauth-success-page.test.ts (new Vitest suite validating contract & route behavior)

---

## Key Changes (bullet points)
- Add htmlSuccess(title: string, detail: string) — CSP-friendly success HTML renderer.
- Replace htmlError("Install successful", ...) fallback with htmlSuccess(...) in POST /oauth/callback.
- Preserve 302 redirect when HubSpot supplies a validated returnUrl (no behavioral regression).
- Ensure all interpolations are escaped via escapeHtml(...) to prevent injection.
- Primary CTA is region-agnostic: https://app.hubspot.com/ (no region-specific origins echoed).
- Inline <style> permitted only for same-document polish; no inline scripts, iframes, meta-refresh, remote fonts, or images.
- Tests authored before implementation (TDD); all new tests passing; full suite and typecheck pass.

---

## Data Flow (mermaid)
```mermaid
flowchart TD
  A[POST /oauth/callback] --> B{is returnUrl present?}
  B -- Yes --> C{is returnUrl allowed?}
  C -- Yes --> D[302 -> returnUrl]
  C -- No --> E[Render htmlSuccess (200, text/html)]
  B -- No --> E
  E --> F[User sees success page with CTA -> https://app.hubspot.com/]
  D --> G[User redirected to HubSpot]
  style E fill:#fff3e0,stroke:#333
  style D fill:#e8f5ee,stroke:#333
```

---

## Security & UX Guarantees (concise)
- CSP-compliant: no <script>, <iframe>, meta refresh, or remote assets.
- All user-controlled strings escaped (escapeHtml).
- Open-redirect prevention retained: isAllowedReturnUrl() still governs 302 behavior.
- CTA is global HubSpot root to avoid misrouting to regional domains.
- No console.log or other debug output in production HTML.

---

## Tests, Traceability & TDD (sacred)
- Tests written first; implementation fixed failing tests to green.
- New test file: apps/api/src/__tests__/oauth-success-page.test.ts
  - Validates CSP compliance, escaping of interpolations (including script payloads), CTA domain, success rendering (200 + text/html), and preservation of 302 redirect when returnUrl is valid.
  - Uses cassette fixtures, deterministic ROOT_KEK env, and cleans tenant rows per-test for isolation.
- Implementation: apps/api/src/routes/oauth.ts
  - Export: export function htmlSuccess(title: string, detail: string): string
  - Call site updated to use htmlSuccess(...) for fallback path.
- Traceability: tests directly assert htmlSuccess outputs and /oauth/callback behavior; see the added test file for exact assertions and payloads.

---

## Why these choices (brief rationale)
- Use htmlSuccess (not htmlError) so success UX is explicit and semantically correct.
- Avoid meta-refresh/auto-redirect because 302 is the authoritative return mechanism; fallback must remain usable without automatic navigation.
- Region-agnostic CTA ensures users are sent to HubSpot’s routing endpoint rather than data-center-specific hosts.
- Inline CSS allowed only for non-executable polish to keep strong CSP while providing a good UX.

---

## Verification Checklist
- [x] New htmlSuccess helper implemented
- [x] Fallback path uses htmlSuccess when no validated returnUrl
- [x] 302 redirect behavior unchanged for valid returnUrl
- [x] All interpolations escaped
- [x] CSP constraints enforced (no scripts/iframes/meta-refresh/remote assets)
- [x] Tests written pre-implementation (TDD) and now passing
- [x] Full test suite and typecheck passed

---

## Notes for reviewers
- Review tests in apps/api/src/__tests__/oauth-success-page.test.ts to see exact contract expectations.
- Confirm htmlSuccess output (apps/api/src/routes/oauth.ts) matches CSP & escaping guarantees.
- No changes to redirect whitelist, tenant insertion logic, or other oauth helpers beyond the fallback rendering swap.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romeoman/hubspot-account-plan-app/pull/34)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->