### PR TITLE
feat(install): default enrichment to on for new tenants (closes #28)

### DIFF
--- a/apps/api/src/__tests__/default-enrichment-28.test.ts
+++ b/apps/api/src/__tests__/default-enrichment-28.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Issue #28 / slice-12 Wave C — default-on HubSpot enrichment for new
+ * tenant installs.
+ *
+ * Contract reference: docs/slice-12-preflight-notes.md §4.
+ *
+ * Locked guarantees this file enforces:
+ *   1. A fresh OAuth install writes `settings.enrichmentEnabled = true`
+ *      on the newly-inserted tenant row.
+ *   2. A reinstall (same `hubspotPortalId`, conflict path) MUST NOT
+ *      clobber a user-set `settings.enrichmentEnabled = false`. The
+ *      default-on is wired into `.values({...})`, NOT into
+ *      `onConflictDoUpdate.set`, so `settings` is left alone on conflict.
+ *   3. Cross-tenant isolation: tenant A's disabled toggle MUST NOT leak
+ *      to tenant B's fresh install, and tenant B's fresh install MUST
+ *      NOT flip tenant A's disabled toggle back to `true`.
+ *
+ * DB-backed test — mirrors the boilerplate in
+ * `apps/api/src/__tests__/oauth-success-page.test.ts` (Wave B).
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as schema from "@hap/db";
+import { createDatabase, createTestClient } from "@hap/db";
+import { eq, like } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { signState } from "../lib/oauth.js";
+import { createOAuthRoutes } from "../routes/oauth.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cassettesDir = join(here, "..", "lib", "__tests__", "cassettes");
+
+function loadCassette(name: string) {
+  return JSON.parse(readFileSync(join(cassettesDir, name), "utf8")) as {
+    response: { status: number; body: unknown };
+  };
+}
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://hap:hap_local_dev@localhost:5433/hap_dev";
+const sqlClient = createTestClient(DATABASE_URL);
+const db = createDatabase(DATABASE_URL);
+
+// Numeric portal-id prefix unique to this test file. The route stores
+// `String(identity.hubId)` on tenants.hubspotPortalId, so the prefix
+// must be all-digit to survive the round trip and let `beforeEach`'s
+// LIKE cleanup target only this file's rows. The random 4-digit suffix
+// avoids collisions across concurrent test files; the per-test counter
+// (`nextHubIdSuffix`) avoids collisions inside this file.
+const PORTAL_PREFIX = `9${Math.floor(1000 + Math.random() * 8999)}`; // e.g. "92847"
+
+const CONFIG = {
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  redirectUri: "http://localhost:3000/oauth/callback",
+  scopes: ["oauth", "crm.objects.companies.read", "crm.objects.contacts.read"],
+  stateTtlSeconds: 600,
+};
+
+const ROOT_KEK_BASE64 = Buffer.alloc(32, 7).toString("base64");
+let savedRootKek: string | undefined;
+
+beforeAll(async () => {
+  await sqlClient`SELECT 1`;
+  savedRootKek = process.env.ROOT_KEK;
+  process.env.ROOT_KEK = ROOT_KEK_BASE64;
+});
+
+afterAll(async () => {
+  if (savedRootKek !== undefined) {
+    process.env.ROOT_KEK = savedRootKek;
+  } else {
+    delete process.env.ROOT_KEK;
+  }
+  await sqlClient.end({ timeout: 5 });
+});
+
+beforeEach(async () => {
+  await db.delete(schema.tenants).where(like(schema.tenants.hubspotPortalId, `${PORTAL_PREFIX}%`));
+});
+
+function fakeFetchSequence(responses: Array<{ status: number; body: unknown }>): typeof fetch {
+  let i = 0;
+  return vi.fn(async () => {
+    const r = responses[i++];
+    if (!r) throw new Error("fakeFetchSequence exhausted");
+    return new Response(JSON.stringify(r.body), {
+      status: r.status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+// Per-test-file numeric suffix counter. Combined with PORTAL_PREFIX it
+// produces unique numeric hub_ids (e.g. "928470001", "928470002", ...)
+// that round-trip through `String(identity.hubId)` and are caught by
+// the `LIKE '<PORTAL_PREFIX>%'` cleanup in beforeEach.
+let nextHubIdSuffix = 1;
+
+function identityResponseForHubId(hubId: number) {
+  const identity = loadCassette("oauth-token-identity.json");
+  const body = { ...(identity.response.body as Record<string, unknown>) };
+  body.hub_id = hubId;
+  return {
+    status: identity.response.status,
+    body,
+    portalIdAsText: String(hubId),
+  };
+}
+
+function freshHubIdForThisFile(): number {
+  const suffix = String(nextHubIdSuffix++).padStart(4, "0");
+  return Number.parseInt(`${PORTAL_PREFIX}${suffix}`, 10);
+}
+
+async function performInstallCallback(hubId?: number): Promise<{ portalIdAsText: string }> {
+  const id = hubId ?? freshHubIdForThisFile();
+  const ident = identityResponseForHubId(id);
+  const exchange = loadCassette("oauth-token-exchange.json");
+  const state = signState({
+    secret: CONFIG.clientSecret,
+    ttlSeconds: CONFIG.stateTtlSeconds,
+  });
+
+  const routes = createOAuthRoutes({
+    config: CONFIG,
+    db,
+    fetch: fakeFetchSequence([
+      { status: exchange.response.status, body: exchange.response.body },
+      { status: ident.status, body: ident.body },
+    ]),
+  });
+
+  const res = await routes.request(`/callback?code=auth-code&state=${encodeURIComponent(state)}`);
+  expect(res.status).toBe(200);
+  return { portalIdAsText: ident.portalIdAsText };
+}
+
+async function performReinstallCallback(portalIdAsText: string): Promise<void> {
+  // Reuse the same portal id — triggers the onConflictDoUpdate path.
+  const identity = loadCassette("oauth-token-identity.json");
+  const body = { ...(identity.response.body as Record<string, unknown>) };
+  body.hub_id = Number.parseInt(portalIdAsText, 10);
+  const exchange = loadCassette("oauth-token-exchange.json");
+  const state = signState({
+    secret: CONFIG.clientSecret,
+    ttlSeconds: CONFIG.stateTtlSeconds,
+  });
+
+  const routes = createOAuthRoutes({
+    config: CONFIG,
+    db,
+    fetch: fakeFetchSequence([
+      { status: exchange.response.status, body: exchange.response.body },
+      { status: identity.response.status, body },
+    ]),
+  });
+
+  const res = await routes.request(`/callback?code=auth-code&state=${encodeURIComponent(state)}`);
+  expect(res.status).toBe(200);
+}
+
+async function readTenantSettings(portalIdAsText: string): Promise<Record<string, unknown> | null> {
+  const rows = await db
+    .select()
+    .from(schema.tenants)
+    .where(eq(schema.tenants.hubspotPortalId, portalIdAsText));
+  const row = rows[0];
+  if (!row) return null;
+  return (row.settings ?? null) as Record<string, unknown> | null;
+}
+
+async function setTenantEnrichmentEnabled(portalIdAsText: string, enabled: boolean): Promise<void> {
+  // Simulates `PUT /api/settings` writing `enrichmentEnabled` on the
+  // tenant's settings JSONB. Slice-12 scope is backend-only (see
+  // preflight §5), so we mutate the row directly rather than going
+  // through the settings route.
+  await db
+    .update(schema.tenants)
+    .set({ settings: { enrichmentEnabled: enabled } })
+    .where(eq(schema.tenants.hubspotPortalId, portalIdAsText));
+}
+
+describe("Issue #28 — default-on enrichment for new tenant installs", () => {
+  it("fresh install: tenant row has settings.enrichmentEnabled === true", async () => {
+    const { portalIdAsText } = await performInstallCallback();
+
+    const settings = await readTenantSettings(portalIdAsText);
+    expect(settings).not.toBeNull();
+    expect(settings).toEqual(expect.objectContaining({ enrichmentEnabled: true }));
+  });
+
+  it("reinstall preserves a user-set enrichmentEnabled=false (no clobber)", async () => {
+    const { portalIdAsText } = await performInstallCallback();
+
+    // Fresh install initialised it to true.
+    expect(await readTenantSettings(portalIdAsText)).toEqual(
+      expect.objectContaining({ enrichmentEnabled: true }),
+    );
+
+    // User disables enrichment via Settings UI / PUT /api/settings.
+    await setTenantEnrichmentEnabled(portalIdAsText, false);
+    expect(await readTenantSettings(portalIdAsText)).toEqual(
+      expect.objectContaining({ enrichmentEnabled: false }),
+    );
+
+    // Reinstall the same portal — triggers onConflictDoUpdate.
+    await performReinstallCallback(portalIdAsText);
+
+    // The .values({...}) default MUST be ignored on conflict; the
+    // onConflictDoUpdate.set MUST NOT touch settings.
+    expect(await readTenantSettings(portalIdAsText)).toEqual(
+      expect.objectContaining({ enrichmentEnabled: false }),
+    );
+  });
+
+  it("cross-tenant isolation: tenant A's disabled toggle never leaks to tenant B (and B's install never flips A back)", async () => {
+    // Tenant A: fresh install → default-on.
+    const { portalIdAsText: portalA } = await performInstallCallback();
+    expect(await readTenantSettings(portalA)).toEqual(
+      expect.objectContaining({ enrichmentEnabled: true }),
+    );
+
+    // Tenant A disables enrichment.
+    await setTenantEnrichmentEnabled(portalA, false);
+    expect(await readTenantSettings(portalA)).toEqual(
+      expect.objectContaining({ enrichmentEnabled: false }),
+    );
+
+    // Tenant B: a separate portal id — fresh install → default-on.
+    const { portalIdAsText: portalB } = await performInstallCallback();
+    expect(portalB).not.toBe(portalA);
+    expect(await readTenantSettings(portalB)).toEqual(
+      expect.objectContaining({ enrichmentEnabled: true }),
+    );
+
+    // Tenant A's setting must NOT have been flipped back by tenant B's
+    // install path (a write into another tenant's row would be a
+    // cross-tenant leakage; CLAUDE.md tenant-isolation rule).
+    expect(await readTenantSettings(portalA)).toEqual(
+      expect.objectContaining({ enrichmentEnabled: false }),
+    );
+  });
+});

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -238,6 +238,7 @@ export function createOAuthRoutes(deps: OAuthDeps) {
       .values({
         hubspotPortalId: portalIdAsText,
         name: identity.hubDomain || portalIdAsText,
+        settings: { enrichmentEnabled: true },
       })
       .onConflictDoUpdate({
         target: tenants.hubspotPortalId,


### PR DESCRIPTION
## Summary

Implements **Wave C / Task 5** of the slice-12 MVP-readiness plan: HubSpot enrichment defaults to **on** for newly-installed tenants. Closes #28.

The change is a **single-line addition** inside the OAuth callback's tenant insert at `apps/api/src/routes/oauth.ts`:

```ts
.values({
  hubspotPortalId: portalIdAsText,
  name: identity.hubDomain || portalIdAsText,
  settings: { enrichmentEnabled: true },   // ← added
})
```

Per the binding contract in [`docs/slice-12-preflight-notes.md §4`](https://github.com/romeoman/hubspot-account-plan-app/blob/main/docs/slice-12-preflight-notes.md#4-28-reinstall-semantics-binding-contract-for-task-5), the default lives in `.values({...})` **only** — `.onConflictDoUpdate.set` is **unchanged**, so reinstalling a tenant whose user has disabled enrichment via `PUT /api/settings` will **not** clobber their preference. That preserves SECURITY.md §19.2's "user-set values are not silently overwritten" guarantee.

### NO migration required

The `settings` JSONB column already exists at [`packages/db/src/schema/tenants.ts:10`](https://github.com/romeoman/hubspot-account-plan-app/blob/main/packages/db/src/schema/tenants.ts#L10):

```ts
settings: jsonb("settings").default({}),
```

So this PR ships zero schema changes.

### UI scope: out

Per preflight §5, slice-12 keeps Issue #28 backend-only. The existing slice-4 Settings UI at `apps/hubspot-project/src/app/settings/` already reads `signalProviders.hubspotEnrichment.enabled` from `GET /api/settings` and reflects whatever the backend returns. No frontend file is touched in this PR.

## Test plan

New DB-backed test file `apps/api/src/__tests__/default-enrichment-28.test.ts` mirrors the Wave B `oauth-success-page.test.ts` boilerplate (vitest + drizzle + cassette-driven OAuth fetch).

### Failing-test-first cycle (TDD)

Tests were written first, run against `main`'s code, and confirmed to fail with the expected reason before any production code changed:

```
× fresh install: tenant row has settings.enrichmentEnabled === true 31ms
× reinstall preserves a user-set enrichmentEnabled=false (no clobber) 6ms
× cross-tenant isolation: tenant A's disabled toggle never leaks to tenant B (and B's install never flips A back) 6ms

AssertionError: expected {} to deeply equal ObjectContaining { "enrichmentEnabled": true }
  at apps/api/src/__tests__/default-enrichment-28.test.ts:202:22
```

After the one-line implementation change, all 3 pass.

### Three test cases

1. **Fresh install** — POST `/oauth/callback` with a fresh portal id → tenant row's `settings.enrichmentEnabled === true`.
2. **Reinstall preserves user-set false** — fresh install (`true`), direct DB update to `false` (simulates `PUT /api/settings`), reinstall the same portal id → `settings.enrichmentEnabled` is still `false`. Validates that the default-on lives in `.values({...})` and NOT in `onConflictDoUpdate.set`.
3. **Cross-tenant isolation** — tenant A installs (`true`), tenant A disables to `false`, tenant B installs with a different portal id (`true`), re-read tenant A → still `false`. Validates CLAUDE.md's mandatory tenant-isolation guarantee: one tenant's install path must never write to another tenant's row.

### Verification commands

```
$ pnpm test apps/api
 Test Files  55 passed (55)
      Tests  542 passed (542)
   Duration  12.19s

$ pnpm typecheck
> tsc --build       # clean exit

$ pnpm lint
Checked 234 files in 43ms. No fixes applied.
Found 5 warnings.   # all pre-existing in unrelated files; 0 errors
```

## Scope confirmation

Exactly **2 files** changed:

- `apps/api/src/routes/oauth.ts` — single `settings: { enrichmentEnabled: true }` line added inside the tenant `.values({...})` block. Nothing else touched in this file.
- `apps/api/src/__tests__/default-enrichment-28.test.ts` — new test file.

No migration. No UI changes. No `apps/api/src/lib/oauth.ts` changes. No `.onConflictDoUpdate.set` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable HubSpot enrichment by default for newly installed tenants during OAuth, while preserving user-set preferences on reinstall. Closes #28.

- **New Features**
  - Set `settings.enrichmentEnabled: true` on tenant insert in the OAuth callback.
  - Reinstall path leaves `settings` untouched (`onConflictDoUpdate` unchanged), so a user-set `false` is not overwritten.
  - No migration or UI changes.

<sup>Written for commit d41bd231050871aeef59f78559db608d38665038. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Default HubSpot Enrichment to On for New Tenants

## Overview
This PR implements **Wave C / Task 5** of the slice-12 MVP-readiness plan (closes #28): HubSpot enrichment now defaults to **enabled** for newly-installed tenants. The implementation follows a strict binding contract that ensures:
- ✅ Fresh installs activate enrichment by default
- ✅ User-set preferences are never overwritten on reinstall  
- ✅ Complete cross-tenant isolation

---

## Release Notes

### What Changed
- **Single production change**: OAuth callback now inserts new tenants with `settings: { enrichmentEnabled: true }` in `apps/api/src/routes/oauth.ts`
- **No database migration required**: The `tenants.settings` column already exists as JSONB with default support
- **UI remains unchanged**: Existing Settings UI reads the backend value; no frontend modification needed

### Impact
- ✅ **Users installing via OAuth see enrichment enabled out-of-the-box** — removes friction for new adopters
- ✅ **Reinstalls preserve user preferences** — no unexpected resets of disabled toggles
- ✅ **Tenant data strictly isolated** — Tenant A's settings never influence Tenant B's fresh install
- ✅ **Zero breaking changes** — existing tenants unaffected; only applies to new installs

---

## Data Flow Architecture

```mermaid
graph TD
    A["OAuth User Clicks Install"] --> B["POST /oauth/install<br/>(Generate signed state)"]
    B --> C["Redirect to HubSpot Auth"]
    C --> D["HubSpot Auth Flow<br/>(User approves)"]
    D --> E["GET /oauth/callback<br/>?code=AUTH_CODE&state=SIGNED_STATE"]
    
    E --> F["Step 1: Validate State<br/>(Anti-tampering)"]
    F --> G["Step 2: Exchange Code<br/>for Access/Refresh Tokens"]
    G --> H["Step 3: Fetch Identity<br/>(portal_id + scopes)"]
    
    H --> I{{"Step 4: Upsert Tenant<br/>[CRITICAL]"}}
    
    I -->|New Portal ID| J["INSERT tenants<br/>WITH settings: &#123;<br/>enrichmentEnabled: true<br/>&#125;"]
    I -->|Existing Portal ID| K["ON CONFLICT...<br/>PRESERVE existing<br/>settings &#40;no change&#41;"]
    
    J --> L["Tenant Created<br/>with Enrichment ON"]
    K --> M["Tenant Updated<br/>Enrichment Untouched"]
    
    L --> N["Step 5-7: Encrypt &<br/>Store OAuth Tokens"]
    M --> N
    
    N --> O["Redirect to<br/>Success/returnUrl"]
    
    style J fill:#90EE90
    style K fill:#FFB6C1
    style I fill:#87CEEB
```

### Key Data Structure
```json
{
  "tenants": {
    "id": "uuid",
    "hubspotPortalId": "12345",
    "name": "acme.com",
    "settings": {
      "enrichmentEnabled": true        // ← NEW DEFAULT
    },
    "isActive": true,
    "createdAt": "2024-01-15T10:30:00Z",
    "updatedAt": "2024-01-15T10:30:00Z"
  }
}
```

---

## Binding Contract (Guaranteed Behavior)

All three guarantees are **enforced by the DB-backed test suite**:

### ✅ Guarantee 1: Fresh Install Enables Enrichment
- **When**: New portal ID encountered during OAuth callback
- **Then**: `tenants.settings.enrichmentEnabled` inserted as `true`
- **Why**: Reduces friction for new adopters; OAuth provides seamless auth
- **Test**: `test('fresh OAuth install writes enrichmentEnabled = true')`

### ✅ Guarantee 2: No Clobber on Reinstall
- **When**: Same portal ID reinstalls (conflict scenario)
- **Then**: Existing `settings` object left **completely untouched** by `onConflictDoUpdate.set`
- **Why**: Preserves user's manual toggle changes (e.g., if they disabled it)
- **Implementation**: `settings: { enrichmentEnabled: true }` is in `.values({})` only, NOT in `onConflictDoUpdate.set`
- **Test**: `test('reinstall preserves user-set enrichmentEnabled = false')`

### ✅ Guarantee 3: Cross-Tenant Isolation
- **When**: Tenant A disables enrichment, then Tenant B installs fresh
- **Then**: Tenant B's insert is completely independent; gets `enrichmentEnabled = true`
- **And**: Tenant A's disabled state remains `false` (never flipped back by B's insert)
- **Test**: `test('cross-tenant isolation: A disabled + B fresh install')`

---

## Testing Strategy: DB-Backed Regression Test

### Test File: `apps/api/src/__tests__/default-enrichment-28.test.ts` (+246 lines)

**Architecture Principles:**
- ✅ **Real database**: Uses actual PostgreSQL (not mocked), mirrors production behavior
- ✅ **Cassette-driven OAuth**: Replays real HubSpot token-exchange & identity responses
- ✅ **Isolation**: Each test file gets a unique numeric portal ID prefix (`PORTAL_PREFIX`) with random suffix
- ✅ **Cleanup**: `beforeEach` purges only this file's test rows via `LIKE '<PORTAL_PREFIX>%'`
- ✅ **Environment sandboxing**: Saves/restores `process.env.ROOT_KEK` across suite

### Test Cases

| Case | Scenario | Assertion | Traceability |
|------|----------|-----------|---|
| **Case 1** | Fresh OAuth install (new portal ID) | `settings.enrichmentEnabled === true` | Validates INSERT path |
| **Case 2** | Reinstall same portal ID after user disabled | `settings.enrichmentEnabled === false` persists | Validates `onConflictDoUpdate` does NOT modify `settings` |
| **Case 3** | Tenant A disabled, Tenant B fresh install | A remains `false`, B becomes `true`, no cross-contamination | Validates JSONB isolation at DB row level |

### Test Execution Flow
```mermaid
graph LR
    A["beforeAll<br/>Verify DB<br/>Save ROOT_KEK"] --> B["beforeEach<br/>LIKE cleanup<br/>PORTAL_PREFIX%"]
    B --> C["perform<br/>InstallCallback<br/>fake OAuth"]
    C --> D["Assert:<br/>enrichmentEnabled<br/>=== true"]
    D --> E["beforeEach<br/>cleanup"]
    E --> F["perform<br/>ReinstallCallback<br/>same portal ID"]
    F --> G["Assert:<br/>enrichmentEnabled<br/>preserved"]
    G --> H["beforeEach<br/>cleanup"]
    H --> I["afterAll<br/>Restore ROOT_KEK<br/>Close DB"]
    
    style A fill:#87CEEB
    style B fill:#FFD700
    style C fill:#90EE90
    style D fill:#90EE90
    style E fill:#FFD700
    style I fill:#87CEEB
```

### Key Test Utilities
- **`fakeFetchSequence(responses)`**: Injects canned OAuth responses to avoid live HubSpot calls
- **`performInstallCallback(hubId?)`**: Simulates fresh OAuth install with unique portal ID
- **`performReinstallCallback(portalIdAsText)`**: Simulates user reinstalling with same portal ID
- **`identityResponseForHubId(hubId)`**: Loads cassette template, injects test portal ID

---

## Code Changes

### Production Change: `apps/api/src/routes/oauth.ts` (+1 line)
```diff
  const tenantInsert = await db
    .insert(tenants)
    .values({
      hubspotPortalId: portalIdAsText,
      name: identity.hubDomain || portalIdAsText,
+     settings: { enrichmentEnabled: true },
    })
    .onConflictDoUpdate({
      target: tenants.hubspotPortalId,
      set: {
        isActive: true,
        updatedAt: sql`CURRENT_TIMESTAMP`,
      },
    })
    .returning();
```

**Why `settings` is NOT in `onConflictDoUpdate.set`:**
- On conflict (reinstall), the `set { isActive: true, ... }` only updates activation state
- `settings` is left untouched, preserving any user-modified `enrichmentEnabled` value
- This ensures Guarantee 2 (no clobber)

---

## Verification Checklist

| Item | Status | Command |
|------|--------|---------|
| ✅ All tests passing | PASS | `pnpm test apps/api` |
| ✅ TypeScript clean | PASS | `pnpm typecheck` |
| ✅ Lint clean | PASS | `pnpm lint` |
| ✅ Files changed | 2 files | `oauth.ts` (+1), `default-enrichment-28.test.ts` (+246) |
| ✅ No DB migration | N/A | `tenants.settings` already exists (JSONB) |
| ✅ No UI changes | N/A | Settings UI reads backend value (unchanged) |

---

## Traceability & Documentation

- **Linked Issue**: #28 (HubSpot enrichment default-on proposal)
- **Slice Reference**: slice-12 MVP-readiness plan, Wave C, Task 5
- **Contract Reference**: `docs/slice-12-preflight-notes.md` §4
- **Test Reference**: Mirrors boilerplate from `oauth-success-page.test.ts` (Wave B)
- **Cassettes Used**:
  - `oauth-token-exchange.json` (HubSpot token endpoint response)
  - `oauth-token-identity.json` (HubSpot identity endpoint response)

---

## Risk Mitigation

| Risk | Mitigation |
|------|-----------|
| **Conflict handling broken** | DB-backed test Case 2 validates `onConflictDoUpdate.set` does not touch `settings` |
| **New tenants missing `settings` key** | INSERT always supplies `settings: { enrichmentEnabled: true }` |
| **Cross-tenant data leak** | Test Case 3 runs concurrent installs for separate portal IDs, verifies isolation |
| **Existing tenants unexpectedly affected** | Only new inserts get the default; `onConflictDoUpdate` path untouched |
| **Environment variable pollution** | Test suite saves/restores `process.env.ROOT_KEK` in `beforeAll`/`afterAll` |

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romeoman/hubspot-account-plan-app/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->