### PR TITLE
docs(runbooks): document custom-domain auto-promotion fix (closes #49)

### DIFF
--- a/docs/runbooks/vercel-deploy.md
+++ b/docs/runbooks/vercel-deploy.md
@@ -112,3 +112,127 @@ cat .vercel/project.json
 ```
 
 If `.vercel/project.json` is missing or points to a different project, run `vercel link --yes --project=hap-signal-workspace-staging --scope=man-digital` first.
+
+## Custom-domain promotion
+
+> **TL;DR**: `hap.mandigital.dev` only auto-promotes to new production deploys when the project-level setting `autoAssignCustomDomains` is `true`. This was fixed on 2026-05-29 ([#49](https://github.com/MAN-Digital/hubspot-account-plan-app/issues/49)). If it ever reverts, the canonical domain will silently freeze on whatever deployment was last manually aliased — git pushes will still produce deploys, but `hap.mandigital.dev` will not move.
+
+### How custom domain promotion actually works in Vercel
+
+There are two independent paths a deploy can reach a URL:
+
+1. **Intrinsic project aliases.** Every production deploy is automatically given a set of `*.vercel.app` aliases derived from the project/team/branch (e.g. `hap-signal-workspace-staging-git-main-man-digital.vercel.app`). These auto-promote unconditionally — they are not gated by any project setting.
+2. **Custom domains attached to the project.** Domains like `hap.mandigital.dev` only follow the latest production deploy when the project-level setting `autoAssignCustomDomains` is `true`. When false, the custom domain stays pinned to whichever deploy it was last explicitly aliased to. CLI deploys (`vercel deploy --prod`) implicitly set this pin; git-integration deploys do not.
+
+This means it is possible — and was the case before #49 — for `hap-signal-workspace-staging-git-main-man-digital.vercel.app` to point at the brand-new deploy while `hap.mandigital.dev` is still pointing at a month-old deploy. Both are "production" deploys; only one is the canonical URL.
+
+### Diagnosis: is the custom domain auto-promoting?
+
+```bash
+VERCEL_TOKEN=$(jq -r '.token' ~/Library/Application\ Support/com.vercel.cli/auth.json)
+
+# 1. Check the project-level flag.
+curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+  "https://api.vercel.com/v9/projects/hap-signal-workspace-staging?slug=man-digital" \
+  | jq '{autoAssignCustomDomains, autoAssignCustomDomainsUpdatedBy}'
+# Expected: { "autoAssignCustomDomains": true, ... }
+# If false → custom domain will NOT auto-promote. Apply fix below.
+
+# 2. Check the domain attachment.
+curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+  "https://api.vercel.com/v9/projects/hap-signal-workspace-staging/domains?slug=man-digital" \
+  | jq '.domains[] | select(.name == "hap.mandigital.dev")'
+# Expected: { "verified": true, "gitBranch": null, "redirect": null, "customEnvironmentId": null }
+# A non-null gitBranch pins the domain to a specific branch (wrong for the canonical URL).
+
+# 3. Confirm what the custom domain currently resolves to.
+vercel inspect hap.mandigital.dev --scope=man-digital --format json 2>/dev/null \
+  | jq '{id, url, target, createdAt: (.createdAt/1000|todate), githubCommitSha: .meta.githubCommitSha}'
+
+# 4. Confirm the latest production deploy.
+vercel ls --environment production --scope=man-digital --format json 2>/dev/null \
+  | jq '.deployments[0] | {url, state, githubCommitSha: .meta.githubCommitSha}'
+
+# The two IDs (step 3 vs step 4) MUST match. If they don't, auto-promotion is broken.
+```
+
+### Fix: enable auto-assignment
+
+```bash
+VERCEL_TOKEN=$(jq -r '.token' ~/Library/Application\ Support/com.vercel.cli/auth.json)
+
+curl -sS -X PATCH -H "Authorization: Bearer $VERCEL_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"autoAssignCustomDomains": true}' \
+  "https://api.vercel.com/v9/projects/hap-signal-workspace-staging?slug=man-digital" \
+  | jq '{autoAssignCustomDomains}'
+```
+
+This patches the project setting but does **not** retroactively realias the canonical domain to the latest deploy. Existing pins stay until either (a) a new production deploy fires after the flag is true, or (b) you manually realias once to recover.
+
+### Recovery: realias once to the current latest deploy
+
+```bash
+cd apps/api  # any directory linked to the project works
+LATEST_URL=$(vercel ls --environment production --scope=man-digital --format json 2>/dev/null \
+  | jq -r '.deployments[0].url')
+vercel alias set "$LATEST_URL" hap.mandigital.dev --scope=man-digital
+```
+
+After this, the next push to `main` will produce a new production deploy, the flag will cause `hap.mandigital.dev` to follow that deploy, and no further manual aliasing is needed.
+
+### Verification procedure (post-fix sanity check)
+
+This is the same procedure operators should run any time they suspect the auto-promotion has broken again:
+
+```bash
+# 1. Create a no-op commit, THEN capture HEAD SHA, THEN push.
+#    Critical ordering: capturing HEAD before the commit captures the wrong SHA.
+git commit --allow-empty -m "chore(deploy): verify auto-promotion (no-op)"
+HEAD_SHA=$(git rev-parse HEAD)
+git push origin main
+
+# 2. Poll until a production deploy with this SHA reaches READY (≤2 min).
+VERCEL_TOKEN=$(jq -r '.token' ~/Library/Application\ Support/com.vercel.cli/auth.json)
+for i in $(seq 1 24); do
+  RESP=$(vercel ls --environment production --scope=man-digital --format json 2>/dev/null)
+  STATE=$(echo "$RESP" | jq -r '.deployments[0].state')
+  SHA=$(echo "$RESP" | jq -r '.deployments[0].meta.githubCommitSha')
+  UID=$(echo "$RESP" | jq -r '.deployments[0].uid // .deployments[0].id')
+  echo "[$i] state=$STATE sha=$SHA"
+  if [ "$STATE" = "READY" ] && [ "$SHA" = "$HEAD_SHA" ]; then
+    echo "Production deploy ready: $UID"
+    LATEST_UID="$UID"
+    break
+  fi
+  sleep 10
+done
+[ "$SHA" = "$HEAD_SHA" ] || { echo "WRONG_DEPLOY: $SHA != $HEAD_SHA"; exit 1; }
+
+# 3. Confirm hap.mandigital.dev resolves to THIS deploy.
+ALIASED=$(vercel inspect hap.mandigital.dev --scope=man-digital --format json 2>/dev/null | jq -r '.id')
+[ "$LATEST_UID" = "$ALIASED" ] && echo "ALIAS_OK" || { echo "ALIAS_MISMATCH: $ALIASED != $LATEST_UID"; exit 1; }
+
+# 4. Authenticated reachability.
+curl -fsS -H "Authorization: Bearer $CRON_SECRET" \
+  "https://hap.mandigital.dev/admin/keep-alive" | jq -e '.status == "ok"'
+
+# 5. Multi-region sanity (run from another network/VPN).
+```
+
+### Manual fallback (use only if auto-promotion is broken and you need to ship now)
+
+```bash
+cd apps/api
+LATEST_URL=$(vercel ls --environment production --scope=man-digital --format json 2>/dev/null \
+  | jq -r '.deployments[0].url')
+vercel alias set "$LATEST_URL" hap.mandigital.dev --scope=man-digital
+```
+
+This is a one-off recovery; it does not fix the underlying flag. If you find yourself running it more than once, re-run the diagnosis above — `autoAssignCustomDomains` likely flipped back to false (the original failure mode under #49).
+
+### Root cause history
+
+The project was created with `autoAssignCustomDomains: false` as a Vercel system default. Before the git integration landed in #39 on 2026-05-18, every "production deploy" was a manual `vercel deploy --prod` CLI run, which implicitly pinned `hap.mandigital.dev` to whatever deploy was made that day. After #39 the git integration started producing new production deploys automatically, but `autoAssignCustomDomains: false` meant the canonical domain remained pinned to the last CLI-deploy (`dpl_DdPBqqzUn5eJTkNHVXxhCQQQ83wB`, 2026-05-19) for the following ten days. The smoke test in PR #46 / #48 surfaced this as a 404 on `/admin/keep-alive` against `hap.mandigital.dev` while the git-aliased URL returned 200.
+
+Fix applied 2026-05-29: PATCH `autoAssignCustomDomains: true` via the projects REST API, then a one-off recovery `vercel alias set`. See [#49](https://github.com/MAN-Digital/hubspot-account-plan-app/issues/49) for the full diagnosis trace.


### PR DESCRIPTION
## Summary

Closes #49 — `hap.mandigital.dev` was silently freezing on month-old deploys despite every main push producing a fresh production deploy. The git integration (#39) was working; the **custom-domain promotion path** was the broken link.

## Root cause

Project setting `autoAssignCustomDomains` was `false` (a Vercel system default that never got toggled at project creation). With this flag false:

- Intrinsic project aliases (`hap-signal-workspace-staging-git-main-man-digital.vercel.app`) auto-promote — those are not gated by the flag.
- Custom domains (`hap.mandigital.dev`) stay pinned to whichever deploy they were last manually aliased to.

The last manual alias was a `vercel deploy --prod` CLI run on 2026-05-19 (`dpl_DdPBqqzUn5eJTkNHVXxhCQQQ83wB`, `meta.githubCommitSha: null`). That pin held for the next ten days even though git pushes kept producing newer production deploys.

Diagnosed via:

```bash
curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
  "https://api.vercel.com/v9/projects/hap-signal-workspace-staging?slug=man-digital" \
  | jq '{autoAssignCustomDomains, autoAssignCustomDomainsUpdatedBy}'
# { "autoAssignCustomDomains": false, "autoAssignCustomDomainsUpdatedBy": "system" }
```

Domain attachment itself was clean: `verified: true`, `gitBranch: null`, `redirect: null`, `customEnvironmentId: null`. No domain-level pin to revert.

## Fix applied (one-off Vercel project config change)

1. **`PATCH /v9/projects/hap-signal-workspace-staging` with `{autoAssignCustomDomains: true}`** — now reflects `true` in the GET response.
2. **One-off recovery realias**: `vercel alias set hap-signal-workspace-staging-4y3ciqmvn-man-digital.vercel.app hap.mandigital.dev --scope=man-digital`. (The PATCH flips behavior for FUTURE deploys; it does not retroactively move the existing pin.)

`hap.mandigital.dev` now resolves to the commit-`28db387` production deploy. Next push to `main` will produce a new production deploy, the flag will cause the canonical domain to follow that deploy automatically, and operators will not need to re-alias.

## Changes in this PR

- `docs/runbooks/vercel-deploy.md` — adds a "Custom-domain promotion" section covering:
  - How the two URL paths (intrinsic aliases vs custom domains) differ.
  - Diagnosis steps (project flag, domain attachment, current resolution).
  - Fix command (`PATCH /v9/projects/...`).
  - Recovery realias.
  - Full verification procedure with v6.1 SHA-ordering (commit first, capture SHA, push).
  - Manual fallback for emergency use.
  - Root-cause history.

No source code changes — infra config + docs only. TDD waiver per close-out plan v6.1 Phase 1.

## Verification

- `GET /v9/projects/hap-signal-workspace-staging` now returns `autoAssignCustomDomains: true`. ✓
- `vercel inspect hap.mandigital.dev` returns the latest production deploy id. ✓
- `curl -fsS -H "Authorization: Bearer \$CRON_SECRET" https://hap.mandigital.dev/admin/keep-alive | jq -e '.status == "ok"'` will be re-run after this PR merges as the no-op-push verification per the new runbook section. Full end-to-end auto-promotion proof requires the next push to main, which will be the PR merge itself.

## Test plan

- [x] Vercel project flag verified `true` via REST GET.
- [x] `hap.mandigital.dev` realiased to current latest production deploy.
- [ ] After merge: confirm the merge-commit production deploy reaches READY and `hap.mandigital.dev` follows it without manual aliasing.
- [ ] After merge: authenticated `curl` to `/admin/keep-alive` returns `{ "status": "ok" }` from `hap.mandigital.dev`.
- [ ] Multi-region sanity check (run from a non-local network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)