### PR TITLE
fix(build): pre-build workspace packages before app builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "pnpm -r --parallel --filter=\"./apps/*\" run dev",
     "dev:api": "pnpm --filter @hap/api run dev",
     "dev:extension": "pnpm --filter @hap/hubspot-extension run dev",
-    "build": "pnpm -r --filter=\"./apps/*\" run build",
+    "build": "pnpm exec tsc -b packages/config packages/db packages/validators apps/api && pnpm --filter @hap/hubspot-extension run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "biome check .",


### PR DESCRIPTION
## Summary

The root `pnpm run build` script previously ran `apps/api` and `apps/hubspot-extension` in parallel via `pnpm -r --filter`, which caused the extension's vite build to fail because `@hap/validators` (and the other `@hap/*` packages) had no `dist/` output yet. This wasn't surfaced by CI (lint/typecheck/test don't run `build`) and was masked locally by stale build caches.

It surfaced today during a fresh Vercel CLI production deploy from the repo root:

```
[commonjs--resolver] Failed to resolve entry for package "@hap/validators". 
The package may have incorrect main/module/exports specified in its package.json.
```

## Fix

Replace the parallel app build with a sequenced two-step build that matches the ordering `apps/api/vercel.json` already uses for git auto-deploys:

```diff
- "build": "pnpm -r --filter=\"./apps/*\" run build",
+ "build": "pnpm exec tsc -b packages/config packages/db packages/validators apps/api && pnpm --filter @hap/hubspot-extension run build",
```

1. `tsc -b` uses TypeScript project references to build packages → api in dependency order, producing `dist/` for each package.
2. The extension's vite build then resolves `@hap/validators` etc. correctly.

## Verification

- `pnpm run build` exits 0 from a clean clone of this branch.
- Vercel CLI `vercel deploy --prod` from the repo root succeeded end-to-end against `hap-signal-workspace-staging` — production deployment `dpl_Vrm9dcFJVAvGEDNgHyZXospzWU7Y` is READY at `https://hap.mandigital.dev`. The same script ran on Vercel's build runner and finished cleanly.

## Risk / impact

- CI behavior unchanged (CI doesn't run `pnpm build`).
- Local `pnpm dev` unchanged.
- Future Vercel CLI deploys from repo root will now succeed without manual hacks.
- Git auto-deploys (which use the dashboard-configured Build Command `cd ../.. && pnpm exec tsc -b ...`) are unaffected — they bypass this script.
- Diff: 1 file, +1/-1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-builds workspace packages and `apps/api` before app builds so the HubSpot extension resolves `@hap/*` packages. Replaces the parallel root build with a sequenced build to fix Vercel CLI deploy failures.

- **Bug Fixes**
  - Root `build` now runs `pnpm exec tsc -b packages/config packages/db packages/validators apps/api` then `pnpm --filter @hap/hubspot-extension run build`.
  - Ensures `dist/` exists for `@hap/validators` and friends; matches `apps/api` deploy order.

<sup>Written for commit 4f4e8a51f3ae558b81dae4e4729779da23abd73e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Build Process Fix: Sequential Compilation for Workspace Packages

## Problem Statement
The previous `pnpm run build` command executed all applications in parallel using `pnpm -r --filter="./apps/*"`, which caused the Vite build of `@hap/hubspot-extension` to fail when building from a clean repository state (e.g., fresh Vercel CLI production deploy). The extension could not resolve built workspace packages (`@hap/validators`, `@hap/config`, `@hap/db`) because their TypeScript compilation outputs (`dist/`) did not exist yet. This failure was not caught by CI (which does not run the build command) and was masked locally by stale cache artifacts.

## Solution: Sequential Build with TypeScript Project References

### Build Sequence Diagram
```mermaid
graph TD
    A["pnpm run build<br/>(root)"] --> B["Step 1: Compile packages + API<br/>tsc -b packages/config<br/>packages/db packages/validators<br/>apps/api"]
    B --> C["Output: dist/ directories<br/>created for all dependencies"]
    C --> D["Step 2: Build extension<br/>pnpm filter @hap/hubspot-extension<br/>run build"]
    D --> E["Vite resolves workspace packages<br/>from their dist/ outputs"]
    E --> F["✓ Build succeeds"]
```

### Dependency Resolution Map
```mermaid
graph LR
    subgraph "Workspace Packages"
        Config["@hap/config<br/>(TS → dist)"]
        DB["@hap/db<br/>(TS → dist)"]
        Validators["@hap/validators<br/>(TS → dist)"]
    end
    
    subgraph "Applications"
        API["@hap/api<br/>(tsc compilation)"]
        Extension["@hap/hubspot-extension<br/>(Vite build)"]
    end
    
    Config --> API
    DB --> API
    Validators --> API
    Config --> Extension
    DB --> Extension
    Validators --> Extension
    API -.->|optional| Extension
```

### Build Execution Flow Comparison
```mermaid
graph TD
    subgraph "BEFORE (Parallel - FAILS)"
        B1["pnpm -r --filter='./apps/*'<br/>run build"]
        B2["Apps run in parallel"]
        B3["@hap/api build"]
        B4["@hap/hubspot-extension build"]
        B5["❌ Extension fails:<br/>cannot resolve @hap/validators<br/>dist/ missing"]
        B1 --> B2
        B2 --> B3
        B2 --> B4
        B4 --> B5
    end
    
    subgraph "AFTER (Sequential - SUCCEEDS)"
        A1["pnpm exec tsc -b"]
        A2["Compile packages in order:<br/>config → db → validators → api"]
        A3["All dist/ outputs created"]
        A4["pnpm --filter @hap/hubspot-extension<br/>run build"]
        A5["✓ Extension build succeeds:<br/>resolves workspace packages"]
        A1 --> A2
        A2 --> A3
        A3 --> A4
        A4 --> A5
    end
```

## Changes Made

### `package.json` Script Update
```
-  "build": "pnpm -r --filter=\"./apps/*\" run build"
+  "build": "pnpm exec tsc -b packages/config packages/db packages/validators apps/api && pnpm --filter @hap/hubspot-extension run build"
```

### Build Steps Explained

| Step | Command | Purpose | Output |
|------|---------|---------|--------|
| **1** | `pnpm exec tsc -b packages/config packages/db packages/validators apps/api` | Uses TypeScript project references to compile workspace packages and API in dependency order | Creates `dist/` directories with compiled JavaScript + type declarations for all dependencies |
| **2** | `pnpm --filter @hap/hubspot-extension run build` | Sequentially builds Vite extension after all dependencies are compiled | Extension can now resolve `@hap/validators`, `@hap/config`, `@hap/db` from their `dist/` outputs |

## Testing & Verification Traceability

### ✓ Verification Completed
- **Clean repository test:** `pnpm run build` exits with code 0 from fresh clone of the branch
- **Production deployment test:** Vercel CLI production deploy succeeded from repository root (Deployment: `dpl_Vrm9dcFJVAvGEDNgHyZXospzWU7Y` → https://hap.mandigital.dev [READY])

### CI Status (Unchanged - No Impact)
The CI pipeline (`.github/workflows/ci.yml`) runs the following checks:
- ✓ **Lint** (`pnpm lint`) - **Not affected**
- ✓ **Type Check** (`pnpm typecheck`) - **Not affected**  
- ✓ **Test** (`pnpm test`) - **Not affected** (includes PostgreSQL integration tests)

**Note:** CI does not execute `pnpm build`, so the build issue was not caught by automated testing. This fix prevents the problem from occurring in production environments.

### Local Development (Unchanged)
- `pnpm dev` - Continues to work unchanged (parallel dev servers for all apps)
- `pnpm test` - Continues to work unchanged (Vitest with existing fixtures)
- Auto-deploys - Git-triggered deployments unaffected

## Impact Assessment

| Aspect | Impact | Notes |
|--------|--------|-------|
| **Build reliability** | ✓ **Improved** | Eliminates flaky builds on fresh clones |
| **CI pipeline** | ✓ **No change** | Build command not part of CI checks |
| **Local development** | ✓ **No change** | `pnpm dev` works as before |
| **Production deployments** | ✓ **Fixed** | Vercel CLI and similar fresh-state deployments now succeed |
| **Diff size** | ✓ **Minimal** | Single line change (+1/-1) in `package.json` |

## Traceability & Reasoning

### Why TypeScript Project References?
- **Dependency ordering:** `tsc -b` respects the TypeScript project references defined in root `tsconfig.json`, ensuring packages compile in the correct order
- **Source of truth:** The tsconfig reference graph (`packages/db`, `packages/config`, `packages/validators`) matches the actual code dependencies
- **Predictable output:** All packages generate identical `dist/` outputs whether built in isolation or as part of the workspace

### Why Sequential Build?
- **Vite resolution requirement:** Vite's module resolution during extension build requires all imported packages to have their `dist/` outputs available at build time
- **Clean environment compatibility:** Parallel builds only work locally because stale caches mask missing outputs; sequential build works in any state

### Future-Proofing
The build command structure enables:
- **Easy addition of new packages:** New workspace packages are automatically included in `tsc -b` if added to tsconfig references
- **Faster builds if needed:** Future optimization could cache intermediate TypeScript outputs without changing this command structure

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romeoman/hubspot-account-plan-app/pull/36)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->