### PR TITLE
feat(ops): keep-alive cron + reconnect Vercel git integration (closes #41 #39)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,12 +1,14 @@
 import { resolveHubSpotOAuthRedirectUri } from "@hap/config";
-import { createDatabase } from "@hap/db";
+import { createDatabase, sql as drizzleSql } from "@hap/db";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { sweepExpiredNonces } from "./lib/replay-nonce.js";
 import { withTenantTxHandle } from "./lib/tenant-tx.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { type CorrelationVariables, correlationMiddleware } from "./middleware/correlation.js";
 import { nonceMiddleware } from "./middleware/nonce.js";
 import { type TenantVariables, tenantMiddleware } from "./middleware/tenant.js";
+import { createKeepAliveRoute } from "./routes/admin/keep-alive.js";
 import { createLifecycleBootstrapRoute } from "./routes/admin/lifecycle-bootstrap.js";
 import { lifecycleWebhookRoutes } from "./routes/lifecycle.js";
 import { createOAuthRoutes } from "./routes/oauth.js";
@@ -128,6 +130,20 @@ app.route("/webhooks/hubspot/lifecycle", lifecycleWebhookRoutes({ db: getDb() })
 // and the tenant middleware because it is gated on a static internal token
 // rather than a HubSpot-signed request. Mirrors the webhook mount posture.
 app.route("/admin/lifecycle", createLifecycleBootstrapRoute());
+
+// Vercel cron — daily `select 1` + nonce TTL sweep. Mounted OUTSIDE `/api/*`
+// because the caller is Vercel's scheduler, not an authenticated tenant. Auth
+// is `Authorization: Bearer <CRON_SECRET>` (Vercel cron convention). Schedule
+// lives in `apps/api/vercel.json` -> `crons[]`.
+app.route(
+  "/admin/keep-alive",
+  createKeepAliveRoute({
+    ping: async () => {
+      await getDb().execute(drizzleSql`select 1`);
+    },
+    sweep: () => sweepExpiredNonces(getDb()),
+  }),
+);
 
 // Composed middleware chain for /api/* routes: auth -> tenant -> route.
 app.use("/api/*", authMiddleware());

--- a/apps/api/src/routes/admin/__tests__/keep-alive.test.ts
+++ b/apps/api/src/routes/admin/__tests__/keep-alive.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for GET /admin/keep-alive — Vercel cron endpoint that pings the DB
+ * (`select 1`) and sweeps expired signed_request_nonce rows. Two birds:
+ *  1) keep Supabase free-tier project from auto-pausing after ~7 days
+ *  2) run the long-dangling nonce TTL sweep on a schedule
+ *
+ * Security contract:
+ *   - Auth is `Authorization: Bearer <CRON_SECRET>` (Vercel cron convention).
+ *   - Constant-time compare. Wrong length and wrong content both return 403.
+ *   - Missing env -> 503 `keepalive_not_configured` (so a misconfigured
+ *     deploy fails loudly to Vercel cron, surfacing in dashboard alerts).
+ *   - DB failure -> 503 `database_unreachable` (also signals cron failure).
+ */
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createKeepAliveRoute } from "../keep-alive";
+
+const VALID_TOKEN = "cron-secret-token-0123456789abcdef";
+
+function mount(
+  deps: {
+    ping?: () => Promise<void>;
+    sweep?: () => Promise<{ deletedCount: number }>;
+    env?: Record<string, string | undefined>;
+  } = {},
+) {
+  const ping = deps.ping ?? vi.fn(async () => undefined);
+  const sweep = deps.sweep ?? vi.fn(async () => ({ deletedCount: 0 }));
+  const env = deps.env ?? { CRON_SECRET: VALID_TOKEN };
+
+  const app = new Hono();
+  app.route("/admin/keep-alive", createKeepAliveRoute({ ping, sweep, env }));
+  return { app, ping, sweep };
+}
+
+describe("GET /admin/keep-alive", () => {
+  it("returns 401 when Authorization header is missing", async () => {
+    const { app, ping, sweep } = mount();
+
+    const res = await app.request("/admin/keep-alive");
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "missing_cron_token" });
+    expect(ping).not.toHaveBeenCalled();
+    expect(sweep).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when Authorization header is not a Bearer token", async () => {
+    const { app, ping, sweep } = mount();
+
+    const res = await app.request("/admin/keep-alive", {
+      headers: { Authorization: VALID_TOKEN }, // missing "Bearer " prefix
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "missing_cron_token" });
+    expect(ping).not.toHaveBeenCalled();
+    expect(sweep).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when bearer has the same length but wrong value", async () => {
+    const wrong = VALID_TOKEN.split("").reverse().join("");
+    expect(wrong.length).toBe(VALID_TOKEN.length);
+    const { app, ping, sweep } = mount();
+
+    const res = await app.request("/admin/keep-alive", {
+      headers: { Authorization: `Bearer ${wrong}` },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "invalid_cron_token" });
+    expect(ping).not.toHaveBeenCalled();
+    expect(sweep).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when bearer has a different length than the configured secret", async () => {
+    const { app, ping, sweep } = mount();
+
+    const res = await app.request("/admin/keep-alive", {
+      headers: { Authorization: "Bearer short" },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "invalid_cron_token" });
+    expect(ping).not.toHaveBeenCalled();
+    expect(sweep).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when CRON_SECRET env is missing (misconfigured)", async () => {
+    const { app, ping, sweep } = mount({
+      env: { CRON_SECRET: undefined },
+    });
+
+    const res = await app.request("/admin/keep-alive", {
+      headers: { Authorization: `Bearer ${VALID_TOKEN}` },
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "keepalive_not_configured" });
+    expect(ping).not.toHaveBeenCalled();
+    expect(sweep).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with status, dbPingMs, sweptNonces, and timestamp on success", async () => {
+    const ping = vi.fn(async () => undefined);
+    const sweep = vi.fn(async () => ({ deletedCount: 7 }));
+    const { app } = mount({ ping, sweep });
+
+    const res = await app.request("/admin/keep-alive", {
+      headers: { Authorization: `Bearer ${VALID_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("ok");
+    expect(typeof body.dbPingMs).toBe("number");
+    expect(body.dbPingMs).toBeGreaterThanOrEqual(0);
+    expect(body.sweptNonces).toBe(7);
+    expect(typeof body.timestamp).toBe("string");
+    // Must not leak the secret in any field.
+    expect(JSON.stringify(body)).not.toContain(VALID_TOKEN);
+    expect(ping).toHaveBeenCalledTimes(1);
+    expect(sweep).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 503 with database_unreachable when ping throws", async () => {
+    const ping = vi.fn(async () => {
+      throw new Error("connect ECONNREFUSED 10.0.0.1:5432");
+    });
+    const sweep = vi.fn(async () => ({ deletedCount: 0 }));
+    const { app } = mount({ ping, sweep });
+
+    const res = await app.request("/admin/keep-alive", {
+      headers: { Authorization: `Bearer ${VALID_TOKEN}` },
+    });
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toEqual({ error: "database_unreachable" });
+    // Must not leak the underlying error message (could contain host:port).
+    expect(JSON.stringify(body)).not.toContain("ECONNREFUSED");
+    expect(JSON.stringify(body)).not.toContain("10.0.0.1");
+    expect(sweep).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 with database_unreachable when sweep throws after a successful ping", async () => {
+    const ping = vi.fn(async () => undefined);
+    const sweep = vi.fn(async () => {
+      throw new Error('relation "signed_request_nonce" does not exist');
+    });
+    const { app } = mount({ ping, sweep });
+
+    const res = await app.request("/admin/keep-alive", {
+      headers: { Authorization: `Bearer ${VALID_TOKEN}` },
+    });
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toEqual({ error: "database_unreachable" });
+    expect(JSON.stringify(body)).not.toContain("signed_request_nonce");
+    expect(ping).toHaveBeenCalledTimes(1);
+    expect(sweep).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/routes/admin/keep-alive.ts
+++ b/apps/api/src/routes/admin/keep-alive.ts
@@ -1,0 +1,117 @@
+/**
+ * Slice 12 follow-up — Vercel cron endpoint to prevent Supabase auto-pause.
+ *
+ * GET /admin/keep-alive
+ *   Mounted OUTSIDE /api/* and the tenant middleware because it is invoked
+ *   by Vercel's scheduler, not by an authenticated tenant. Mirrors the
+ *   /admin/lifecycle/bootstrap mount posture.
+ *
+ *   Pings the DB (caller-supplied `ping`) and sweeps expired
+ *   signed_request_nonce rows (caller-supplied `sweep`). Two birds:
+ *     1) keep the Supabase free-tier project from auto-pausing after ~7d
+ *        of DB inactivity
+ *     2) actually run the long-dangling nonce TTL sweep the schema comment
+ *        in signed-request-nonce.ts has promised since slice 3
+ *
+ * Auth:
+ *   - Header `Authorization: Bearer <CRON_SECRET>` (Vercel cron convention).
+ *   - Constant-time compare via length-safe `timingSafeEqual`.
+ *   - Missing env  -> 503 `keepalive_not_configured` (loud failure surfaces
+ *     in Vercel cron alerts; never 500).
+ *   - Missing/malformed header -> 401 `missing_cron_token`.
+ *   - Wrong bearer (any length) -> 403 `invalid_cron_token`.
+ *
+ * Success:
+ *   - 200 JSON `{ status: "ok", dbPingMs, sweptNonces, timestamp }`.
+ *
+ * Failure:
+ *   - Ping or sweep throws -> 503 `database_unreachable`. We never leak
+ *     the underlying error message (could contain host:port, table names,
+ *     or other infrastructure details).
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import { Hono } from "hono";
+
+const BEARER_PREFIX = "Bearer ";
+
+export type KeepAliveDeps = {
+  /** Run a cheap DB round-trip (e.g. `select 1`). Throws on unreachable DB. */
+  ping: () => Promise<void>;
+  /** Sweep expired signed_request_nonce rows. Returns count deleted. */
+  sweep: () => Promise<{ deletedCount: number }>;
+  /** Env source (defaults to process.env). Override in tests. */
+  env?: Record<string, string | undefined>;
+};
+
+/**
+ * Length-safe constant-time string compare. Mirrors the pattern used in
+ * `lifecycle-bootstrap.ts` and `middleware/hubspot-signature.ts`:
+ * `timingSafeEqual` throws on unequal `Buffer.byteLength`, so we gate on
+ * length and still burn a compare against a padded buffer to keep timing
+ * roughly flat across length-mismatch and content-mismatch paths.
+ */
+function safeEquals(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.byteLength !== bBuf.byteLength) {
+    const padded = Buffer.alloc(aBuf.byteLength);
+    timingSafeEqual(aBuf, padded);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+function extractBearer(header: string | undefined): string | null {
+  if (!header?.startsWith(BEARER_PREFIX)) return null;
+  const token = header.slice(BEARER_PREFIX.length);
+  return token.length === 0 ? null : token;
+}
+
+export function createKeepAliveRoute(deps: KeepAliveDeps) {
+  const env = deps.env ?? process.env;
+  const app = new Hono();
+
+  app.get("/", async (c) => {
+    const expected = env.CRON_SECRET;
+    if (!expected || expected.length === 0) {
+      return c.json({ error: "keepalive_not_configured" }, 503);
+    }
+
+    const provided = extractBearer(c.req.header("authorization"));
+    if (!provided) {
+      return c.json({ error: "missing_cron_token" }, 401);
+    }
+    if (!safeEquals(provided, expected)) {
+      return c.json({ error: "invalid_cron_token" }, 403);
+    }
+
+    const startedAt = Date.now();
+    try {
+      await deps.ping();
+    } catch {
+      return c.json({ error: "database_unreachable" }, 503);
+    }
+    const dbPingMs = Date.now() - startedAt;
+
+    let sweptNonces: number;
+    try {
+      const swept = await deps.sweep();
+      sweptNonces = swept.deletedCount;
+    } catch {
+      return c.json({ error: "database_unreachable" }, 503);
+    }
+
+    return c.json(
+      {
+        status: "ok",
+        dbPingMs,
+        sweptNonces,
+        timestamp: new Date().toISOString(),
+      },
+      200,
+    );
+  });
+
+  return app;
+}

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -4,5 +4,6 @@
   "installCommand": "cd ../.. && corepack enable && pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm exec tsc -b packages/config packages/db packages/validators apps/api",
   "outputDirectory": "public",
-  "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }],
+  "crons": [{ "path": "/admin/keep-alive", "schedule": "0 12 * * *" }]
 }

--- a/docs/decisions/oauth-scope-policy.md
+++ b/docs/decisions/oauth-scope-policy.md
@@ -1,0 +1,164 @@
+# Decision: OAuth scope policy — read-only vs. seed-write
+
+**Status**: Proposed (awaiting product sign-off)
+**Decision needed by**: before Wave D operator walkthrough (#37) ships, or sooner if anyone tries `pnpm seed:test-portal` against a live portal
+**Tracking**: [#38](https://github.com/MAN-Digital/hubspot-account-plan-app/issues/38)
+**Recommendation**: **Path C (Private App token for the seed script)**, with Path A as the cheap fallback if engineering time is the bottleneck
+
+## TL;DR
+
+The marketplace listing is the decision driver. The production app is `"distribution": "marketplace"`, which means any scope change requires HubSpot to re-review the app — that's days-to-weeks of latency and a real risk that a reviewer questions why a "signal-first read-only" product wants write access. That removes Path B from the table as a near-term option.
+
+Of the two remaining paths:
+
+- **Path A** (manual data entry, abandon the seed) is free-today but throws away PR #32 and adds ~1h of clicking before every walkthrough.
+- **Path C** (Private App token, decouple the seed from the user-facing OAuth grant) is 3–4 hours of work and keeps the seed as a durable QA tool with the production app's read-only posture intact.
+
+Path C wins on total cost across all future walkthroughs. Path A only wins if there will be exactly one walkthrough.
+
+## The problem in one sentence
+
+`scripts/seed-hubspot-test-portal.ts` (wired in PR #32) reads the per-tenant OAuth token from `tenant_hubspot_oauth`, then calls `POST /crm/v3/objects/companies`. That token was issued under read-only scopes, so HubSpot returns `403 Forbidden` on the first write.
+
+## Constraints worth naming upfront
+
+These are the facts that pin down the option space:
+
+1. **Marketplace distribution**: `apps/hubspot-project/src/app/app-hsmeta.json` declares `"distribution": "marketplace"`. Per HubSpot's [App Marketplace policy](https://developers.hubspot.com/docs/apps/marketplace/get-started/create-marketplace-app), scope changes on a listed app trigger re-review.
+2. **Existing OAuth grants are scope-locked**: HubSpot's OAuth flow does not retroactively grant new scopes to existing access tokens. Even after a scope change is approved, every installed tenant must re-grant via reinstall before the new scopes apply to their token.
+3. **Product wedge is "read-only signal-first"**: The CLAUDE.md product brief explicitly frames the app as read-only. Asking for write scopes changes the trust posture users see at install time — the install consent screen will list "Read and write companies" instead of "Read companies".
+4. **The seed script's auth surface is already tested via injection**: `runSeed()` accepts a `clientFactory` (see [scripts/seed-hubspot-test-portal.ts:426-428](../../scripts/seed-hubspot-test-portal.ts)). The tests already substitute a mock. Path C can use the same seam.
+5. **HubSpotClient is OAuth-coupled**: [apps/api/src/lib/hubspot-client.ts](../../apps/api/src/lib/hubspot-client.ts) takes `{ tenantId, db }` and decrypts an OAuth token from `tenant_hubspot_oauth`. There is no "use this static Bearer token" entry point today.
+6. **The seed only needs 6 HubSpot methods**: `searchCompaniesByMarker`, `createCompany`, `updateCompany`, `createContact`, `findContactByEmail`, `associateContactWithCompany`. The `SeedHubSpotClient` interface in the seed file already names them.
+
+## The three paths
+
+### Path A — keep the app read-only, abandon the seed script
+
+Accept that `pnpm seed:test-portal` is unusable against the production OAuth grant. For the Slice-2 walkthrough (8 QA states × ~17 records), manually create companies and contacts in the HubSpot UI using the dataset in [docs/qa/test-portal-seed-plan.md](../qa/test-portal-seed-plan.md). PR #32's seed code becomes documentation (and its test suite still validates the dataset shape).
+
+| Aspect                          | Detail                                                                               |
+| ------------------------------- | ------------------------------------------------------------------------------------ |
+| Eng effort today                | 0 (or ~30 min to add `pnpm seed:test-portal:print` flag for paste-into-UI checklist) |
+| Operator effort per walkthrough | ~1h of clicking                                                                      |
+| Scope footprint                 | unchanged — pure read-only                                                           |
+| Marketplace impact              | none                                                                                 |
+| Reuse value                     | low — every walkthrough repeats the manual work                                      |
+| Reversibility                   | high — Path C can be added later                                                     |
+
+**When this wins**: if Wave D is a one-shot acceptance gate and Slice 5 + future walkthroughs would never use a seed.
+
+### Path B — add `crm.objects.{companies,contacts}.write` to required scopes
+
+Edit `app-hsmeta.json`, re-upload via `pnpm hs:project upload`, and resubmit the marketplace listing for re-review. Once approved, ask every installed tenant to reinstall.
+
+| Aspect                          | Detail                                                                                                                        |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Eng effort today                | ~30 min (config + upload)                                                                                                     |
+| Operator effort per walkthrough | 0                                                                                                                             |
+| Scope footprint                 | expanded — install consent now shows "Read and write companies/contacts"                                                      |
+| Marketplace impact              | **re-review required**, days-to-weeks of latency, real risk of reviewer pushback on a "signal-first" product asking for write |
+| Existing installs               | broken until each tenant reinstalls                                                                                           |
+| Trust posture change            | "read-only signal" → "we can edit your CRM"                                                                                   |
+| Reversibility                   | low once shipped — going from write-back-to-read in a listed app is also a re-review                                          |
+
+**When this wins**: only if there is a separate near-term product reason to write to HubSpot (e.g., enrichment writing properties back) that justifies the consent change on its own merits. Doing this purely to make the test-portal seed work is the wrong trade.
+
+### Path C — separate seed mechanism via HubSpot Private App access token
+
+Refactor `scripts/seed-hubspot-test-portal.ts` to support two auth modes:
+
+1. If `HUBSPOT_PRIVATE_APP_TOKEN` env var set → use it via a new `PrivateAppSeedClient` that calls the same HubSpot REST API with the Private App's Bearer token.
+2. Else fall back to the current OAuth-token-from-DB path (so the existing test mocks still work, and a future Path B world still works).
+
+Operator workflow:
+
+- One-time per test portal: in the HubSpot portal, create a Private App with `crm.objects.companies.write` + `crm.objects.contacts.write` + matching read scopes. Copy the access token.
+- Add `HUBSPOT_PRIVATE_APP_TOKEN=<token>` to local `.env` (one line per portal if you switch between them).
+- Run `pnpm seed:test-portal --portal <id>` as documented.
+
+| Aspect                          | Detail                                                                                               |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Eng effort today                | 3–4h (new client class, env wiring, tests, doc update)                                               |
+| Operator effort per walkthrough | 0 (after one-time Private App setup, ~5 min per portal)                                              |
+| Scope footprint                 | production app unchanged — Private Apps are per-portal, granted by the portal admin manually         |
+| Marketplace impact              | none                                                                                                 |
+| Existing installs               | unaffected                                                                                           |
+| Trust posture change            | none for end users — Private Apps live in the portal admin's UI, not in the marketplace consent flow |
+| Reusable for                    | Slice 2 walkthrough, Slice 5 pilot, any future QA seed (incl. multi-portal test matrix)              |
+| Reversibility                   | high — if a future product feature legitimately needs write, Path B can be layered on top            |
+
+**When this wins**: every scenario except "we will literally never run the seed again". Even if Wave D is the only acceptance gate today, the seed will likely come back for Slice 5 pilot and any future regression sweep.
+
+## Why Path B is not the right answer (extended)
+
+Three independent reasons:
+
+1. **Marketplace re-review is a critical-path block**. We don't control the review timeline. Wave D would either wait (slipping slice-12 acceptance further) or re-review in parallel and risk reviewer pushback that ratchets up the back-and-forth.
+2. **Asking for write scopes purely to enable an internal seed script is a category error.** Scopes are user-facing trust surface; the seed is an engineering testing tool. Mixing the two pushes complexity onto the wrong audience.
+3. **Once you have write scopes, they're hard to remove from a marketplace-listed app.** Scope reduction is also a re-review event, and HubSpot's marketplace listings show historical scope sets to potential installers. We'd be locking in a worse trust posture for marginal test convenience.
+
+The only case where Path B is correct is when **a product feature already wants write capability** (e.g., enrichment writing properties back to HubSpot). At that point, the seed-script convenience comes along for the ride. Until then, Path B is paying a real cost for a synthetic benefit.
+
+## What Path C looks like concretely
+
+Minimum viable refactor of `scripts/seed-hubspot-test-portal.ts`:
+
+```ts
+// New: scripts/seed-hubspot-private-app-client.ts
+// Implements SeedHubSpotClient using fetch + Bearer Private App token.
+// ~150 lines, mirrors the 6 methods on the interface.
+
+// Edit: scripts/seed-hubspot-test-portal.ts (around line 425-445)
+let client: SeedHubSpotClient;
+if (deps.clientFactory) {
+  client = deps.clientFactory();
+} else if (env.HUBSPOT_PRIVATE_APP_TOKEN) {
+  // Path C — recommended for operator workflows.
+  client = new PrivateAppSeedClient({
+    token: env.HUBSPOT_PRIVATE_APP_TOKEN,
+  });
+} else {
+  // Fallback — only works if/when Path B is also adopted in some future world.
+  // ... existing OAuth-token-from-DB path ...
+}
+```
+
+Documentation deltas:
+
+- `docs/qa/test-portal-seed-plan.md`: add a "Private App setup" subsection (5-step recipe) under "Prerequisites".
+- `.env.example` (if it exists): add a commented `HUBSPOT_PRIVATE_APP_TOKEN=` line.
+- Existing `docs/qa/slice-2-walkthrough.md`: no change — the seed output table format stays the same.
+
+Test deltas:
+
+- `scripts/__tests__/seed-hubspot-test-portal.test.ts`: add a test that when `env.HUBSPOT_PRIVATE_APP_TOKEN` is set, the script constructs the Private App client (asserted by injected factory). Existing tests stay green because they use `clientFactory` injection directly.
+- New unit tests for `PrivateAppSeedClient` against `vi.fn()` `global.fetch`.
+
+Acceptance for the Path C work:
+
+- [ ] `pnpm seed:test-portal --dry-run` still passes (no token needed)
+- [ ] `pnpm seed:test-portal --portal <id>` with `HUBSPOT_PRIVATE_APP_TOKEN` set seeds 8 companies + correct contact counts
+- [ ] Rerun against the same portal flips create→update (idempotency intact)
+- [ ] Unit tests pass; no real HubSpot calls in `pnpm test`
+
+## Recommendation
+
+**Adopt Path C now.**
+
+Reasoning:
+
+- 3–4h of engineering is cheap relative to (a) the marketplace risk of Path B and (b) the per-walkthrough manual-entry cost of Path A across every future walkthrough.
+- The existing seed code, its dataset, its test suite, and its idempotency design are all preserved.
+- The production app keeps its clean read-only posture, which matches the documented product wedge.
+- Reversible — a future Path B (real product need for write) can be layered on top without removing the Private App path.
+
+**If 3–4h is too much engineering time right now**, fall back to Path A with one polish: add a `pnpm seed:test-portal:print` mode that emits the planned dataset as a Markdown checklist suitable for paste-into-HubSpot-UI. That keeps Wave D unblocked today while preserving the option to do Path C later when the seed is needed more often.
+
+**Do not adopt Path B** unless and until a separate product feature actually justifies write scopes on its own merits.
+
+## What happens after the decision lands
+
+- Path C: open an issue/task to implement the refactor; estimate 3–4h; close #38 when the refactor merges and is documented.
+- Path A (fallback): close #38 with a comment saying "deferred to Path C when needed; using manual UI entry for Slice 2 + 5". Add the `:print` flag if Wave D operators ask for it.
+- Path B: would require a parallel issue to schedule marketplace re-review and a comms plan for existing tenants. Don't start this without explicit product sign-off.

--- a/docs/runbooks/supabase-auto-pause.md
+++ b/docs/runbooks/supabase-auto-pause.md
@@ -1,0 +1,86 @@
+# Supabase auto-pause runbook
+
+> **TL;DR**: A Vercel cron hits `/admin/keep-alive` once a day. As long as that cron keeps firing, the production Supabase project stays warm. If the project pauses anyway, unpause via the Supabase dashboard and check the cron history in Vercel.
+
+## What triggers an auto-pause
+
+Supabase free-tier projects pause after roughly **7 days of database inactivity**. "Inactivity" means no queries executed against Postgres — inbound HTTP requests that fail before reaching the DB do not count.
+
+Pausing is silent. The dashboard still loads, but every connection from the API returns `connection refused` until someone clicks "Restore project" in the Supabase UI.
+
+This was first observed during slice 12 (issue [#41](https://github.com/MAN-Digital/hubspot-account-plan-app/issues/41)) when the project paused between the slice landing in `main` and the operator walkthrough being executed. Every backend operation (OAuth callback, lifecycle webhook, settings API) returned 5xx until the project was manually unpaused.
+
+## Mitigation in place
+
+Vercel cron schedule lives in [apps/api/vercel.json](apps/api/vercel.json):
+
+```json
+"crons": [{ "path": "/admin/keep-alive", "schedule": "0 12 * * *" }]
+```
+
+The cron hits [apps/api/src/routes/admin/keep-alive.ts](apps/api/src/routes/admin/keep-alive.ts) daily at 12:00 UTC. Each invocation:
+
+1. Runs `select 1` against Postgres (the keep-alive ping)
+2. Calls `sweepExpiredNonces(db)` to delete `signed_request_nonce` rows older than 10 minutes (TTL cleanup that has been promised in the schema comment since slice 3)
+
+The DB ping happens regardless of the sweep result, so the auto-pause clock is reset on every successful run.
+
+### Auth
+
+Vercel cron injects `Authorization: Bearer <CRON_SECRET>` automatically when the `CRON_SECRET` env var is set on the project. The route compares this with constant-time `timingSafeEqual`. Behavior:
+
+| Condition                      | Status | Body                                                         |
+| ------------------------------ | ------ | ------------------------------------------------------------ |
+| `CRON_SECRET` env not set      | 503    | `{ "error": "keepalive_not_configured" }`                    |
+| Authorization header missing   | 401    | `{ "error": "missing_cron_token" }`                          |
+| Bearer token wrong             | 403    | `{ "error": "invalid_cron_token" }`                          |
+| DB unreachable (ping or sweep) | 503    | `{ "error": "database_unreachable" }`                        |
+| Success                        | 200    | `{ "status": "ok", "dbPingMs", "sweptNonces", "timestamp" }` |
+
+A 503 from this route surfaces as a failed run in Vercel's cron history, which is the alerting channel we want — failures are loud, not silent.
+
+## Setup on a fresh deployment
+
+The route is wired in code. The only manual step is the env var:
+
+```bash
+# From the apps/api directory of a linked project
+vercel env add CRON_SECRET production
+# Paste a random 32+ byte secret. This becomes the Bearer token Vercel injects.
+```
+
+After the next deploy, verify:
+
+```bash
+# Confirm Vercel registered the cron
+vercel crons ls --scope=man-digital
+# Expected: an entry for /admin/keep-alive on the production deployment
+
+# Smoke-test the endpoint manually
+curl -i -H "Authorization: Bearer $CRON_SECRET" https://hap.mandigital.dev/admin/keep-alive
+# Expected: HTTP 200, JSON with status=ok, dbPingMs (number), sweptNonces (number)
+```
+
+## If the project pauses anyway
+
+1. **Unpause**: open [the Supabase project](https://supabase.com/dashboard/project/ucjpzljcppxsxtclnbdj) → click "Restore project" or "Resume".
+2. **Verify reach** from the machine that has `.env` populated:
+   ```bash
+   export DATABASE_URL=$(grep '^DATABASE_URL=' .env | cut -d= -f2-)
+   psql "$DATABASE_URL" -c 'select now(), version();'
+   ```
+3. **Check why keep-alive stopped firing**:
+   - Vercel dashboard → project → Cron Jobs → look at the last few runs.
+   - If runs were succeeding but ten or more days have elapsed since the last 200, the cron schedule may have been disabled or removed.
+   - If runs were failing (503 `database_unreachable`), the DB was already paused — once unpaused, the next scheduled run will get it warm again.
+4. **Force a warm-up** without waiting for the next scheduled run:
+   ```bash
+   curl -i -H "Authorization: Bearer $CRON_SECRET" https://hap.mandigital.dev/admin/keep-alive
+   ```
+
+## When this mitigation is no longer enough
+
+If you observe repeated pauses despite the cron firing successfully, the working assumption (daily `select 1` is sufficient) has broken. Two next steps:
+
+- **Bump cron frequency** to every 6 hours (`0 */6 * * *`) — still well inside Vercel cron Hobby limits.
+- **Upgrade Supabase to Pro** ($25/month) — paid projects do not auto-pause. Track that decision in a new ops issue rather than silently flipping it.

--- a/docs/runbooks/vercel-deploy.md
+++ b/docs/runbooks/vercel-deploy.md
@@ -1,0 +1,114 @@
+# Vercel deployment runbook
+
+> **TL;DR**: Pushes to `main` auto-deploy to production at `https://hap.mandigital.dev`. Pushes to any other branch trigger preview deploys. If something is wrong with the integration, the symptoms are silent — no errors, just no deploys.
+
+## How deploys reach production today
+
+The Vercel project `man-digital/hap-signal-workspace-staging` is linked to the GitHub repo `MAN-Digital/hubspot-account-plan-app`.
+
+| Setting             | Value                                              |
+| ------------------- | -------------------------------------------------- |
+| Production Branch   | `main`                                             |
+| Root Directory      | `apps/api`                                         |
+| Framework Preset    | `hono`                                             |
+| Auto-Deploy on Push | `enabled` (`gitProviderOptions.createDeployments`) |
+| Production URL      | `https://hap.mandigital.dev`                       |
+| Team                | `man-digital` (`team_RgSSPVkSj5hbNoeq7df4lepE`)    |
+| Project ID          | `prj_4URVqH5tUCVFzASVnahG22Pzk5I3`                 |
+
+Branch behavior:
+
+- Push to `main` → production deploy → aliased to `hap.mandigital.dev`
+- Push to any other branch → preview deploy at a per-deployment URL
+- Open PR → preview deploy posted as a check on the PR
+
+## How this was broken before (resolved 2026-05-18, issue #39)
+
+Between project creation and 2026-05-18, the Vercel project had **no git repository connected at all**. Every "production deploy" in the dashboard prior to that date was a manual `vercel deploy --prod` run from a local machine. Merging to `main` did nothing on the Vercel side because there was no webhook to receive the event.
+
+The fix was a single CLI call:
+
+```bash
+cd apps/api  # must be inside a directory linked to the project
+vercel link --yes --project=hap-signal-workspace-staging --scope=man-digital
+vercel git connect https://github.com/MAN-Digital/hubspot-account-plan-app.git --yes
+```
+
+After this, the project's `link` field in the API response populates with:
+
+```json
+{
+  "type": "github",
+  "repo": "hubspot-account-plan-app",
+  "org": "MAN-Digital",
+  "productionBranch": "main",
+  "gitCredentialId": "cred_..."
+}
+```
+
+## Diagnosing an "auto-deploy stopped firing" report
+
+The dashboard alerts are quiet on this kind of regression. Check these in order:
+
+### 1. Confirm git is still linked
+
+```bash
+VERCEL_TOKEN=$(jq -r '.token' ~/Library/Application\ Support/com.vercel.cli/auth.json)
+TEAM=team_RgSSPVkSj5hbNoeq7df4lepE
+curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+  "https://api.vercel.com/v9/projects/hap-signal-workspace-staging?teamId=$TEAM" \
+  | jq '.link'
+```
+
+`link: null` means someone (or something) disconnected it. Reconnect with the `vercel git connect` call above.
+
+`link.productionBranch != "main"` means production deploys aren't firing on `main` pushes. Fix via dashboard → Project Settings → Git → Production Branch.
+
+### 2. Confirm the GitHub webhook is reaching Vercel
+
+```bash
+gh api repos/MAN-Digital/hubspot-account-plan-app/hooks --jq '.[] | select(.config.url|test("vercel")) | {url:.config.url, active, last_response: .last_response}'
+```
+
+Last response code should be 200 or 204. If 4xx/5xx, look at the failure reason — usually means a credential expired or the project was deleted.
+
+### 3. Confirm recent deploys show `Source: git`
+
+```bash
+vercel ls hap-signal-workspace-staging --scope=man-digital
+```
+
+In the `Username` column, git-triggered deploys show `github` (or the committer's GitHub login). CLI-triggered deploys show the Vercel user who ran the CLI (e.g. `romeoman`).
+
+If all recent deploys show a Vercel username, no git events have fired since the last manual deploy.
+
+## Manual deploy fallback
+
+If the git integration is broken and you need to ship right now:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git worktree add .claude/worktrees/deploy-main origin/main
+cd .claude/worktrees/deploy-main
+cd apps/api
+vercel link --yes --project=hap-signal-workspace-staging --scope=man-digital
+mkdir -p public && echo "Serverless API placeholder" > public/.placeholder
+vercel deploy --prod --yes
+```
+
+The `public/` placeholder hack exists because `apps/api/vercel.json` declares `outputDirectory: "public"`. The git-integration build does not need this — Vercel's build runner creates the empty directory on its own when invoked via webhook. This is only required for CLI deploys, and only because we deploy from the repo root via `cd ../..` in `installCommand` / `buildCommand`. (See [#44](https://github.com/MAN-Digital/hubspot-account-plan-app/issues/44) for the gory history.)
+
+## Don't create new projects by accident
+
+`vercel deploy` from a directory that doesn't have a `.vercel/project.json` will create a brand-new project named after the directory. This happened during slice 12 and produced the orphan `man-digital/deploy-main` project ([#40](https://github.com/MAN-Digital/hubspot-account-plan-app/issues/40)).
+
+Before running `vercel deploy --prod` from any directory, confirm:
+
+```bash
+cat .vercel/project.json
+# Must show:
+#   { "projectId": "prj_4URVqH5tUCVFzASVnahG22Pzk5I3",
+#     "orgId":     "team_RgSSPVkSj5hbNoeq7df4lepE" }
+```
+
+If `.vercel/project.json` is missing or points to a different project, run `vercel link --yes --project=hap-signal-workspace-staging --scope=man-digital` first.


### PR DESCRIPTION
Closes #41 and #39.

## Summary

Two ops fixes bundled into one PR because both surfaced during the same slice-12 follow-up and the same runbook flow naturally covers both.

### 1. Supabase auto-pause (#41)

Daily Vercel cron at `/admin/keep-alive` pings the DB and sweeps expired `signed_request_nonce` rows. Two wins for one ~150-line route:
- Stops Supabase free-tier from pausing after ~7d of DB inactivity (recurring slice-12 incident)
- Finally runs the dangling nonce TTL sweep the schema comment has promised since slice 3

### 2. Vercel auto-deploy not firing (#39)

Root cause: project had `link: null` — no git repo connected at all. Every prior "production deploy" was a manual CLI run. Reconnected with `vercel git connect`; preview auto-deploy verified by this branch's push triggering `dpl_2Y2eysPCUuXyhZUTQY9xU6hgGiEk` within 26 seconds (see issue #39 comment for full evidence).

## What's in the change

| File | What |
|------|------|
| `apps/api/src/routes/admin/keep-alive.ts` | New Hono sub-app. Bearer-token auth, constant-time compare, 503 on misconfig/DB-unreachable, 200 with `{ status, dbPingMs, sweptNonces, timestamp }` on success. |
| `apps/api/src/routes/admin/__tests__/keep-alive.test.ts` | 8 tests covering all auth paths and DB-failure modes. |
| `apps/api/src/app.ts` | Mount `/admin/keep-alive` alongside `/admin/lifecycle`, outside the `/api/*` auth middleware. |
| `apps/api/vercel.json` | `crons: [{ "path": "/admin/keep-alive", "schedule": "0 12 * * *" }]` |
| `docs/runbooks/supabase-auto-pause.md` | Setup, verification, recovery if the project pauses anyway. |
| `docs/runbooks/vercel-deploy.md` | How the deploy pipeline is wired, diagnostic for "auto-deploy stopped firing", manual-deploy fallback, orphan-project footgun guard. |

Side-effect: orphan project `man-digital/deploy-main` (#40) deleted via API; see that issue for evidence.

## Verification

```
pnpm typecheck                   # exit 0, clean
pnpm lint                        # 0 errors, 5 pre-existing warnings (per handoff #45)
pnpm test                        # 888/891 pass; 3 failures in tenant-tx + replay-nonce
                                 # are pre-existing RLS-role-permission failures against
                                 # the production Supabase pooler (not regressions)
```

Git integration verified by branch-push → preview-deploy in <30s; production-deploy on `main` will be verified when this PR merges.

## Operational follow-up after merge

1. Add `CRON_SECRET` (random 32+ byte secret) to the Vercel production env: `vercel env add CRON_SECRET production`
2. Watch for auto-deploy of the merge commit to fire on `main` (proves #39's production path)
3. Verify the cron registered: `vercel crons ls --scope=man-digital | grep keep-alive`
4. Smoke-test: `curl -i -H "Authorization: Bearer $CRON_SECRET" https://hap.mandigital.dev/admin/keep-alive` → HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
