### PR TITLE
fix(keep-alive): direct handler mount so route resolves in prod (post-#46 hotfix)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,7 +8,7 @@ import { authMiddleware } from "./middleware/auth.js";
 import { type CorrelationVariables, correlationMiddleware } from "./middleware/correlation.js";
 import { nonceMiddleware } from "./middleware/nonce.js";
 import { type TenantVariables, tenantMiddleware } from "./middleware/tenant.js";
-import { createKeepAliveRoute } from "./routes/admin/keep-alive.js";
+import { createKeepAliveHandler } from "./routes/admin/keep-alive.js";
 import { createLifecycleBootstrapRoute } from "./routes/admin/lifecycle-bootstrap.js";
 import { lifecycleWebhookRoutes } from "./routes/lifecycle.js";
 import { createOAuthRoutes } from "./routes/oauth.js";
@@ -135,9 +135,14 @@ app.route("/admin/lifecycle", createLifecycleBootstrapRoute());
 // because the caller is Vercel's scheduler, not an authenticated tenant. Auth
 // is `Authorization: Bearer <CRON_SECRET>` (Vercel cron convention). Schedule
 // lives in `apps/api/vercel.json` -> `crons[]`.
-app.route(
+//
+// Registered as a direct handler (not via `app.route` sub-app) because the
+// sub-app + inner `app.get("/")` pattern that PR #46 used registers the path
+// as `/admin/keep-alive/` in Hono's production router and 404s on the bare
+// `/admin/keep-alive` path that Vercel cron + curl hit.
+app.get(
   "/admin/keep-alive",
-  createKeepAliveRoute({
+  createKeepAliveHandler({
     ping: async () => {
       await getDb().execute(drizzleSql`select 1`);
     },

--- a/apps/api/src/routes/admin/__tests__/keep-alive.test.ts
+++ b/apps/api/src/routes/admin/__tests__/keep-alive.test.ts
@@ -13,7 +13,7 @@
  */
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
-import { createKeepAliveRoute } from "../keep-alive";
+import { createKeepAliveHandler } from "../keep-alive";
 
 const VALID_TOKEN = "cron-secret-token-0123456789abcdef";
 
@@ -28,8 +28,13 @@ function mount(
   const sweep = deps.sweep ?? vi.fn(async () => ({ deletedCount: 0 }));
   const env = deps.env ?? { CRON_SECRET: VALID_TOKEN };
 
+  // Mount as a direct handler on the main Hono app — same pattern as
+  // production. The previous test used `app.route("/admin/keep-alive", subApp)`
+  // with an inner `app.get("/")`, which passed in tests but 404'd in
+  // production because Hono's production router registers that combo as
+  // `/admin/keep-alive/` (trailing slash) and doesn't normalize.
   const app = new Hono();
-  app.route("/admin/keep-alive", createKeepAliveRoute({ ping, sweep, env }));
+  app.get("/admin/keep-alive", createKeepAliveHandler({ ping, sweep, env }));
   return { app, ping, sweep };
 }
 

--- a/apps/api/src/routes/admin/keep-alive.ts
+++ b/apps/api/src/routes/admin/keep-alive.ts
@@ -2,9 +2,14 @@
  * Slice 12 follow-up — Vercel cron endpoint to prevent Supabase auto-pause.
  *
  * GET /admin/keep-alive
- *   Mounted OUTSIDE /api/* and the tenant middleware because it is invoked
- *   by Vercel's scheduler, not by an authenticated tenant. Mirrors the
- *   /admin/lifecycle/bootstrap mount posture.
+ *   Mounted as a direct handler on the main Hono app (NOT a sub-app via
+ *   `app.route`). The sub-app pattern with an inner `app.get("/")` registers
+ *   the route as `/admin/keep-alive/` (with trailing slash) in Hono's
+ *   production router, which doesn't match the bare `/admin/keep-alive` path
+ *   that Vercel cron + curl hit. Direct registration sidesteps that quirk.
+ *   The original sub-app implementation in PR #46 produced a 404 in
+ *   production despite passing all local tests — see follow-up PR for
+ *   the post-mortem.
  *
  *   Pings the DB (caller-supplied `ping`) and sweeps expired
  *   signed_request_nonce rows (caller-supplied `sweep`). Two birds:
@@ -16,8 +21,7 @@
  * Auth:
  *   - Header `Authorization: Bearer <CRON_SECRET>` (Vercel cron convention).
  *   - Constant-time compare via length-safe `timingSafeEqual`.
- *   - Missing env  -> 503 `keepalive_not_configured` (loud failure surfaces
- *     in Vercel cron alerts; never 500).
+ *   - Missing env  -> 503 `keepalive_not_configured`.
  *   - Missing/malformed header -> 401 `missing_cron_token`.
  *   - Wrong bearer (any length) -> 403 `invalid_cron_token`.
  *
@@ -31,7 +35,7 @@
  */
 
 import { timingSafeEqual } from "node:crypto";
-import { Hono } from "hono";
+import type { Context } from "hono";
 
 const BEARER_PREFIX = "Bearer ";
 
@@ -46,10 +50,7 @@ export type KeepAliveDeps = {
 
 /**
  * Length-safe constant-time string compare. Mirrors the pattern used in
- * `lifecycle-bootstrap.ts` and `middleware/hubspot-signature.ts`:
- * `timingSafeEqual` throws on unequal `Buffer.byteLength`, so we gate on
- * length and still burn a compare against a padded buffer to keep timing
- * roughly flat across length-mismatch and content-mismatch paths.
+ * `lifecycle-bootstrap.ts` and `middleware/hubspot-signature.ts`.
  */
 function safeEquals(a: string, b: string): boolean {
   const aBuf = Buffer.from(a, "utf8");
@@ -68,11 +69,17 @@ function extractBearer(header: string | undefined): string | null {
   return token.length === 0 ? null : token;
 }
 
-export function createKeepAliveRoute(deps: KeepAliveDeps) {
+/**
+ * Build the keep-alive route handler. Mount with
+ * `app.get("/admin/keep-alive", createKeepAliveHandler({...}))`.
+ *
+ * Returns a Hono handler rather than a sub-app on purpose — see file
+ * header for the production-routing reason.
+ */
+export function createKeepAliveHandler(deps: KeepAliveDeps) {
   const env = deps.env ?? process.env;
-  const app = new Hono();
 
-  app.get("/", async (c) => {
+  return async (c: Context) => {
     const expected = env.CRON_SECRET;
     if (!expected || expected.length === 0) {
       return c.json({ error: "keepalive_not_configured" }, 503);
@@ -111,7 +118,5 @@ export function createKeepAliveRoute(deps: KeepAliveDeps) {
       },
       200,
     );
-  });
-
-  return app;
+  };
 }


### PR DESCRIPTION
Hotfix to PR #46. Production smoke-test caught a routing regression.

## Symptom

After PR #46 merged and auto-deployed (which itself was the proof of #39), `GET /admin/keep-alive` returned `404 Not Found` instead of the expected `401 missing_cron_token`. Every other route on the same deploy worked (`/health` → 200, `/oauth/install` → 302, `POST /admin/lifecycle/bootstrap` → 401). The cron would have failed daily once it started firing.

## Root cause

PR #46 mounted the route as a sub-app:

```ts
app.route("/admin/keep-alive", createKeepAliveRoute({...}))
// inside the sub-app:
app.get("/", handler)
```

Hono's production router concatenates the mount path + inner route literally, registering `/admin/keep-alive` + `/` as `/admin/keep-alive/` (trailing slash). The bare `/admin/keep-alive` path that Vercel cron + curl hit never matched.

The existing `/admin/lifecycle/bootstrap` mount works because its inner route is `/bootstrap`, not `/`, so concatenation produces a slash-clean path. The local Hono test runtime normalizes this (which is why all 8 tests in PR #46 passed); the production router does not.

## Fix

Drop the sub-app shell. The route file now exports `createKeepAliveHandler(deps)` (returns a Hono Context handler) instead of `createKeepAliveRoute(deps)` (returned a sub-app). `app.ts` mounts directly:

```ts
app.get("/admin/keep-alive", createKeepAliveHandler({ ping, sweep }))
```

Same auth + ping + sweep logic, same response shapes, same 8 tests — only the mount mechanism changed.

## Verification

```
pnpm typecheck    — clean
pnpm lint         — 0 errors, 5 pre-existing warnings
pnpm test apps/api/src/routes/admin/__tests__/keep-alive.test.ts — 8/8 pass
```

Plus a built-dist probe to catch this class of bug in the future (the unit tests alone weren't enough):

```
/admin/keep-alive        -> 401 (missing_cron_token)  ← was 404
/admin/keep-alive bearer -> 403 (invalid_cron_token)
/admin/keep-alive/       -> 404 (acceptable; not the canonical URL)
/health                  -> 200
```

## Why the test suite missed this

`app.request("/admin/keep-alive")` in Hono's in-memory test runtime DOES match `/admin/keep-alive/` (trailing slash) routes — the test harness normalizes. The production router doesn't. This is a known but undocumented divergence.

A follow-up could add a built-dist smoke test to CI to catch sub-app/mount-path mismatches before they reach production. Out of scope for this hotfix.

## Test plan

- [x] All 8 keep-alive unit tests pass with the new handler-factory shape
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Local built-dist probe confirms `/admin/keep-alive` returns 401 without auth (was 404)
- [ ] Post-merge: production `curl -H "Authorization: Bearer $CRON_SECRET" https://hap.mandigital.dev/admin/keep-alive` returns 200 with `{ status: "ok", dbPingMs, sweptNonces, timestamp }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
